### PR TITLE
Initial work on end to end dbus

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,7 +18,8 @@ Checks: >
     -readability-isolate-declaration,
     -bugprone-assignment-in-if-condition,
     -clang-analyzer-unix.Malloc,
-    -cppcoreguidelines-interfaces-global-init
+    -cppcoreguidelines-interfaces-global-init,
+    -readability-function-cognitive-complexity
 
 CheckOptions:
     - key: readability-function-cognitive-complexity.Threshold

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,7 +19,8 @@ Checks: >
     -bugprone-assignment-in-if-condition,
     -clang-analyzer-unix.Malloc,
     -cppcoreguidelines-interfaces-global-init,
-    -readability-function-cognitive-complexity
+    -readability-function-cognitive-complexity,
+    -modernize-macro-to-enum
 
 CheckOptions:
     - key: readability-function-cognitive-complexity.Threshold

--- a/doc/example.ini
+++ b/doc/example.ini
@@ -1,9 +1,20 @@
-; This is a sample configuration file.
+;===========================================================================
+; This is a sample node configuration file.
 
 [Node]
-OrchestratorIP=<ip>
-OrchestratorPort=<port>
+Name=foo
+Host=127.0.0.1
+Port=2020
 
-[Orchestrator]
-Port=<port>
-ExpectedNodes=<ip1>,<ip2>,...,<ip n>
+;===========================================================================
+; This is a sample orchestrator configuration file.
+
+[Manager]
+Port=2020
+Nodes=foo,bar
+
+[Node foo]
+Ip=1.2.3.4
+
+[Node bar]
+Ip=1.2.3.5

--- a/src/libhirte/common/protocol.h
+++ b/src/libhirte/common/protocol.h
@@ -7,11 +7,26 @@
 #define HIRTE_NODE_DBUS_NAME "org.containers.hirte.Node"
 
 #define HIRTE_OBJECT_PATH "/org/containers/hirte"
+
+/* Public objects */
 #define HIRTE_MANAGER_OBJECT_PATH HIRTE_OBJECT_PATH
-#define HIRTE_INTERNAL_MANAGER_OBJECT_PATH HIRTE_OBJECT_PATH "/internal"
 #define NODE_OBJECT_PATH_PREFIX HIRTE_OBJECT_PATH "/node"
 
+/* Public interfaces */
 #define HIRTE_INTERFACE_BASE_NAME "org.containers.hirte"
 #define MANAGER_INTERFACE HIRTE_INTERFACE_BASE_NAME ".Manager"
-#define INTERNAL_MANAGER_INTERFACE HIRTE_INTERFACE_BASE_NAME ".internal.Manager"
 #define NODE_INTERFACE HIRTE_INTERFACE_BASE_NAME ".Node"
+
+
+/* Internal objects */
+#define INTERNAL_MANAGER_OBJECT_PATH HIRTE_OBJECT_PATH "/internal"
+#define INTERNAL_NODE_OBJECT_PATH HIRTE_OBJECT_PATH "/node"
+
+/* Internal interfaces */
+#define INTERNAL_MANAGER_INTERFACE HIRTE_INTERFACE_BASE_NAME ".internal.Manager"
+#define INTERNAL_NODE_INTERFACE HIRTE_INTERFACE_BASE_NAME ".internal.Node"
+
+#define HIRTE_BUS_ERROR_OFFLINE "org.containers.hirte.Offline"
+
+#define USEC_PER_SEC 1000000
+#define HIRTE_DEFAULT_DBUS_TIMEOUT (USEC_PER_SEC * 30)

--- a/src/libhirte/common/protocol.h
+++ b/src/libhirte/common/protocol.h
@@ -29,4 +29,4 @@
 #define HIRTE_BUS_ERROR_OFFLINE "org.containers.hirte.Offline"
 
 #define USEC_PER_SEC 1000000
-#define HIRTE_DEFAULT_DBUS_TIMEOUT (USEC_PER_SEC * 30)
+#define HIRTE_DEFAULT_DBUS_TIMEOUT ((uint64_t) (USEC_PER_SEC * 30))

--- a/src/libhirte/ini/config.c
+++ b/src/libhirte/ini/config.c
@@ -5,21 +5,33 @@
 #include "ini.h"
 #include "libhirte/common/common.h"
 
