### PR TITLE
Add GH build job skeleton

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: cs9-build
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/centos/centos:stream9
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        # Use githash of a tested commit instead of merge commit
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Report success
+      run: |
+        echo "Success :-)"


### PR DESCRIPTION
Add a skeleton of GH build job running inside latest CS9 container.

Signed-off-by: Martin Perina <mperina@redhat.com>
