### PR TITLE
connect to user and systemd dbus

### DIFF
--- a/libhirte/include/bus/peer-bus.h
+++ b/libhirte/include/bus/peer-bus.h
@@ -1,10 +1,10 @@
 #pragma once
 
+
 #include <netinet/in.h>
 #include <systemd/sd-bus.h>
-#include <systemd/sd-event.h>
 
-#include "common/list.h"
+#include "../common/list.h"
 
 char *assemble_tcp_address(const struct sockaddr_in *addr);
 

--- a/libhirte/include/bus/systemd-bus.h
+++ b/libhirte/include/bus/systemd-bus.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <systemd/sd-bus.h>
+
+sd_bus *systemd_bus_open(sd_event *event);

--- a/libhirte/include/bus/user-bus.h
+++ b/libhirte/include/bus/user-bus.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <systemd/sd-bus.h>
+
+sd_bus *user_bus_open(sd_event *event);

--- a/libhirte/include/orchestrator.h
+++ b/libhirte/include/orchestrator.h
@@ -17,6 +17,8 @@ typedef struct {
         sd_event *event_loop;
         sd_event_source *peer_connection_source;
 
+        sd_bus *user_dbus;
+
         PeerManager *peer_manager;
 } Orchestrator;
 

--- a/libhirte/include/orchestrator/peer-manager.h
+++ b/libhirte/include/orchestrator/peer-manager.h
@@ -2,7 +2,7 @@
 
 #include "../../include/common/common.h"
 #include "../../include/common/list.h"
-#include "../peer-bus.h"
+#include "../bus/peer-bus.h"
 
 typedef struct {
         sd_event *event_loop;

--- a/libhirte/include/socket.h
+++ b/libhirte/include/socket.h
@@ -4,3 +4,5 @@
 
 int create_tcp_socket(uint16_t port);
 int accept_tcp_connection_request(int fd);
+
+int fd_check_peercred(int fd);

--- a/libhirte/meson.build
+++ b/libhirte/meson.build
@@ -1,7 +1,9 @@
 libhirte_src = [
     'include/node.h',
     'include/orchestrator.h',
-    'include/peer-bus.h',
+    'include/bus/peer-bus.h',
+    'include/bus/user-bus.h',
+    'include/bus/systemd-bus.h',
     'include/socket.h',
     'include/common/memory.h',
     'include/orchestrator/peer-manager.h',
@@ -10,7 +12,9 @@ libhirte_src = [
     'src/common/dbus.h',
     'src/node.c',
     'src/orchestrator.c',
-    'src/peer-bus.c',
+    'src/bus/peer-bus.c',
+    'src/bus/user-bus.c',
+    'src/bus/systemd-bus.c',
     'src/socket.c',
     'src/orchestrator/peer-manager.c',
 ]

--- a/libhirte/src/bus/peer-bus.c
+++ b/libhirte/src/bus/peer-bus.c
@@ -1,8 +1,9 @@
 #include <arpa/inet.h>
+#include <errno.h>
 #include <stdio.h>
 
-#include "../include/peer-bus.h"
-#include "common/dbus.h"
+#include "../../include/bus/peer-bus.h"
+#include "../common/dbus.h"
 
 char *assemble_tcp_address(const struct sockaddr_in *addr) {
         if (addr == NULL) {

--- a/libhirte/src/bus/systemd-bus.c
+++ b/libhirte/src/bus/systemd-bus.c
@@ -1,0 +1,68 @@
+#include <errno.h>
+#include <stdio.h>
+
+#include "../../include/bus/systemd-bus.h"
+#include "../../include/socket.h"
+#include "../common/dbus.h"
+
+static int systemd_bus_new(sd_bus **ret) {
+        if (ret == NULL) {
+                return -EINVAL;
+        }
+
+        int r = 0;
+        _cleanup_sd_bus_ sd_bus *bus = NULL;
+
+        if (geteuid() != 0) {
+                r = sd_bus_default_system(&bus);
+                if (r < 0) {
+                        return r;
+                }
+                *ret = steal_pointer(&bus);
+                return 1;
+        }
+
+        r = sd_bus_new(&bus);
+        if (r < 0) {
+                return r;
+        }
+        r = sd_bus_set_address(bus, "unix:path=/run/systemd/private");
+        if (r < 0) {
+                return r;
+        }
+        r = sd_bus_start(bus);
+        if (r < 0) {
+                return r;
+        }
+
+        int fd = sd_bus_get_fd(bus);
+        if (fd < 0) {
+                return fd;
+        }
+        r = fd_check_peercred(fd);
+        if (r < 0) {
+                return r;
+        }
+
+        *ret = steal_pointer(&bus);
+        return 1;
+}
+
+sd_bus *systemd_bus_open(sd_event *event) {
+        int r = 0;
+        _cleanup_sd_bus_ sd_bus *bus = NULL;
+
+        r = systemd_bus_new(&bus);
+        if (r < 0) {
+                fprintf(stderr, "Failed to connect to systemd bus: %s\n", strerror(-r));
+                return NULL;
+        }
+        r = sd_bus_attach_event(bus, event, SD_EVENT_PRIORITY_NORMAL);
+        if (r < 0) {
+                fprintf(stderr, "Failed to attach systemd bus to event: %s\n", strerror(-r));
+                return NULL;
+        }
+        (void) sd_bus_set_description(bus, "systemd-bus");
+
+        return steal_pointer(&bus);
+}

--- a/libhirte/src/bus/user-bus.c
+++ b/libhirte/src/bus/user-bus.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+
+#include "../../include/bus/user-bus.h"
+#include "../common/dbus.h"
+
+sd_bus *user_bus_open(sd_event *event) {
+        int r = 0;
+        _cleanup_sd_bus_ sd_bus *bus = NULL;
+
+        r = sd_bus_open_user(&bus);
+        if (r < 0) {
+                fprintf(stderr, "Failed to connect to user bus: %s\n", strerror(-r));
+                return NULL;
+        }
+
+        r = sd_bus_attach_event(bus, event, SD_EVENT_PRIORITY_NORMAL);
+        if (r < 0) {
+                fprintf(stderr, "Failed to attach bus to event: %s\n", strerror(-r));
+                return NULL;
+        }
+        (void) sd_bus_set_description(bus, "user-bus");
+
+        return steal_pointer(&bus);
+}


### PR DESCRIPTION
This PR does
- add dedicated functions for connecting to the local user dbus and the dbus of systemd
- opens the local user dbus and systemd dbus when creating a `node`
- opens the local user dbus when creating the `orchestrator`

Therefore, this PR 
- fixes #20 
- fixes #22 (partially)