### PR TITLE
dbus connection to orchestrator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build-client:
 
 build-node:
 	mkdir -p bin
-	gcc src/node/node.c -g -Wall -o bin/node
+	gcc src/node/node.c src/node/opt.c -g -Wall -o bin/node
 
 build-orch:
 	mkdir -p bin

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,10 @@ build-client:
 
 build-node:
 	mkdir -p bin
-	gcc src/node/node.c src/node/opt.c -g -Wall -o bin/node
+	gcc \
+	src/node/node.c \
+	src/node/opt.c \
+	-g -Wall -o bin/node `pkg-config --cflags --libs libsystemd`
 
 build-orch:
 	mkdir -p bin

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,10 @@ build-client:
 
 build-node:
 	mkdir -p bin
-	gcc \
+	gcc -D_GNU_SOURCE \
 	src/node/node.c \
 	src/node/opt.c \
+	src/node/dbus.c \
 	-g -Wall -o bin/node `pkg-config --cflags --libs libsystemd`
 
 build-orch:

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ build-client:
 build-node:
 	mkdir -p bin
 	gcc -D_GNU_SOURCE \
-	src/node/node.c \
-	src/node/opt.c \
-	src/node/dbus.c \
-	-g -Wall -o bin/node `pkg-config --cflags --libs libsystemd`
+		src/node/node.c \
+		src/node/opt.c \
+		src/node/dbus.c \
+		-g -Wall -o bin/node `pkg-config --cflags --libs libsystemd`
 
 build-orch:
 	mkdir -p bin

--- a/README.md
+++ b/README.md
@@ -40,15 +40,21 @@ At the moment the client and node binary do only print a simple greeting and exi
 
 The orchestrator can be run via:
 ```bash
-./bin/orch <port>
+./bin/orch -p <port>
 ```
 It starts a tcp socket and accepts connections, but does not do much more at this point. 
 This can be tested manually via
 ```bash
 nc <host> <port>
-# e.g.
-# nc localhost 1999
 ```
+
+#### node
+
+Nodes can be run via:
+```bash
+./bin/node -h <host> -p <port>
+```
+It creates a new dbus which tries to connect to the specified host. It does not do much more at this point. 
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Nodes can be run via:
 ```bash
 ./bin/node -h <host> -p <port>
 ```
-It creates a new dbus which tries to connect to the specified host. It does not do much more at this point. 
+It creates a new dbus which tries to connect to the specified host. The host will print out a message if the request was accepted. It does not do much more at this point. 
 
 ## Documentation
 

--- a/src/node/dbus.c
+++ b/src/node/dbus.c
@@ -1,0 +1,44 @@
+#include "dbus.h"
+
+#include <arpa/inet.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+int setup_peer_dbus(sd_bus *dbus, const struct sockaddr_in *addr) {
+        int r;
+        r = sd_bus_new(&dbus);
+        if (r < 0) {
+                fprintf(stderr, "Failed to create bus: %s\n", strerror(-r));
+                return -1;
+        }
+        (void) sd_bus_set_description(dbus, "orchestrator");
+
+        /* we trust everything from the orchestrator, there is only one peer anyway */
+        r = sd_bus_set_trusted(dbus, true);
+        if (r < 0) {
+                fprintf(stderr, "Failed to trust orchestrator: %s\n", strerror(-r));
+                return -1;
+        }
+
+        _cleanup_free_ char *dbus_addr = NULL;
+        r = asprintf(&dbus_addr, "tcp:host=%s,port=%d", inet_ntoa(addr->sin_addr), ntohs(addr->sin_port));
+        if (r < 0) {
+                fprintf(stderr, "Out of memory\n");
+                return -1;
+        }
+
+        r = sd_bus_set_address(dbus, dbus_addr);
+        if (r < 0) {
+                fprintf(stderr, "Failed to set address: %s\n", strerror(-r));
+                return -1;
+        }
+
+        fprintf(stdout, "connecting to orchestrator on '%s'\n", dbus_addr);
+        r = sd_bus_start(dbus);
+        if (r < 0) {
+                fprintf(stderr, "Failed to connect to orchestrator: %s\n", strerror(-r));
+                return -1;
+        }
+
+        return 0;
+}

