### PR TITLE
Add signal handling to hirte and hirte-node

### DIFF
--- a/libhirte/src/node.c
+++ b/libhirte/src/node.c
@@ -3,14 +3,12 @@
 #include "../include/bus/peer-bus.h"
 #include "../include/bus/systemd-bus.h"
 #include "../include/bus/user-bus.h"
+#include "../include/common/common.h"
 #include "../include/node.h"
 #include "./common/dbus.h"
-#include "../include/common/common.h"
 
-static int node_signal_handler(sd_event_source *event_source,
-                               UNUSED const struct signalfd_siginfo *si,
-                               UNUSED void *userdata)
-{
+static int node_signal_handler(
+                sd_event_source *event_source, UNUSED const struct signalfd_siginfo *si, UNUSED void *userdata) {
         // Do whatever cleanup is needed here.
 
         sd_event *event = sd_event_source_get_event(event_source);
@@ -19,8 +17,7 @@ static int node_signal_handler(sd_event_source *event_source,
         return 0;
 }
 
-static int node_setup_signal_handler(sd_event *event)
-{
+static int node_setup_signal_handler(sd_event *event) {
         sigset_t sigset;
         int r = 0;
 
@@ -140,7 +137,7 @@ bool node_start(Node *node) {
         r = sd_event_loop(node->event_loop);
         if (r < 0) {
                 fprintf(stderr, "Starting node event loop failed: %m\n");
-                return false; 
+                return false;
         }
 
         fprintf(stdout, "Exited node event loop()\n");

--- a/libhirte/src/node.c
+++ b/libhirte/src/node.c
@@ -13,7 +13,6 @@ static int node_signal_handler(
 
         sd_event *event = sd_event_source_get_event(event_source);
         sd_event_exit(event, 0);
-
         return 0;
 }
 

--- a/libhirte/src/orchestrator.c
+++ b/libhirte/src/orchestrator.c
@@ -7,12 +7,9 @@
 #include "../include/orchestrator/peer-manager.h"
 #include "../include/socket.h"
 #include "./common/dbus.h"
-#include "../include/common/common.h"
 
-static int orch_signal_handler(sd_event_source *event_source,
-                               UNUSED const struct signalfd_siginfo *si,
-                               UNUSED void *userdata)
-{
+static int orch_signal_handler(
+                sd_event_source *event_source, UNUSED const struct signalfd_siginfo *si, UNUSED void *userdata) {
         // Do whatever cleanup is needed here.
 
         sd_event *event = sd_event_source_get_event(event_source);
@@ -21,8 +18,7 @@ static int orch_signal_handler(sd_event_source *event_source,
         return 0;
 }
 
-static int orch_setup_signal_handler(sd_event *event)
-{
+static int orch_setup_signal_handler(sd_event *event) {
         sigset_t sigset;
         int r = 0;
 
@@ -184,7 +180,7 @@ bool orch_start(const Orchestrator *orchestrator) {
         if (r < 0) {
                 fprintf(stderr, "Starting orch event loop failed: %m\n");
                 return false;
-        } 
+        }
 
         fprintf(stdout, "Exited orch event loop()\n");
 


### PR DESCRIPTION
This PR addresses issue #67.  Now if a SIGTERM signal is sent to hirte or hirte-node processes, registered handlers are invoked by their respective event loops.  These handlers can initiate whatever clean-up is needed, and then exit the event loops.