### PR TITLE
Check source code formatting using Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,16 @@ fmt:
 		clang-format -i --sort-includes $${file} ; \
 	done
 
+check-fmt:
+	# TODO: Replace [client|common|node|orch] with ** after formatting
+	# is fixed under src/ini subdirectory
+	for file in ./src/[client|common|node|orch]/*.[ch] ; do \
+		clang-format --dry-run -Werror $${file} ; \
+		if [ $$? -ne 0 ] ; then \
+			exit 1 ; \
+		fi ; \
+	done
+
 test-all:
 	echo "TBD"
 


### PR DESCRIPTION
Check source code formatting using `make check-fmt` to be able to fix
formatting issues before creating a PR. To run this formatting check
clang-extra-tools package needs to be installed.

Signed-off-by: Martin Perina <mperina@redhat.com>
