### PR TITLE
Add signal handling to orch and node event loops.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 
 builddir
+tags

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ sudo dnf install -y clang-tools-extra gcc make meson systemd-devel
 make fmt
 ```
 
+For the most part, this project follows systemd coding style: [systemd-coding-style](https://github.com/systemd/systemd/blob/main/docs/CODING_STYLE.md).
+Also, this project borrows some of the coding conventions from systemd.  For example, function names pertaining to D-Bus services look like <code>bus_service_set_property()</code>.
+
 A formatting check of existing files can be executed by:
 ```bash
 make check-fmt

--- a/hirte/src/node/node.c
+++ b/hirte/src/node/node.c
@@ -9,6 +9,8 @@
 
 
 int main(int argc, char *argv[]) {
+        int r = -1;
+
         fprintf(stdout, "Hello from node!\n");
 
         struct sockaddr_in host;
@@ -31,13 +33,22 @@ int main(int argc, char *argv[]) {
                 return EXIT_FAILURE;
         }
 
-        if (!service_register_shutdown(node->user_dbus, node->event_loop)) {
+        if (!shutdown_service_register(node->user_dbus, node->event)) {
                 fprintf(stderr, "Failed to register shutdown service\n");
+                return EXIT_FAILURE;
+        }
+
+        r = event_loop_add_shutdown_signals(node->event);
+        if (r < 0) {
+                fprintf(stderr, "Failed to add signals to node event loop\n");
                 return EXIT_FAILURE;
         }
 
         if (node_start(node)) {
                 return EXIT_SUCCESS;
         }
+
+        fprintf(stdout, "Node exited\n");
+
         return EXIT_FAILURE;
 }

--- a/hirte/src/orch/orch.c
+++ b/hirte/src/orch/orch.c
@@ -7,6 +7,8 @@
 #include "opt.h"
 
 int main(int argc, char *argv[]) {
+        int r = -1;
+
         fprintf(stdout, "Hello from orchestrator!\n");
 
         uint16_t accept_port = 0;
@@ -26,13 +28,22 @@ int main(int argc, char *argv[]) {
                 return EXIT_FAILURE;
         }
 
-        if (!service_register_shutdown(orchestrator->user_dbus, orchestrator->event_loop)) {
+        if (!shutdown_service_register(orchestrator->user_dbus, orchestrator->event)) {
                 fprintf(stderr, "Failed to register shutdown service\n");
+                return EXIT_FAILURE;
+        }
+
+        r = event_loop_add_shutdown_signals(orchestrator->event);
+        if (r < 0) {
+                fprintf(stderr, "Failed to add signals to orchestrator event loop\n");
                 return EXIT_FAILURE;
         }
 
         if (orch_start(orchestrator)) {
                 return EXIT_SUCCESS;
         }
+
+        fprintf(stdout, "Orchestrator exited\n");
+
         return EXIT_FAILURE;
 }

--- a/libhirte/include/node.h
+++ b/libhirte/include/node.h
@@ -13,7 +13,7 @@ typedef struct {
         char *orch_addr;
         char *user_bus_service_name;
 
-        sd_event *event_loop;
+        sd_event *event;
 
         sd_bus *user_dbus;
         sd_bus *systemd_dbus;

--- a/libhirte/include/orchestrator.h
+++ b/libhirte/include/orchestrator.h
@@ -13,7 +13,7 @@ typedef struct {
         uint16_t accept_port;
         char *user_bus_service_name;
 
-        sd_event *event_loop;
+        sd_event *event;
         sd_event_source *peer_connection_source;
 
         sd_bus *user_dbus;

--- a/libhirte/include/service/shutdown.h
+++ b/libhirte/include/service/shutdown.h
@@ -4,4 +4,5 @@
 #include <systemd/sd-bus.h>
 
 int shutdown_event_loop(sd_event *event_loop);
-bool service_register_shutdown(sd_bus *target_bus, sd_event *event_loop);
+bool shutdown_service_register(sd_bus *target_bus, sd_event *event);
+int event_loop_add_shutdown_signals(sd_event *event);

--- a/libhirte/src/node.c
+++ b/libhirte/src/node.c
@@ -54,7 +54,7 @@ Node *node_new(const struct sockaddr_in *peer_addr, const char *bus_service_name
         Node *n = malloc0(sizeof(Node));
         n->orch_addr = steal_pointer(&orch_addr);
         n->user_bus_service_name = steal_pointer(&service_name);
-        n->event_loop = steal_pointer(&event);
+        n->event = steal_pointer(&event);
         n->user_dbus = steal_pointer(&user_dbus);
         n->systemd_dbus = steal_pointer(&systemd_dbus);
         n->peer_dbus = steal_pointer(&peer_dbus);
@@ -67,9 +67,9 @@ void node_unrefp(Node **node) {
         if (node == NULL || (*node) == NULL) {
                 return;
         }
-        if ((*node)->event_loop != NULL) {
+        if ((*node)->event != NULL) {
                 fprintf(stdout, "Freeing allocated sd-event of Node...\n");
-                sd_event_unrefp(&(*node)->event_loop);
+                sd_event_unrefp(&(*node)->event);
         }
         if ((*node)->orch_addr != NULL) {
                 fprintf(stdout, "Freeing allocated orch_addr of Node...\n");
@@ -103,7 +103,7 @@ bool node_start(Node *node) {
         }
 
         int r = 0;
-        r = sd_event_loop(node->event_loop);
+        r = sd_event_loop(node->event);
         if (r < 0) {
                 fprintf(stderr, "Starting event loop failed: %s\n", strerror(-r));
                 return false;

--- a/libhirte/src/service/shutdown.c
+++ b/libhirte/src/service/shutdown.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include <stdio.h>
 #include <systemd/sd-bus-vtable.h>
 
@@ -6,18 +7,22 @@
 #include "../../include/service/shutdown.h"
 #include "../common/memory.h"
 
-int shutdown_event_loop(sd_event *event_loop) {
-        if (event_loop == NULL) {
-                return 0;
+int shutdown_event_loop(sd_event *event) {
+        if (event == NULL) {
+                return -EINVAL;
         }
 
-        return sd_event_exit(event_loop, 0);
+        return sd_event_exit(event, 0);
 }
 
 static int method_shutdown(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
-        sd_event *event_loop = (sd_event *) userdata;
+        if (userdata == NULL) {
+                return -EINVAL;
+        }
 
-        int r = shutdown_event_loop(event_loop);
+        sd_event *event = (sd_event *) userdata;
+
+        int r = shutdown_event_loop(event);
         if (r < 0) {
                 return sd_bus_reply_method_errnof(m, -r, "Failed to shutown event loop: %m\n");
         }
@@ -29,13 +34,69 @@ static const sd_bus_vtable vtable_shutdown[] = { SD_BUS_VTABLE_START(0),
                                                  SD_BUS_METHOD("Shutdown", "", "", method_shutdown, 0),
                                                  SD_BUS_VTABLE_END };
 
-bool service_register_shutdown(sd_bus *target_bus, sd_event *event_loop) {
+bool shutdown_service_register(sd_bus *target_bus, sd_event *event) {
         _cleanup_free_ char *interface_name = assemble_interface_name("Shutdown");
         int r = sd_bus_add_object_vtable(
-                        target_bus, NULL, HIRTE_OBJECT_PATH, interface_name, vtable_shutdown, event_loop);
+                        target_bus, NULL, HIRTE_OBJECT_PATH, interface_name, vtable_shutdown, event);
         if (r < 0) {
-                fprintf(stderr, "Failed to register shutdown service: %s\n", strerror(-r));
+                fprintf(stderr, "Failed to register shutdown service: %m\n");
                 return false;
         }
         return true;
+}
+
+static int event_loop_signal_handler(
+                sd_event_source *event_source, UNUSED const struct signalfd_siginfo *si, UNUSED void *userdata) {
+        if (event_source == NULL) {
+                return -EINVAL;
+        }
+
+        sd_event *event = sd_event_source_get_event(event_source);
+        return shutdown_event_loop(event);
+}
+
+int event_loop_add_shutdown_signals(sd_event *event) {
+        sigset_t sigset;
+        int r = 0;
+
+        if (event == NULL) {
+                return -EINVAL;
+        }
+
+        // Block this thread from handling SIGTERM and SIGINT so that these
+        // signals can be handled by the event loop instead.
+        r = sigemptyset(&sigset);
+        if (r < 0) {
+                fprintf(stderr, "sigemptyset() failed: %m\n");
+                return -1;
+        }
+        r = sigaddset(&sigset, SIGTERM);
+        if (r < 0) {
+                fprintf(stderr, "sigaddset() failed: %m\n");
+                return -1;
+        }
+        r = sigaddset(&sigset, SIGINT);
+        if (r < 0) {
+                fprintf(stderr, "sigaddset() failed: %m\n");
+                return -1;
+        }
+        r = sigprocmask(SIG_BLOCK, &sigset, NULL);
+        if (r < 0) {
+                fprintf(stderr, "sigprocmask() failed: %m\n");
+                return -1;
+        }
+
+        // Add SIGTERM and SIGINT as event sources in the event loop.
+        r = sd_event_add_signal(event, NULL, SIGTERM, event_loop_signal_handler, NULL);
+        if (r < 0) {
+                fprintf(stderr, "sd_event_add_signal() failed: %m\n");
+                return -1;
+        }
+        r = sd_event_add_signal(event, NULL, SIGINT, event_loop_signal_handler, NULL);
+        if (r < 0) {
+                fprintf(stderr, "sd_event_add_signal() failed: %m\n");
+                return -1;
+        }
+
+        return 0;
 }


### PR DESCRIPTION
Signed-off-by: Steve Dunnagan <sdunnaga@redhat.com>

This PR addresses issue #67. Now if a SIGTERM signal is sent to hirte or hirte-node processes, registered handlers are invoked by their respective event loops. These handlers can initiate whatever clean-up is needed, and then exit the event loops.