### PR TITLE
Add cmd line option that accepts /path/to/ini

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ build-node:
 build-orch:
 	mkdir -p bin
 	gcc -D_GNU_SOURCE \
+		src/ini/ini.c \
 		src/orch/orch.c \
 		src/orch/opt.c \
 		src/orch/controller.c \

--- a/doc/example.ini
+++ b/doc/example.ini
@@ -1,0 +1,9 @@
+; This is a sample configuration file.
+
+[Node]
+OrchestratorIP=<ip>
+OrchestratorPort=<port>
+
+[Orchestrator]
+Port=<port>
+ExpectedNodes=<ip1>,<ip2>,...,<ip n>

--- a/src/orch/opt.c
+++ b/src/orch/opt.c
@@ -4,11 +4,11 @@
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-void get_opts(int argc, char *argv[], int *ctrlPort) {
+void get_opts(int argc, char *argv[], int *ctrlPort, char **configPath) {
         int opt;
-        int pflag;
-        while ((opt = getopt(argc, argv, "p:")) != -1) {
+        int pflag = 0;
+
+        while ((opt = getopt(argc, argv, "p:c:")) != -1) {
                 switch (opt) {
                 case 'p':
                         if (parse_long(optarg, (long *) ctrlPort) != 0) {
@@ -17,6 +17,9 @@ void get_opts(int argc, char *argv[], int *ctrlPort) {
                         }
                         pflag = 1;
                         break;
+                case 'c':
+                        asprintf(configPath, "%s", optarg);
+                        break;
                 default:
                         exit(EXIT_FAILURE);
                 }
@@ -24,6 +27,11 @@ void get_opts(int argc, char *argv[], int *ctrlPort) {
 
         if (pflag != 1) {
                 fprintf(stderr, "Missing port option. Usage: %s [-p port]\n", argv[0]);
+                exit(EXIT_FAILURE);
+        }
+
+        if (configPath == NULL) {
+                fprintf(stderr, "Missing INI file path. Usage: %s [-c /path/to/ini-file]\n", argv[0]);
                 exit(EXIT_FAILURE);
         }
 }

--- a/src/orch/opt.h
+++ b/src/orch/opt.h
@@ -1,6 +1,6 @@
 #ifndef _BLUE_CHIHUAHUA_ORCH_OPTIONS
 #define _BLUE_CHIHUAHUA_ORCH_OPTIONS
 
-void get_opts(int argc, char *argv[], int *ctrlPort);
+void get_opts(int argc, char *argv[], int *ctrlPort, char **configPath);
 
 #endif

--- a/src/orch/orch.c
+++ b/src/orch/orch.c
@@ -1,19 +1,27 @@
 #include "../common/dbus.h"
+#include "../ini/ini.h"
 #include "controller.h"
 #include "opt.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 
+/* A function that takes care of printing the lines of the ini file  */
+static int ini_handler_func(void *user, const char *section, const char *name, const char *value) {
+        printf("[%s] %s = %s\n", section, name, value);
+        return EXIT_FAILURE;
+}
+
 int main(int argc, char *argv[]) {
         fprintf(stdout, "Hello from orchestrator!\n");
 
         int port;
-        get_opts(argc, argv, &port);
+        _cleanup_free_ char *configPath = NULL;
 
-        int r;
+        get_opts(argc, argv, &port, &configPath);
+
         _cleanup_sd_event_ sd_event *event = NULL;
-        r = sd_event_default(&event);
+        int r = sd_event_default(&event);
         if (r < 0) {
                 fprintf(stderr, "Failed to create event: %s\n", strerror(-r));
                 return EXIT_FAILURE;
@@ -23,6 +31,12 @@ int main(int argc, char *argv[]) {
         r = controller_setup(port, event, event_source);
         if (r < 0) {
                 fprintf(stderr, "Failed to setup controller");
+                return EXIT_FAILURE;
+        }
+
+        r = ini_parse(configPath, ini_handler_func, NULL);
+        if (r < 0) {
+                fprintf(stderr, "Failed to parse INI file: %s\n", configPath);
                 return EXIT_FAILURE;
         }
 


### PR DESCRIPTION
Attempts to solve #8 

Added a new command line option that accepts /path/to/ini/file as a parameter. I also added a intial code for parsing the file to the orchestrator. At the moment it just prints the file line by line.

I have also changed the get_opts() function a tiny bit so I could check for parsing the command line args.