--- a/src/node/dbus.h
+++ b/src/node/dbus.h
@@ -1,0 +1,10 @@
+#ifndef _BLUE_CHIHUAHUA_NODE_PEER_DBUS
+#define _BLUE_CHIHUAHUA_NODE_PEER_DBUS
+
+#include "../common/dbus.h"
+
+#include <netinet/in.h>
+
+int setup_peer_dbus(sd_bus *dbus, const struct sockaddr_in *addr);
+
+#endif

--- a/src/node/node.c
+++ b/src/node/node.c
@@ -1,4 +1,5 @@
 #include "../common/dbus.h"
+#include "dbus.h"
 #include "opt.h"
 
 #include <stdio.h>
@@ -24,13 +25,20 @@ int main(int argc, char *argv[]) {
                 return EXIT_FAILURE;
         }
 
+        _cleanup_sd_bus_ sd_bus *orch = NULL;
+        r = setup_peer_dbus(orch, &host);
+        if (r < 0) {
+                return EXIT_FAILURE;
+        }
 
         r = sd_event_loop(event);
         if (r < 0) {
                 fprintf(stderr, "Event loop failed: %s\n", strerror(-r));
                 return EXIT_FAILURE;
         }
-
+        if (r < 0) {
+                return EXIT_FAILURE;
+        }
 
         return EXIT_SUCCESS;
 }

