### PR TITLE
Update default option for meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,8 @@ project(
   version: '0.0.1',
   license: 'GPL-2.0-or-later',
   default_options: [
-    'warning_level=3',
+    'c_std=gnu11',
+    'warning_level=2',
     'debug=true'
   ]
 )

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,9 @@ project(
   ]
 )
 
+# add global arguments for gcc
+add_global_arguments('-D_GNU_SOURCE', language : 'c')
+
 # external dependencies
 systemd_dep = dependency('libsystemd')
 


### PR DESCRIPTION
This PR aligns the default options for meson used in `systemd` (see [here](https://github.com/systemd/systemd/blob/main/meson.build#L6-L12)):
```
'c_std=gnu11'
'warning_level=2'
...
```
and adds the `_GNU_SOURCE` as global compiler argument. 
