### PR TITLE
Enhance cli args handling: add getopt_long

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,8 +15,8 @@ systemd_dep = dependency('libsystemd')
 
 # internal dependencies
 common_inc = include_directories('src/common')
+common_src = files('src/common/parse-util.c')
 ini_inc = include_directories('src/ini')
-
 ini_src = files('src/ini/ini.c')
 
 

--- a/src/common/opt.h
+++ b/src/common/opt.h
@@ -1,0 +1,13 @@
+#ifndef _BLUE_CHIHUAHUA_NODE_OPTIONS_COMMON
+#define _BLUE_CHIHUAHUA_NODE_OPTIONS_COMMON
+
+#define ARG_PORT "port"
+#define ARG_PORT_SHORT 'P'
+#define ARG_HOST "host"
+#define ARG_HOST_SHORT 'H'
+#define ARG_CONFIG "config"
+#define ARG_CONFIG_SHORT 'c'
+#define ARG_HELP "help"
+#define ARG_HELP_SHORT 'h'
+
+#endif

--- a/src/common/parse-util.c
+++ b/src/common/parse-util.c
@@ -1,0 +1,41 @@
+#include "parse-util.h"
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+bool parse_long(const char *in, long *ret) {
+        const int base = 10;
+        char *x = NULL;
+
+        if (in == NULL || strlen(in) == 0) {
+                return false;
+        }
+
+        errno = 0;
+        *ret = strtol(in, &x, base);
+
+        if (errno > 0 || !x || x == in || *x != 0) {
+                return false;
+        }
+
+        return true;
+}
+
+bool parse_port(const char *in, uint16_t *ret) {
+        if (in == NULL || strlen(in) == 0) {
+                return false;
+        }
+
+        bool r = false;
+        long l = 0;
+        r = parse_long(in, &l);
+
+        if (!r || l < 0 || l > USHRT_MAX) {
+                return false;
+        }
+
+        *ret = (uint16_t) l;
+        return true;
+}

--- a/src/common/parse-util.h
+++ b/src/common/parse-util.h
@@ -1,22 +1,10 @@
 #ifndef _BLUE_CHIHUAHUA_ORCH_PARSEUTIL
 #define _BLUE_CHIHUAHUA_ORCH_PARSEUTIL
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <inttypes.h>
+#include <stdbool.h>
 
-int parse_long(const char *in, long *val) {
-        if (in == NULL) {
-                return 1;
-        }
-
-        const int decimalBase = 10;
-        char *ptr = NULL;
-        *val = strtol(in, &ptr, decimalBase);
-        if (strcmp(ptr, "") != 0) {
-                return 1;
-        }
-        return 0;
-}
+bool parse_long(const char *in, long *ret);
+bool parse_port(const char *in, uint16_t *ret);
 
 #endif

--- a/src/node/meson.build
+++ b/src/node/meson.build
@@ -5,6 +5,8 @@ node_src = [
   'node.c',
   'opt.c'
 ]