-int match(const char *section, const char *check_section, const char *name, const char *check_name) {
-        if (streq(section, check_section) == 0 && streq(name, check_name) == 0) {
-                return EXIT_SUCCESS;
-        }
-        return EXIT_FAILURE;
+typedef struct {
+        char *key;
+        char *value;
+} keyValue;
+
+struct topic {
+        char *topic;
+        struct hashmap *keys_and_values;
+};
+
+static void key_value_free(void *item) {
+        keyValue *kv = item;
+        free(kv->key);
+        free(kv->value);
+}
+
+static void topic_free(void *item) {
+        topic *topic = item;
+        free(topic->topic);
+        hashmap_free(topic->keys_and_values);
 }
 
 // NOLINTNEXTLINE
 int key_value_compare_key(const void *a, const void *b, UNUSED void *udata) {
         const keyValue *kva = a;
         const keyValue *kvb = b;
-        if (kva->value == NULL || kvb->value == NULL) {
-                return streq(kva->key, kvb->key);
-        }
-        return streq(kva->key, kvb->key) && streq(kva->value, kvb->value);
+        return strcmp(kva->key, kvb->key);
 }
 
 uint64_t key_value_hash(const void *item, uint64_t seed0, uint64_t seed1) {
@@ -31,7 +43,7 @@ uint64_t key_value_hash(const void *item, uint64_t seed0, uint64_t seed1) {
 int topic_compare_topic_name(const void *a, const void *b, UNUSED void *udata) {
         const topic *ta = a;
         const topic *tb = b;
-        return streq(ta->topic, tb->topic);
+        return strcmp(ta->topic, tb->topic);
 }
 
 uint64_t topic_hash(const void *item, uint64_t seed0, uint64_t seed1) {
@@ -39,64 +51,130 @@ uint64_t topic_hash(const void *item, uint64_t seed0, uint64_t seed1) {
         return hashmap_sip(top->topic, strlen(top->topic), seed0, seed1);
 }
 
+struct topic *config_lookup_topic(config *config, const char *name) {
+        return hashmap_get(config, &(topic){ .topic = (char *) name });
+}
+
+struct topic *config_ensure_topic(config *config, const char *name) {
+        struct topic *old = config_lookup_topic(config, name);
+        if (old != NULL) {
+                return old;
+        }
+
+        char *sec = strdup(name);
+        if (sec == NULL) {
+                return NULL;
+        }
+
+        struct hashmap *hm = hashmap_new(
+                        sizeof(keyValue), 0, 0, 0, key_value_hash, key_value_compare_key, key_value_free, NULL);
+        if (hm == NULL) {
+                free(sec);
+                return NULL;
+        }
+
+        topic newtopic = { sec, hm };
+        hashmap_set(config, &newtopic);
+        if (hashmap_oom(config)) {
+                topic_free(&newtopic);
+                return NULL;
+        }
+
+        return config_lookup_topic(config, name);
+}
+
+const char *topic_lookup(topic *t, const char *key) {
+        keyValue *kv = hashmap_get(t->keys_and_values, &(keyValue){ .key = (char *) key });
+        if (kv == NULL) {
+                return NULL;
+        }
+        return kv->value;
+}
+
+bool topic_set(topic *t, const char *key, const char *value) {
+        char *key_dup = strdup(key);
+        if (key_dup == NULL) {
+                return false;
+        }
+        char *value_dup = strdup(value);
+        if (value_dup == NULL) {
+                free(key_dup);
+                return false;
+        }
+
+        keyValue kv = { key_dup, value_dup };
+        keyValue *replaced = hashmap_set(t->keys_and_values, &kv);
+        if (hashmap_oom(t->keys_and_values)) {
+                key_value_free(&kv);
+                return false;
+        }
+        if (replaced) {
+                key_value_free(replaced);
+        }
+        return true;
+}
+
+const char *config_lookup(config *config, const char *topicname, const char *key) {
+        topic *t = config_lookup_topic(config, topicname);
+        if (t == NULL) {
+                return NULL;
+        }
+        return topic_lookup(t, key);
+}
+
 /*
-This function will be used in ini_parse() for node ini file parsing.
-*/
+ * This function will be used in ini_parse() for node ini file parsing.
+ */
 static int handler(void *user, const char *section, const char *name, const char *value) {
+        config *c = (config *) user;
+
         assert(section != NULL);
         assert(name != NULL);
         assert(user != NULL);
         assert(value != NULL);
 
-        char *sec = strdup(section);
-        char *name_dup = strdup(name);
-        char *value_dup = strdup(value);
-
-        struct hashmap *topics = (struct hashmap *) user;
-        keyValue *key_value = (keyValue *) malloc(sizeof(keyValue));
-        key_value->key = name_dup;
-        key_value->value = value_dup;
-        topic *tmptopic = hashmap_get((struct hashmap *) user, &(topic){ .topic = sec });
-        if (tmptopic != NULL) {
-                hashmap_set(tmptopic->keys_and_values, key_value);
-                free(sec);
-        } else {
-                struct hashmap *hm = hashmap_new(
-                                sizeof(keyValue), 0, 0, 0, key_value_hash, key_value_compare_key, NULL, NULL);
-                hashmap_set(hm, key_value);
-                tmptopic = (topic *) malloc(sizeof(topic));
-                tmptopic->keys_and_values = hm;
-                tmptopic->topic = sec;
-                hashmap_set(topics, tmptopic);
-                free(tmptopic);
+        topic *t = config_ensure_topic(c, section);
+        if (t == NULL) {
+                return 1; /* out of memory */
         }
-        free(key_value);
-        return EXIT_SUCCESS;
+
+        if (!topic_set(t, name, value)) {
+                return 1;
+        }
+
+        return 0;
+}
+
+config *new_config(void) {
+        return hashmap_new(sizeof(topic), 0, 0, 0, topic_hash, topic_compare_topic_name, topic_free, NULL);
 }
 
 /* Get the file path
     if it can't find the or cant parse the path it will return configurationOrch
     with nulls else will return configurationOrch with all the data */
-struct hashmap *parsing_ini_file(const char *file) {
-        struct hashmap *temp = hashmap_new(
-                        sizeof(topic), 0, 0, 0, topic_hash, topic_compare_topic_name, NULL, NULL);
+config *parsing_ini_file(const char *file) {
+        config *config = new_config();
+        if (config == NULL) {
+                return NULL; /* oom */
+        }
         if (file == NULL) {
-                return temp;
+                return config;
         }
-        if (ini_parse(file, handler, temp) < 0) {
+
+        if (ini_parse(file, handler, config) < 0) {
                 printf("Can't load the file %s\n", file);
-                return temp;
+                return config;
         }
-        return temp;
+        return config;
 }
 
-void print_all_topics(struct hashmap *topics) {
-        if (topics != NULL) {
+void print_all_topics(config *config) {
+        if (config != NULL) {
                 return;
         }
         size_t iter = 0;
         void *item = NULL;
-        while (hashmap_iter(topics, &iter, &item)) {
+        while (hashmap_iter(config, &iter, &item)) {
                 topic *tp = item;
                 size_t iter_kv = 0;
                 void *item_kv = NULL;
@@ -109,20 +187,18 @@ void print_all_topics(struct hashmap *topics) {
         }
 }
 
-void free_topics_hashmap(struct hashmap **topics) {
-        size_t iter = 0;
-        void *item = NULL;
-        while (hashmap_iter(*topics, &iter, &item)) {
-                topic *tp = item;
-                size_t iter_kv = 0;
-                void *item_kv = NULL;
-                while (hashmap_iter(tp->keys_and_values, &iter_kv, &item_kv)) {
-                        keyValue *kv = (keyValue *) item_kv;
-                        free(kv->value);
-                        free(kv->key);
-                }
-                free(tp->topic);
-                hashmap_free(tp->keys_and_values);
+void free_hashmapp(struct hashmap **hmp) {
+        if (hmp && *hmp) {
+                hashmap_free(*hmp);
         }
-        hashmap_free(*topics);
+}
+
+void free_config(config *config) {
+        hashmap_free(config);
+}
+
+void free_configp(config **configp) {
+        if (configp && *configp) {
+                free_config(*configp);
+        }
 }

--- a/src/libhirte/ini/config.h
+++ b/src/libhirte/ini/config.h
@@ -2,20 +2,24 @@
 
 #include "libhirte/hashmap/hashmap.h"
 
-typedef struct {
-        char *key;
-        char *value;
-} keyValue;
-
-typedef struct {
-        char *topic;
-        struct hashmap *keys_and_values;
-} topic;
+typedef struct hashmap config;
+typedef struct topic topic;
 
 
-struct hashmap *parsing_ini_file(const char *file);
-void free_topics_hashmap(struct hashmap **topics);
+config *parsing_ini_file(const char *file);
+config *new_config(void);
+void free_config(config *config);
+void free_configp(config **configp);
 
-void print_all_topics(struct hashmap *topics);
+void print_all_topics(config *config);
+topic *config_lookup_topic(config *config, const char *name);
+topic *config_ensure_topic(config *config, const char *name);
+const char *config_lookup(config *config, const char *topicname, const char *key);
 
-#define _cleanup_hashmap_ __attribute__((__cleanup__(free_topics_hashmap)))
+const char *topic_lookup(topic *t, const char *key);
+bool topic_set(topic *t, const char *key, const char *value);
+
+void free_hashmapp(struct hashmap **hmp);
+
+#define _cleanup_hashmap_ __attribute__((__cleanup__(free_hashmap)))
+#define _cleanup_config_ __attribute__((__cleanup__(free_configp)))

--- a/src/node/node.c
+++ b/src/node/node.c
@@ -149,7 +149,8 @@ bool node_parse_config(Node *node, const char *configfile) {
         return true;
 }
 
-static int node_method_list_units(UNUSED sd_bus_message *m, UNUSED void *userdata, UNUSED sd_bus_error *ret_error) {
+static int node_method_list_units(
+                UNUSED sd_bus_message *m, UNUSED void *userdata, UNUSED sd_bus_error *ret_error) {
         return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "ListUnit is not implemented yet");
 }
 
@@ -222,12 +223,12 @@ bool node_start(Node *node) {
         }
 
         r = sd_bus_add_object_vtable(
-                                     node->peer_dbus,
-                                     NULL,
-                                     INTERNAL_NODE_OBJECT_PATH,
-                                     INTERNAL_NODE_INTERFACE,
-                                     internal_node_vtable,
-                                     node);
+                        node->peer_dbus,
+                        NULL,
+                        INTERNAL_NODE_OBJECT_PATH,
+                        INTERNAL_NODE_INTERFACE,
+                        internal_node_vtable,
+                        node);
         if (r < 0) {
                 fprintf(stderr, "Failed to add manager vtable: %s\n", strerror(-r));
                 return false;

--- a/src/node/node.c
+++ b/src/node/node.c
@@ -111,36 +111,35 @@ bool node_set_name(Node *node, const char *name) {
 }
 
 bool node_parse_config(Node *node, const char *configfile) {
-        _cleanup_hashmap_ struct hashmap *ini_hashmap = NULL;
-        struct hashmap *node_hashmap = NULL;
+        _cleanup_config_ config *config = NULL;
+        topic *topic = NULL;
         const char *name = NULL, *host = NULL, *port = NULL;
 
-        ini_hashmap = parsing_ini_file(configfile);
-        if (ini_hashmap == NULL) {
+        config = parsing_ini_file(configfile);
+        if (config == NULL) {
                 return false;
         }
 
-        node_hashmap = hashmap_get(ini_hashmap, "Node");
-
-        if (node_hashmap == NULL) {
+        topic = config_lookup_topic(config, "Node");
+        if (topic == NULL) {
                 return true;
         }
 
-        name = hashmap_get(node_hashmap, "Name");
+        name = topic_lookup(topic, "Name");
         if (name) {
                 if (!node_set_name(node, name)) {
                         return false;
                 }
         }
 
-        host = hashmap_get(node_hashmap, "Host");
+        host = topic_lookup(topic, "Host");
         if (host) {
                 if (!node_set_host(node, host)) {
                         return false;
                 }
         }
 
-        port = hashmap_get(node_hashmap, "Port");
+        port = topic_lookup(topic, "Port");
         if (port) {
                 if (!node_set_port(node, port)) {
                         return false;

--- a/src/orch/managednode.c
+++ b/src/orch/managednode.c
@@ -10,9 +10,8 @@ static const sd_bus_vtable internal_manager_orchestrator_vtable[] = {
 
 static const sd_bus_vtable node_vtable[] = { SD_BUS_VTABLE_START(0), SD_BUS_VTABLE_END };
 
-ManagedNode *managed_node_new(Manager *manager) {
+ManagedNode *managed_node_new(Manager *manager, const char *name) {
         _cleanup_managed_node_ ManagedNode *node = malloc0(sizeof(ManagedNode));
-
         if (node == NULL) {
                 return NULL;
         }
@@ -20,45 +19,20 @@ ManagedNode *managed_node_new(Manager *manager) {
         node->manager = manager;
         LIST_INIT(nodes, node);
 
+        if (name) {
+                node->name = strdup(name);
+                if (node->name == NULL) {
+                        return NULL;
+                }
+
+                /* TODO: Should escape the name if needed */
+                int r = asprintf(&node->object_path, "%s/%s", NODE_OBJECT_PATH_PREFIX, name);
+                if (r < 0) {
+                        return NULL;
+                }
+        }
+
         return steal_pointer(&node);
-}
-
-bool managed_node_set_agent_bus(ManagedNode *node, sd_bus *bus) {
-
-        if (node->bus != NULL) {
-                fprintf(stderr, "Error: Trying to add two agents for a node\n");
-                return false;
-        }
-
-        node->bus = sd_bus_ref(bus);
-        int r = sd_bus_add_object_vtable(
-                        bus,
-                        NULL,
-                        HIRTE_INTERNAL_MANAGER_OBJECT_PATH,
-                        INTERNAL_MANAGER_INTERFACE,
-                        internal_manager_orchestrator_vtable,
-                        node);
-        if (r < 0) {
-                fprintf(stderr, "Failed to add peer bus vtable: %s\n", strerror(-r));
-                return false;
-        }
-
-        r = sd_bus_match_signal_async(
-                        bus,
-                        NULL,
-                        "org.freedesktop.DBus.Local",
-                        "/org/freedesktop/DBus/Local",
-                        "org.freedesktop.DBus.Local",
-                        "Disconnected",
-                        node_disconnected,
-                        NULL,
-                        node);
-        if (r < 0) {
-                fprintf(stderr, "Failed to request match for Disconnected message: %s\n", strerror(-r));
-                return false;
-        }
-
-        return true;
 }
 
 ManagedNode *managed_node_ref(ManagedNode *node) {
@@ -71,12 +45,12 @@ void managed_node_unref(ManagedNode *node) {
         if (node->ref_count != 0) {
                 return;
         }
-        if (node->bus_slot) {
-                sd_bus_slot_unref(node->bus_slot);
+        if (node->export_slot) {
+                sd_bus_slot_unref(node->export_slot);
         }
-        if (node->bus) {
-                sd_bus_unref(node->bus);
-        }
+
+        managed_node_unset_agent_bus(node);
+
         free(node->name);
         free(node->object_path);
         free(node);
@@ -89,11 +63,104 @@ void managed_node_unrefp(ManagedNode **nodep) {
         }
 }
 
+bool managed_node_export(ManagedNode *node) {
+        Manager *manager = node->manager;
+
+        assert(node->name != NULL);
+
+        int r = sd_bus_add_object_vtable(
+                        manager->user_dbus,
+                        &node->export_slot,
+                        node->object_path,
+                        NODE_INTERFACE,
+                        node_vtable,
+                        node);
+        if (r < 0) {
+                fprintf(stderr, "Failed to add node vtable: %s\n", strerror(-r));
+                return false;
+        }
+
+        return true;
+}
+
+bool managed_node_has_agent(ManagedNode *node) {
+        return node->agent_bus != NULL;
+}
+
+bool managed_node_set_agent_bus(ManagedNode *node, sd_bus *bus) {
+        int r = 0;
+
+        if (node->agent_bus != NULL) {
+                fprintf(stderr, "Error: Trying to add two agents for a node\n");
+                return false;
+        }
+
+        node->agent_bus = sd_bus_ref(bus);
+        if (node->name == NULL) {
+                // We only connect to this on the unnamed nodes so register
+                // can be called. We can't reconnect it during migration.
+                r = sd_bus_add_object_vtable(
+                                bus,
+                                &node->internal_manager_slot,
+                                HIRTE_INTERNAL_MANAGER_OBJECT_PATH,
+                                INTERNAL_MANAGER_INTERFACE,
+                                internal_manager_orchestrator_vtable,
+                                node);
+                if (r < 0) {
+                        managed_node_unset_agent_bus(node);
+                        fprintf(stderr, "Failed to add peer bus vtable: %s\n", strerror(-r));
+                        return false;
+                }
+        }
+
+        r = sd_bus_match_signal_async(
+                        bus,
+                        &node->disconnect_slot,
+                        "org.freedesktop.DBus.Local",
+                        "/org/freedesktop/DBus/Local",
+                        "org.freedesktop.DBus.Local",
+                        "Disconnected",
+                        node_disconnected,
+                        NULL,
+                        node);
+        if (r < 0) {
+                managed_node_unset_agent_bus(node);
+                fprintf(stderr, "Failed to request match for Disconnected message: %s\n", strerror(-r));
+                return false;
+        }
+
+        return true;
+}
+
+void managed_node_unset_agent_bus(ManagedNode *node) {
+        if (node->disconnect_slot) {
+                sd_bus_slot_unref(node->disconnect_slot);
+                node->disconnect_slot = NULL;
+        }
+
+        if (node->internal_manager_slot) {
+                sd_bus_slot_unref(node->internal_manager_slot);
+                node->internal_manager_slot = NULL;
+        }
+
+        if (node->agent_bus) {
+                sd_bus_unref(node->agent_bus);
+                node->agent_bus = NULL;
+        }
+}
+
+
+/* org.containers.hirte.internal.Manager.Register(in s name)) */
 static int managed_node_method_register(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
         ManagedNode *node = userdata;
         Manager *manager = node->manager;
         char *name = NULL;
         _cleanup_free_ char *description = NULL;
+
+        /* Once we're not anonymous, don't allow register calls */
+        if (node->name != NULL) {
+                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_ADDRESS_IN_USE, "Can't register twice");
+        }
 
         /* Read the parameters */
         int r = sd_bus_message_read(m, "s", &name);
@@ -102,41 +169,31 @@ static int managed_node_method_register(sd_bus_message *m, void *userdata, UNUSE
                 return r;
         }
 
-        if (node->name != NULL) {
-                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_ADDRESS_IN_USE, "Can't register twice");
+        ManagedNode *named_node = manager_find_node(manager, name);
+        if (named_node == NULL) {
+                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_SERVICE_UNKNOWN, "Unexpected node name");
         }
 
-        ManagedNode *existing = manager_find_node(manager, name);
-        if (existing != NULL) {
+        if (managed_node_has_agent(named_node)) {
                 return sd_bus_reply_method_errorf(
-                                m, SD_BUS_ERROR_ADDRESS_IN_USE, "Node name already registered");
-        }
-
-        node->name = strdup(name);
-        if (node->name == NULL) {
-                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_NO_MEMORY, "No memory");
-        }
-
-        r = asprintf(&node->object_path, "%s/%s", NODE_OBJECT_PATH_PREFIX, name);
-        if (r < 0) {
-                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_NO_MEMORY, "No memory");
+                                m, SD_BUS_ERROR_ADDRESS_IN_USE, "The node is already connected");
         }
 
         r = asprintf(&description, "node-%s", name);
-        if (r < 0) {
-                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_NO_MEMORY, "No memory");
+        if (r >= 0) {
+                (void) sd_bus_set_description(node->agent_bus, description);
         }
 
-        (void) sd_bus_set_description(node->bus, description);
-
-        r = sd_bus_add_object_vtable(
-                        manager->user_dbus, &node->bus_slot, node->object_path, NODE_INTERFACE, node_vtable, node);
-        if (r < 0) {
-                fprintf(stderr, "Failed to add peer bus vtable: %s\n", strerror(-r));
-                return EXIT_FAILURE;
+        /* Migrate the agent connection to the named node */
+        _cleanup_sd_bus_ sd_bus *agent_bus = sd_bus_ref(node->agent_bus);
+        if (!managed_node_set_agent_bus(named_node, agent_bus)) {
+                return sd_bus_reply_method_errorf(
+                                m, SD_BUS_ERROR_FAILED, "Internal error: Couldn't set agent bus");
         }
 
-        printf("Registered managed node from fd %d as '%s'\n", sd_bus_get_fd(node->bus), name);
+        managed_node_unset_agent_bus(node);
+
+        printf("Registered managed node from fd %d as '%s'\n", sd_bus_get_fd(agent_bus), name);
 
         return sd_bus_reply_method_return(m, "");
 }
@@ -148,20 +205,15 @@ static int node_disconnected(UNUSED sd_bus_message *message, void *userdata, UNU
         if (node->name) {
                 printf("Node '%s' disconnected\n", node->name);
         } else {
-                printf("Unregistered node disconnected\n");
+                printf("Anonymous node disconnected\n");
         }
 
-        if (node->bus_slot) {
-                sd_bus_slot_unref(node->bus_slot);
-                node->bus_slot = NULL;
-        }
+        managed_node_unset_agent_bus(node);
 
-        if (node->bus) {
-                sd_bus_close_unref(node->bus);
-                node->bus = NULL;
+        /* Remove anoymous nodes when they disconnect */
+        if (node->name == NULL) {
+                manager_remove_node(manager, node);
         }
-
-        manager_remove_node(manager, node);
 
         return 0;
 }

--- a/src/orch/managednode.c
+++ b/src/orch/managednode.c
@@ -23,6 +23,7 @@ ManagedNode *managed_node_new(Manager *manager, const char *name) {
                 return NULL;
         }
 
+        node->ref_count = 1;
         node->manager = manager;
         LIST_INIT(nodes, node);
 

--- a/src/orch/managednode.h
+++ b/src/orch/managednode.h
@@ -9,21 +9,28 @@ struct ManagedNode {
 
         Manager *manager; /* weak ref */
 
-        sd_bus *bus;
-        sd_bus_slot *bus_slot;
+        /* public bus api */
+        sd_bus_slot *export_slot;
+
+        /* internal bus api */
+        sd_bus *agent_bus;
+        sd_bus_slot *internal_manager_slot;
+        sd_bus_slot *disconnect_slot;
 
         LIST_FIELDS(ManagedNode, nodes);
 
-        char *name;
+        char *name; /* NULL for not yet unregistred nodes */
         char *object_path;
 };
 
-
-ManagedNode *managed_node_new(Manager *manager);
+ManagedNode *managed_node_new(Manager *manager, const char *name);
 ManagedNode *managed_node_ref(ManagedNode *node);
 void managed_node_unref(ManagedNode *node);
 void managed_node_unrefp(ManagedNode **nodep);
 
+bool managed_node_export(ManagedNode *node);
+bool managed_node_has_agent(ManagedNode *node);
 bool managed_node_set_agent_bus(ManagedNode *node, sd_bus *bus);
+void managed_node_unset_agent_bus(ManagedNode *node);
 
 #define _cleanup_managed_node_ _cleanup_(managed_node_unrefp)

--- a/src/orch/managednode.h
+++ b/src/orch/managednode.h
@@ -4,6 +4,24 @@
 
 #include "types.h"
 
+struct ManagedRequest {
+        int ref_count;
+        ManagedNode *node;
+
+        sd_bus_message *request_message;
+
+        sd_bus_slot *slot;
+
+        sd_bus_message *message;
+
+        LIST_FIELDS(ManagedRequest, outstanding_requests);
+};
+
+ManagedRequest *managed_request_ref(ManagedRequest *req);
+void managed_request_unref(ManagedRequest *req);
+void managed_request_unrefp(ManagedRequest **req);
+
+
 struct ManagedNode {
         int ref_count;
 
@@ -21,6 +39,8 @@ struct ManagedNode {
 
         char *name; /* NULL for not yet unregistred nodes */
         char *object_path;
+
+        LIST_HEAD(ManagedRequest, outstanding_requests);
 };
 
 ManagedNode *managed_node_new(Manager *manager, const char *name);
@@ -34,3 +54,4 @@ bool managed_node_set_agent_bus(ManagedNode *node, sd_bus *bus);
 void managed_node_unset_agent_bus(ManagedNode *node);
 
 #define _cleanup_managed_node_ _cleanup_(managed_node_unrefp)
+#define _cleanup_managed_request_ _cleanup_(managed_request_unrefp)

--- a/src/orch/managednode.h
+++ b/src/orch/managednode.h
@@ -19,9 +19,11 @@ struct ManagedNode {
 };
 
 
-ManagedNode *managed_node_new(Manager *manager, sd_bus *bus);
+ManagedNode *managed_node_new(Manager *manager);
 ManagedNode *managed_node_ref(ManagedNode *node);
 void managed_node_unref(ManagedNode *node);
 void managed_node_unrefp(ManagedNode **nodep);
+
+bool managed_node_set_agent_bus(ManagedNode *node, sd_bus *bus);
 
 #define _cleanup_managed_node_ _cleanup_(managed_node_unrefp)

--- a/src/orch/manager.c
+++ b/src/orch/manager.c
@@ -103,26 +103,31 @@ bool manager_set_port(Manager *manager, const char *port_s) {
 }
 
 bool manager_parse_config(Manager *manager, const char *configfile) {
-        _cleanup_hashmap_ struct hashmap *ini_hashmap = NULL;
-        struct hashmap *manager_hashmap = NULL;
+        _cleanup_config_ config *config = NULL;
+        topic *topic = NULL;
         const char *port = NULL;
 
-        ini_hashmap = parsing_ini_file(configfile);
-        if (ini_hashmap == NULL) {
+        config = parsing_ini_file(configfile);
+        if (config == NULL) {
                 return false;
         }
 
-        manager_hashmap = hashmap_get(ini_hashmap, "Manager");
-        if (manager_hashmap == NULL) {
+        print_all_topics(config);
+
+        topic = config_lookup_topic(config, "Manager");
+        if (topic == NULL) {
                 return true;
         }
 
-        port = hashmap_get(manager_hashmap, "Port");
+        port = topic_lookup(topic, "Port");
+        printf("Port: %s\n", port);
         if (port) {
                 if (!manager_set_port(manager, port)) {
                         return false;
                 }
         }
+
+        /* TODO: Handle per-node-name option section */
 
         return true;
 }

--- a/src/orch/manager.c
+++ b/src/orch/manager.c
@@ -182,7 +182,7 @@ bool manager_parse_config(Manager *manager, const char *configfile) {
 static int manager_accept_node_connection(
                 UNUSED sd_event_source *source, int fd, UNUSED uint32_t revents, void *userdata) {
         Manager *manager = userdata;
-        _cleanup_managed_node_ ManagedNode *node = NULL;
+        ManagedNode *node = NULL;
         _cleanup_fd_ int nfd = accept_tcp_connection_request(fd);
 
         if (nfd < 0) {

--- a/src/orch/manager.c
+++ b/src/orch/manager.c
@@ -242,7 +242,7 @@ static bool manager_setup_node_connection_handler(Manager *manager) {
 
 /* This is a test method for now, it just returns what you passed */
 static int manager_method_ping(sd_bus_message *m, UNUSED void *userdata, UNUSED sd_bus_error *ret_error) {
-        const char *arg;
+        const char *arg = NULL;
 
         int r = sd_bus_message_read(m, "s", &arg);
         if (r < 0) {
@@ -252,20 +252,17 @@ static int manager_method_ping(sd_bus_message *m, UNUSED void *userdata, UNUSED 
         return sd_bus_reply_method_return(m, "s", arg);
 }
 
-static const sd_bus_vtable manager_vtable[] = {
-        SD_BUS_VTABLE_START(0),
-        SD_BUS_METHOD("Ping", "s", "s", manager_method_ping, 0),
-        SD_BUS_VTABLE_END
-};
+static const sd_bus_vtable manager_vtable[] = { SD_BUS_VTABLE_START(0),
+                                                SD_BUS_METHOD("Ping", "s", "s", manager_method_ping, 0),
+                                                SD_BUS_VTABLE_END };
 
-static int debug_messages_handler (sd_bus_message *m, UNUSED void *userdata, UNUSED sd_bus_error *ret_error)
-{
+static int debug_messages_handler(sd_bus_message *m, UNUSED void *userdata, UNUSED sd_bus_error *ret_error) {
         fprintf(stderr,
                 "Incomming public message: path: %s, iface: %s, member: %s, signature: '%s'\n",
-               sd_bus_message_get_path (m),
-               sd_bus_message_get_interface (m),
-               sd_bus_message_get_member (m),
-               sd_bus_message_get_signature (m, true));
+                sd_bus_message_get_path(m),
+                sd_bus_message_get_interface(m),
+                sd_bus_message_get_member(m),
+                sd_bus_message_get_signature(m, true));
         return 0;
 }
 
@@ -297,16 +294,17 @@ bool manager_start(Manager *manager) {
                 return false;
         }
 
-        if (DEBUG_MESSAGES)
+        if (DEBUG_MESSAGES) {
                 sd_bus_add_filter(manager->user_dbus, NULL, debug_messages_handler, NULL);
+        }
 
         r = sd_bus_add_object_vtable(
-                                     manager->user_dbus,
-                                     &manager->manager_slot,
-                                     HIRTE_MANAGER_OBJECT_PATH,
-                                     MANAGER_INTERFACE,
-                                     manager_vtable,
-                                     manager);
+                        manager->user_dbus,
+                        &manager->manager_slot,
+                        HIRTE_MANAGER_OBJECT_PATH,
+                        MANAGER_INTERFACE,
+                        manager_vtable,
+                        manager);
         if (r < 0) {
                 fprintf(stderr, "Failed to add node vtable: %s\n", strerror(-r));
                 return false;

--- a/src/orch/manager.h
+++ b/src/orch/manager.h
@@ -17,6 +17,7 @@ struct Manager {
         sd_event_source *node_connection_source;
 
         sd_bus *user_dbus;
+        sd_bus_slot *manager_slot;
 
         LIST_HEAD(ManagedNode, nodes);
         LIST_HEAD(ManagedNode, anonymous_nodes);

--- a/src/orch/manager.h
+++ b/src/orch/manager.h
@@ -19,6 +19,7 @@ struct Manager {
         sd_bus *user_dbus;
 
         LIST_HEAD(ManagedNode, nodes);
+        LIST_HEAD(ManagedNode, anonymous_nodes);
 };
 
 Manager *manager_new(void);
@@ -34,5 +35,7 @@ bool manager_stop(Manager *manager);
 
 ManagedNode *manager_find_node(Manager *manager, const char *name);
 void manager_remove_node(Manager *manager, ManagedNode *node);
+
+ManagedNode *manager_add_node(Manager *manager, const char *name);
 
 #define _cleanup_manager_ _cleanup_(manager_unrefp)

--- a/src/orch/types.h
+++ b/src/orch/types.h
@@ -2,3 +2,4 @@
 
 typedef struct Manager Manager;
 typedef struct ManagedNode ManagedNode;
+typedef struct ManagedRequest ManagedRequest;


### PR DESCRIPTION
This wires up:

Predefined node names in the configuration. This means you need some configuration to test things. For easy testing use the example config:

```
$ src/orch/hirte -c ../doc/example.ini
$ src/node/hirte-node -c ../doc/example.ini
```

The manager dbus API with a a simple test method. Test it like so:
```
$ gdbus call --session --dest org.containers.hirte --object-path /org/containers/hirte --method org.containers.hirte.Manager.Ping "foo"
```

The manager node operation "ListUnits" is wired up all the way into the node agent. However, that currently then returns a "Not implemented yet" error which is sent back to the caller. Try with:

```
$ gdbus call --session --dest org.containers.hirte --object-^Cth /org/containers/hirte/node/foo --method org.containers.hirte.Node.ListUnits 
```