--- a/src/node/node.c
+++ b/src/node/node.c
@@ -1,7 +1,20 @@
+#include "opt.h"
+
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
-int main() {
+int main(int argc, char *argv[]) {
         fprintf(stdout, "Hello from node!\n");
+
+        struct sockaddr_in host;
+        memset(&host, 0, sizeof(host));
+        host.sin_family = AF_INET;
+        host.sin_addr.s_addr = htonl(INADDR_ANY);
+        host.sin_port = 0;
+
+        get_opts(argc, argv, &host);
+
+
         return EXIT_SUCCESS;
 }

--- a/src/node/node.c
+++ b/src/node/node.c
@@ -1,3 +1,4 @@
+#include "../common/dbus.h"
 #include "opt.h"
 
 #include <stdio.h>
@@ -14,6 +15,21 @@ int main(int argc, char *argv[]) {
         host.sin_port = 0;
 
         get_opts(argc, argv, &host);
+
+        int r;
+        _cleanup_sd_event_ sd_event *event = NULL;
+        r = sd_event_default(&event);
+        if (r < 0) {
+                fprintf(stderr, "Failed to create event: %s\n", strerror(-r));
+                return EXIT_FAILURE;
+        }
+
+
+        r = sd_event_loop(event);
+        if (r < 0) {
+                fprintf(stderr, "Event loop failed: %s\n", strerror(-r));
+                return EXIT_FAILURE;
+        }
 
 
         return EXIT_SUCCESS;

--- a/src/node/opt.c
+++ b/src/node/opt.c
@@ -1,0 +1,45 @@
+#include "opt.h"
+#include "../common/parse-util.h"
+
+#include <arpa/inet.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void get_opts(int argc, char *argv[], struct sockaddr_in *orchAddr) {
+        int opt, r, port;
+        int hflag, pflag;
+        while ((opt = getopt(argc, argv, "h:p:")) != -1) {
+                switch (opt) {
+                case 'h':
+                        r = inet_pton(AF_INET, optarg, &(orchAddr->sin_addr));
+                        if (r < 1) {
+                                fprintf(stderr, "Invalid host option '%s'\n", optarg);
+                                exit(EXIT_FAILURE);
+                        }
+
+                        hflag = 1;
+                        break;
+                case 'p':
+                        if (parse_long(optarg, (long *) &port) != 0) {
+                                fprintf(stderr, "Invalid port option '%s'\n", optarg);
+                                exit(EXIT_FAILURE);
+                        }
+                        orchAddr->sin_port = htons(port);
+
+                        pflag = 1;
+                        break;
+                default:
+                        exit(EXIT_FAILURE);
+                }
+        }
+
+        if (hflag != 1) {
+                fprintf(stderr, "Missing host option. Usage: %s [-h host] [-p port]\n", argv[0]);
+                exit(EXIT_FAILURE);
+        }
+        if (pflag != 1) {
+                fprintf(stderr, "Missing port option. Usage: %s [-h host] [-p port]\n", argv[0]);
+                exit(EXIT_FAILURE);
+        }
+}

--- a/src/node/opt.h
+++ b/src/node/opt.h
@@ -1,0 +1,8 @@
+#ifndef _BLUE_CHIHUAHUA_NODE_OPTIONS
+#define _BLUE_CHIHUAHUA_NODE_OPTIONS
+
+#include <netinet/in.h>
+
+void get_opts(int argc, char *argv[], struct sockaddr_in *orchAddr);
+
+#endif

--- a/src/orch/controller.c
+++ b/src/orch/controller.c
@@ -62,6 +62,9 @@ static int accept_handler(sd_event_source *s, int fd, uint32_t revents, void *us
 
 int controller_setup(int port, sd_event *event, sd_event_source *event_source) {
         _cleanup_fd_ int accept_fd = create_master_socket(port);
+        if (accept_fd < 0) {
+                return -1;
+        }
 
         int r = sd_event_add_io(event, &event_source, accept_fd, EPOLLIN, accept_handler, NULL);
         if (r < 0) {

--- a/src/orch/controller.c
+++ b/src/orch/controller.c
@@ -56,12 +56,13 @@ static int accept_handler(sd_event_source *s, int fd, uint32_t revents, void *us
         }
 
         // TODO: setup peer dbus, incl. vtable with services, signals, properties
+        fprintf(stdout, "accepted connection request\n");
 
         return 0;
 }
 
-int controller_setup(int port, sd_event *event, sd_event_source *event_source) {
-        _cleanup_fd_ int accept_fd = create_master_socket(port);
+int controller_setup(int accept_fd, int port, sd_event *event, sd_event_source *event_source) {
+        accept_fd = create_master_socket(port);
         if (accept_fd < 0) {
                 return -1;
         }

--- a/src/orch/controller.h
+++ b/src/orch/controller.h
@@ -3,6 +3,6 @@
 
 #include "../common/dbus.h"
 
-int controller_setup(int port, sd_event *event, sd_event_source *event_source);
+int controller_setup(int accept_fd, int port, sd_event *event, sd_event_source *event_source);
 
 #endif

--- a/src/orch/orch.c
+++ b/src/orch/orch.c
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
         _cleanup_sd_event_source_ sd_event_source *event_source = NULL;
         r = controller_setup(port, event, event_source);
         if (r < 0) {
-                fprintf(stderr, "Failed to setup controller");
+                fprintf(stderr, "Failed to setup controller\n");
                 return EXIT_FAILURE;
         }
 

--- a/src/orch/orch.c
+++ b/src/orch/orch.c
@@ -19,8 +19,9 @@ int main(int argc, char *argv[]) {
                 return EXIT_FAILURE;
         }
 
+        _cleanup_fd_ int accept_fd = -1;
         _cleanup_sd_event_source_ sd_event_source *event_source = NULL;
-        r = controller_setup(port, event, event_source);
+        r = controller_setup(accept_fd, port, event, event_source);
         if (r < 0) {
                 fprintf(stderr, "Failed to setup controller\n");
                 return EXIT_FAILURE;


### PR DESCRIPTION
This PR fixes https://github.com/engelmi/orch/issues/11 by
- getting the host and port via cli options (`-h` and `-p`)
- implementing a setup function for the peer dbus to the orchestrator and using the parsed host:port
- updated README
- fixes an out-of-scope bug for the fd of the tcp master socket