+node_src += common_src
+
 executable(
   'node',
   node_src,

--- a/src/node/opt.c
+++ b/src/node/opt.c
@@ -1,4 +1,5 @@
 #include "opt.h"
+#include "../common/opt.h"
 #include "../common/parse-util.h"
 
 #include <arpa/inet.h>
@@ -6,17 +7,25 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void get_opts(int argc, char *argv[], struct sockaddr_in *orchAddr) {
+const struct option options[] = { { ARG_HOST, required_argument, 0, ARG_HOST_SHORT },
+                                  { ARG_PORT, required_argument, 0, ARG_PORT_SHORT },
+                                  { NULL, 0, 0, '\0' } };
+
+const char *get_optstring() {
+        return "H:P:";
+}
+
+void get_opts(int argc, char *argv[], struct sockaddr_in *orch_addr) {
         int r = 0;
         int opt = 0;
-        int port = 0;
+        uint16_t port = 0;
         int hflag = 0;
         int pflag = 0;
 
-        while ((opt = getopt(argc, argv, "h:p:")) != -1) {
+        while ((opt = getopt_long(argc, argv, get_optstring(), options, NULL)) != -1) {
                 switch (opt) {
-                case 'h':
-                        r = inet_pton(AF_INET, optarg, &(orchAddr->sin_addr));
+                case ARG_HOST_SHORT:
+                        r = inet_pton(AF_INET, optarg, &(orch_addr->sin_addr));
                         if (r < 1) {
                                 fprintf(stderr, "Invalid host option '%s'\n", optarg);
                                 exit(EXIT_FAILURE);
@@ -24,12 +33,12 @@ void get_opts(int argc, char *argv[], struct sockaddr_in *orchAddr) {
 
                         hflag = 1;
                         break;
-                case 'p':
-                        if (parse_long(optarg, (long *) &port) != 0) {
+                case ARG_PORT_SHORT:
+                        if (!parse_port(optarg, &port)) {
                                 fprintf(stderr, "Invalid port option '%s'\n", optarg);
                                 exit(EXIT_FAILURE);
                         }
-                        orchAddr->sin_port = htons(port);
+                        orch_addr->sin_port = htons(port);
 
                         pflag = 1;
                         break;

--- a/src/node/opt.h
+++ b/src/node/opt.h
@@ -3,6 +3,6 @@
 
 #include <netinet/in.h>
 
-void get_opts(int argc, char *argv[], struct sockaddr_in *orchAddr);
+void get_opts(int argc, char *argv[], struct sockaddr_in *orch_addr);
 
 #endif

--- a/src/orch/controller.c
+++ b/src/orch/controller.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <sys/socket.h>
 
-int create_master_socket(const int port) {
+int create_master_socket(const uint16_t port) {
         struct sockaddr_in servaddr;
 
         int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
@@ -62,7 +62,7 @@ static int accept_handler(sd_event_source *s, int fd, uint32_t revents, void *us
         return 0;
 }
 
-int controller_setup(int accept_fd, int port, sd_event *event, sd_event_source *event_source) {
+int controller_setup(int accept_fd, uint16_t port, sd_event *event, sd_event_source *event_source) {
         accept_fd = create_master_socket(port);
         if (accept_fd < 0) {
                 return -1;

--- a/src/orch/controller.h
+++ b/src/orch/controller.h
@@ -3,6 +3,6 @@
 
 #include "../common/dbus.h"
 
-int controller_setup(int accept_fd, int port, sd_event *event, sd_event_source *event_source);
+int controller_setup(int accept_fd, uint16_t port, sd_event *event, sd_event_source *event_source);
 
 #endif

--- a/src/orch/meson.build
+++ b/src/orch/meson.build
@@ -6,6 +6,7 @@ orch_src = [
   'controller.c'
 ]
 orch_src += ini_src
+orch_src += common_src
 
 executable(
   'orch',

--- a/src/orch/opt.c
+++ b/src/orch/opt.c
@@ -1,24 +1,34 @@
 #include "opt.h"
+#include "../common/opt.h"
 #include "../common/parse-util.h"
 
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
-void get_opts(int argc, char *argv[], int *ctrlPort, char **configPath) {
+
+const struct option options[] = { { ARG_PORT, required_argument, 0, ARG_PORT_SHORT },
+                                  { ARG_CONFIG, required_argument, 0, ARG_CONFIG_SHORT },
+                                  { NULL, 0, 0, '\0' } };
+
+const char *get_optstring() {
+        return "P:c:";
+}
+
+void get_opts(int argc, char *argv[], uint16_t *ctrl_port, char **config_path) {
         int opt = 0;
         int pflag = 0;
 
-        while ((opt = getopt(argc, argv, "p:c:")) != -1) {
+        while ((opt = getopt_long(argc, argv, get_optstring(), options, NULL)) != -1) {
                 switch (opt) {
-                case 'p':
-                        if (parse_long(optarg, (long *) ctrlPort) != 0) {
+                case ARG_PORT_SHORT:
+                        if (!parse_port(optarg, ctrl_port)) {
                                 fprintf(stderr, "Invalid port option '%s'\n", optarg);
                                 exit(EXIT_FAILURE);
                         }
                         pflag = 1;
                         break;
-                case 'c':
-                        asprintf(configPath, "%s", optarg);
+                case ARG_CONFIG_SHORT:
+                        asprintf(config_path, "%s", optarg);
                         break;
                 default:
                         exit(EXIT_FAILURE);
@@ -30,7 +40,7 @@ void get_opts(int argc, char *argv[], int *ctrlPort, char **configPath) {
                 exit(EXIT_FAILURE);
         }
 
-        if (configPath == NULL) {
+        if (config_path == NULL) {
                 fprintf(stderr, "Missing INI file path. Usage: %s [-c /path/to/ini-file]\n", argv[0]);
                 exit(EXIT_FAILURE);
         }

--- a/src/orch/opt.h
+++ b/src/orch/opt.h
@@ -1,6 +1,8 @@
 #ifndef _BLUE_CHIHUAHUA_ORCH_OPTIONS
 #define _BLUE_CHIHUAHUA_ORCH_OPTIONS
 
-void get_opts(int argc, char *argv[], int *ctrlPort, char **configPath);
+#include <inttypes.h>
+
+void get_opts(int argc, char *argv[], uint16_t *ctrl_port, char **config_path);
 
 #endif

--- a/src/orch/orch.c
+++ b/src/orch/orch.c
@@ -16,7 +16,7 @@ static int ini_handler_func(void *user, const char *section, const char *name, c
 int main(int argc, char *argv[]) {
         fprintf(stdout, "Hello from orchestrator!\n");
 
-        int port = 0;
+        uint16_t port = 0;
         _cleanup_free_ char *configPath = NULL;
 
         get_opts(argc, argv, &port, &configPath);

--- a/test/common/meson.build
+++ b/test/common/meson.build
@@ -1,4 +1,9 @@
 # common test configuration
+parse_util_src = [
+  'parse-util_test.c'
+]
 
-e = executable('parse-util_test', 'parse-util_test.c')
+parse_util_src += common_src
+
+e = executable('parse-util_test', parse_util_src)
 test('parse-util_test', e)

--- a/test/common/parse-util_test.c
+++ b/test/common/parse-util_test.c
@@ -3,12 +3,13 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 #ifndef __FUNCTION_NAME__
 #        define __FUNCTION_NAME__ __func__
 #endif
 
-void test_parse_long(const char *input, int expectedReturn, long expectedResult) {
+void test_parse_long(const char *input, bool expectedReturn, long expectedResult) {
         char *msg = NULL;
 
         long res = 0;
@@ -29,11 +30,41 @@ void test_parse_long(const char *input, int expectedReturn, long expectedResult)
         }
 }
 
+void test_parse_port(const char *input, bool expected_return, uint16_t expected_result) {
+        char *msg = NULL;
+
+        uint16_t res = 0;
+        bool ret = parse_port(input, &res);
+        if ((ret != expected_return) || (res != expected_result)) {
+                asprintf(&msg,
+                         "FAILED: %s\n\tInput: '%s'\n\tExpected: Return=%d, Result=%d\n\tGot: Return=%d, Result=%d\n",
+                         __FUNCTION_NAME__,
+                         input,
+                         expected_return,
+                         expected_result,
+                         ret,
+                         res);
+        }
+
+        if (msg != NULL) {
+                fprintf(stderr, "%s", msg);
+        }
+}
+
 int main() {
-        test_parse_long(NULL, 1, 0L);
-        test_parse_long("", 0, 0L);
-        test_parse_long("foo", 1, 0L);
-        test_parse_long("1234", 0, 1234L);
-        test_parse_long("1234abc", 1, 1234L);
-        test_parse_long("abc1234", 1, 0L);
+        test_parse_long(NULL, false, 0L);
+        test_parse_long("", false, 0L);
+        test_parse_long("foo", false, 0L);
+        test_parse_long("1234", true, 1234L);
+        test_parse_long("1234abc", false, 1234L);
+        test_parse_long("abc1234", false, 0L);
+
+        test_parse_port(NULL, false, 0);
+        test_parse_port("", false, 0);
+        test_parse_port("foo", false, 0);
+        test_parse_port("0", true, 0);
+        test_parse_port("8888", true, 8888);
+        test_parse_port("65535", true, 65535);
+        test_parse_port("65536", false, 0);
+        test_parse_port("-2", false, 0);
 }


### PR DESCRIPTION
- Switched to using getopt_long instead of getopt.
- Removed function implementation from parse-util header file, and added parse_port function
- Port variable type is changed to unsigned short (uint16)
- Fixed and added parse-util unit tests
- Some more refactorings