### PR TITLE
Add signal handler for client program.

### DIFF
--- a/binchihua/src/client/client.c
+++ b/binchihua/src/client/client.c
@@ -1,7 +1,32 @@
+#include <signal.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
+
+// NOLINTNEXTLINE
+static bool done = false;
+
+static void signal_handler(int signal) {
+        printf("\n%s(): Received signal %d\n", __func__, signal);
+        done = true;
+}
 
 int main() {
-        fprintf(stdout, "Hello from client!\n");
-        return EXIT_SUCCESS;
+        struct sigaction sa;
+        sa.sa_handler = &signal_handler;
+        sigaction(SIGINT, &sa, NULL);
+        sigaction(SIGTERM, &sa, NULL);
+        sigaction(SIGSEGV, &sa, NULL);
+        sigaction(SIGBUS, &sa, NULL);
+        sigaction(SIGABRT, &sa, NULL);
+
+        while (!done) {
+                sleep(1);
+                printf("%s(): Hello from client\n", __func__);
+        }
+
+        printf("%s(): Goodbye fromt client\n", __func__);
+
+        exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
This adds a signal handler to the client program.

To try this out, run the client program, and do a Ctrl-C.  The kernel sends a SIGINT to the application.  The signal handler has registered for SIGINT, and when the signal handler is invoked by the kernel, the program has an opportunity to stop the application, close files, free memory, etc.  You can send various signals to the program.  For example, to send a SIGTERM on Fedora:
```$ sudo kill -15 <client_pid>```

Use ```kill -l``` to get a list of the signal numbers.