### PR TITLE
Warnings as errors

### DIFF
--- a/binchihua/src/common/hashmap/hashmap.c
+++ b/binchihua/src/common/hashmap/hashmap.c
@@ -2,12 +2,14 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
-#include "hashmap.h"
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "hashmap.h"
+#include "../../../../libchihua-msg/include/common/common.h"
 
 static void *(*_malloc)(size_t) = NULL;
 static void *(*_realloc)(void *, size_t) = NULL;
@@ -86,7 +88,7 @@ struct hashmap *hashmap_new_with_allocator(
         _malloc = _malloc ? _malloc : malloc;
         _realloc = _realloc ? _realloc : realloc;
         _free = _free ? _free : free;
-        int ncap = 16;
+        size_t ncap = 16;
         if (cap < ncap) {
                 cap = ncap;
         } else {
@@ -523,16 +525,22 @@ static uint64_t SIP64(const uint8_t *in, const size_t inlen, uint64_t seed0, uin
         switch (left) {
         case 7:
                 b |= ((uint64_t) in[6]) << 48;
+                [[fallthrough]];
         case 6:
                 b |= ((uint64_t) in[5]) << 40;
+                [[fallthrough]];
         case 5:
                 b |= ((uint64_t) in[4]) << 32;
+                [[fallthrough]];
         case 4:
                 b |= ((uint64_t) in[3]) << 24;
+                [[fallthrough]];
         case 3:
                 b |= ((uint64_t) in[2]) << 16;
+                [[fallthrough]];
         case 2:
                 b |= ((uint64_t) in[1]) << 8;
+                [[fallthrough]];
         case 1:
                 b |= ((uint64_t) in[0]);
                 break;
@@ -621,44 +629,58 @@ static void MM86128(const void *key, const int len, uint32_t seed, void *out) {
         switch (len & 15) {
         case 15:
                 k4 ^= tail[14] << 16;
+                [[fallthrough]];
         case 14:
                 k4 ^= tail[13] << 8;
+                [[fallthrough]];
         case 13:
                 k4 ^= tail[12] << 0;
                 k4 *= c4;
                 k4 = ROTL32(k4, 18);
                 k4 *= c1;
                 h4 ^= k4;
+                [[fallthrough]];
         case 12:
                 k3 ^= tail[11] << 24;
+                [[fallthrough]];
         case 11:
                 k3 ^= tail[10] << 16;
+                [[fallthrough]];
         case 10:
                 k3 ^= tail[9] << 8;
+                [[fallthrough]];
         case 9:
                 k3 ^= tail[8] << 0;
                 k3 *= c3;
                 k3 = ROTL32(k3, 17);
                 k3 *= c4;
                 h3 ^= k3;
+                [[fallthrough]];
         case 8:
                 k2 ^= tail[7] << 24;
+                [[fallthrough]];
         case 7:
                 k2 ^= tail[6] << 16;
+                [[fallthrough]];
         case 6:
                 k2 ^= tail[5] << 8;
+                [[fallthrough]];
         case 5:
                 k2 ^= tail[4] << 0;
                 k2 *= c2;
                 k2 = ROTL32(k2, 16);
                 k2 *= c3;
                 h2 ^= k2;
+                [[fallthrough]];
         case 4:
                 k1 ^= tail[3] << 24;
+                [[fallthrough]];
         case 3:
                 k1 ^= tail[2] << 16;
+                [[fallthrough]];
         case 2:
                 k1 ^= tail[1] << 8;
+                [[fallthrough]];
         case 1:
                 k1 ^= tail[0] << 0;
                 k1 *= c1;
@@ -698,7 +720,7 @@ uint64_t hashmap_sip(const void *data, size_t len, uint64_t seed0, uint64_t seed
 }
 
 // hashmap_murmur returns a hash value for `data` using Murmur3_86_128.
-uint64_t hashmap_murmur(const void *data, size_t len, uint64_t seed0, uint64_t seed1) {
+uint64_t hashmap_murmur(const void *data, size_t len, uint64_t seed0, UNUSED uint64_t seed1) {
         char out[16];
         MM86128(data, len, seed0, &out);
         return *(uint64_t *) out;

--- a/binchihua/src/ini/config.c
+++ b/binchihua/src/ini/config.c
@@ -1,9 +1,10 @@
-#include "config.h"
-#include "../common/strings.h"
-#include "assert.h"
-#include "ini.h"
 #include <stdlib.h>
 
+#include "../../../libchihua-msg/include/common/common.h"
+#include "../common/strings.h"
+#include "assert.h"
+#include "config.h"
+#include "ini.h"
 
 int match(const char *section, const char *check_section, const char *name, const char *check_name) {
         if (streq(section, check_section) == 0 && streq(name, check_name) == 0) {
@@ -13,7 +14,7 @@ int match(const char *section, const char *check_section, const char *name, cons
 }
 
 // NOLINTNEXTLINE
-int key_value_compare_key(const void *a, const void *b, void *udata) {
+int key_value_compare_key(const void *a, const void *b, UNUSED void *udata) {
         const keyValue *kva = a;
         const keyValue *kvb = b;
         if (kva->value == NULL || kvb->value == NULL) {
@@ -28,7 +29,7 @@ uint64_t key_value_hash(const void *item, uint64_t seed0, uint64_t seed1) {
 }
 
 // NOLINTNEXTLINE
-int topic_compare_topic_name(const void *a, const void *b, void *udata) {
+int topic_compare_topic_name(const void *a, const void *b, UNUSED void *udata) {
         const topic *ta = a;
         const topic *tb = b;
         return streq(ta->topic, tb->topic);

--- a/binchihua/src/orch/orch.c
+++ b/binchihua/src/orch/orch.c
@@ -1,16 +1,10 @@
-#include "../../../libchihua-msg/include/orchestrator.h"
-#include "../ini/config.h"
-#include "opt.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 
-/* A function that takes care of printing the lines of the ini file  */
-// NOLINTNEXTLINE
-static int ini_handler_func(void *user, const char *section, const char *name, const char *value) {
-        printf("[%s] %s = %s\n", section, name, value);
-        return EXIT_FAILURE;
-}
+#include "../../../libchihua-msg/include/common/common.h"
+#include "../../../libchihua-msg/include/orchestrator.h"
+#include "../ini/config.h"
+#include "opt.h"
 
 int main(int argc, char *argv[]) {
         fprintf(stdout, "Hello from orchestrator!\n");

--- a/libchihua-msg/include/common/common.h
+++ b/libchihua-msg/include/common/common.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define UNUSED __attribute__((unused))

--- a/libchihua-msg/src/orchestrator/controller.c
+++ b/libchihua-msg/src/orchestrator/controller.c
@@ -1,11 +1,12 @@
-#include "../../include/orchestrator/controller.h"
-#include "../common/dbus.h"
-
 #include <errno.h>
 #include <netinet/in.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>
+
+#include "../../include/common/common.h"
+#include "../../include/orchestrator/controller.h"
+#include "../common/dbus.h"
 
 static int create_master_socket(uint16_t port) {
         struct sockaddr_in servaddr;
@@ -90,8 +91,7 @@ void controller_unrefp(Controller **controller) {
         free(*controller);
 }
 
-// NOLINTNEXTLINE
-static int accept_handler(sd_event_source *s, int fd, uint32_t revents, void *userdata) {
+static int accept_handler(UNUSED sd_event_source *source, int fd, UNUSED uint32_t revents, UNUSED void *userdata) {
         _cleanup_fd_ int nfd = accept4(fd, NULL, NULL, SOCK_NONBLOCK | SOCK_CLOEXEC);
         if (nfd < 0) {
                 if (errno == EAGAIN || errno == EINTR || errno == EWOULDBLOCK) {

--- a/meson.build
+++ b/meson.build
@@ -4,20 +4,21 @@ project(
   version: '0.0.1',
   license: 'GPL-2.0-or-later',
   default_options: [
-    'c_std=gnu11',
-    'warning_level=2',
-    'debug=true'
+    'c_std=gnu17',     # Adds "-std=gnu17".  Includes GNU 17 extensions.
+    'warning_level=2', # Adds "-Wextra".  Enables additional warnings. 
+    'debug=true',      # Adds "-g".  Object files include debugging symbols.
+    'werror=true'      # Adds "-Werror".  Treat warnings as errors.
   ]
 )
 
-# add global arguments for gcc
+# Enable GNU extensions.
 add_global_arguments('-D_GNU_SOURCE', language : 'c')
 
-# external dependencies
+# Link with systemd shared library.
 systemd_dep = dependency('libsystemd')
 
-# build shared library
+# Subdirectory for the shared library.
 subdir('libchihua-msg')
 
-# build binaries
+# Subdirectory for applications.
 subdir('binchihua')


### PR DESCRIPTION
Summary of changes;
- Build with GCC 17.
- Enable treating warnings as errors.
- Fix all warnings.
