### PR TITLE
Add implementation of manager-wide ListUnits

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,11 @@ project(
 # Enable GNU extensions.
 add_global_arguments('-D_GNU_SOURCE', language : 'c')
 
+test_cflags = [ '-Wno-cast-function-type' ]
+
+cc = meson.get_compiler('c')
+common_cflags = cc.get_supported_arguments(test_cflags)
+
 # Link with systemd shared library.
 systemd_dep = dependency('libsystemd')
 

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -233,7 +233,7 @@ static int list_units_callback(sd_bus_message *m, void *userdata, UNUSED sd_bus_
                 return sd_bus_reply_method_error(req->request_message, sd_bus_message_get_error(m));
         }
 
-        sd_bus_message *reply = NULL;
+        _cleanup_sd_bus_message_ sd_bus_message *reply = NULL;
 
         int r = sd_bus_message_new_method_return(req->request_message, &reply);
         if (r < 0) {

--- a/src/agent/meson.build
+++ b/src/agent/meson.build
@@ -14,6 +14,7 @@ executable(
   link_with: [
     hirte_lib,
   ],
+  c_args: common_cflags,
   include_directories: include_directories('..'),
   install: true
 )

--- a/src/client/meson.build
+++ b/src/client/meson.build
@@ -13,5 +13,6 @@ executable(
   link_with: [
     hirte_lib,
   ],
+  c_args: common_cflags,
   install: true
 )

--- a/src/libhirte/common/common.h
+++ b/src/libhirte/common/common.h
@@ -38,6 +38,8 @@ static inline void freep(void *p) {
         free(*(void **) p);
 }
 
+typedef void (*free_func_t)(void *ptr);
+
 #define malloc0(n) (calloc(1, (n) ?: 1))
 
 static inline void *malloc0_array(size_t base_size, size_t element_size, size_t n_elements) {

--- a/src/libhirte/common/common.h
+++ b/src/libhirte/common/common.h
@@ -40,6 +40,22 @@ static inline void freep(void *p) {
 
 #define malloc0(n) (calloc(1, (n) ?: 1))
 
+static inline void *malloc0_array(size_t base_size, size_t element_size, size_t n_elements) {
+        /* Check for overflow of multiplication */
+        if (element_size > 0 && n_elements > SIZE_MAX / element_size) {
+                return NULL;
+        }
+
+        /* Check for overflow of addition */
+        size_t array_size = element_size * n_elements;
+        size_t total_size = base_size + array_size;
+        if (total_size < array_size) {
+                return NULL;
+        }
+
+        return malloc0(total_size);
+}
+
 #define _cleanup_(x) __attribute__((__cleanup__(x)))
 #define _cleanup_free_ _cleanup_(freep)
 #define _cleanup_fd_ _cleanup_(closep)

--- a/src/manager/manager.h
+++ b/src/manager/manager.h
@@ -19,6 +19,7 @@ struct Manager {
         sd_bus *user_dbus;
         sd_bus_slot *manager_slot;
 
+        int n_nodes;
         LIST_HEAD(Node, nodes);
         LIST_HEAD(Node, anonymous_nodes);
 };

--- a/src/manager/meson.build
+++ b/src/manager/meson.build
@@ -18,5 +18,6 @@ executable(
     hirte_lib,
   ],
   install: true,
+  c_args: common_cflags,
   include_directories: include_directories('..')
 )


### PR DESCRIPTION
This calls ListUnits on each online node and collects the responses, adding the name first in the struct.

The free_func_t type requires us to add -Wno-cast-function-type to cflags, because we need to be able to cast real destroy functions to the generic one.

Signed-off-by: Alexander Larsson <alexl@redhat.com>