### PR TITLE
Adding hirte integration test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,79 @@
+name: Integration Testing  
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: cs9 x86_64 e2e 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y install podman 
+
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          # Use githash of a tested commit instead of merge commit
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: build hirte tests containers
+        run: |
+          podman run --rm --name hirte-builder \
+          -v  ${PWD}:/hirte:Z -it quay.io/yarboa/hirte-builder:1.0.0 \
+          /bin/bash -c "rm -rf builddir; meson setup builddir; \
+          meson install -C builddir --destdir bin"
+          podman build -f tests/Containerfile -t hirte-image .
+
+      - name: run hirte containers
+        run: |
+          podman run -d --net podman --rm -p 2020:2020 --name hirte-mgr \
+          $(podman images *hirte-image --format {{.ID}})
+          podman run -d --net podman --rm --name hirte-agent-foo \
+          $(podman images *hirte-image --format {{.ID}})
+          podman run -d --net podman --rm --name hirte-agent-bar \
+          $(podman images *hirte-image --format {{.ID}})
+          PODMAN_NET=$(hostname -I | awk '{print $1}')
+          echo "PODMAN_NET=$PODMAN_NET" >> $GITHUB_ENV
+
+      - name: run hirte orchestrator
+        run: |
+          podman exec -t  hirte-mgr \
+          su - test-user -c  "(/usr/local/bin/hirte -c /hirte/example-hirte.ini > mgr.log 2>&1 &)"
+
+      - name: run hirte agent-bar
+        run: |
+          # Change node name in config file
+          podman exec -it hirte-agent-bar \
+          sed -i "s/\(Name=\)\(.*\)/\1bar/" /hirte/example-hirte-agent.ini
+          # Change manager address in config file
+          podman exec -it hirte-agent-bar \
+          sed -i "s/\(Host=\)\(.*\)/\1${{ env.PODMAN_NET }}/" /hirte/example-hirte-agent.ini
+          podman exec -t hirte-agent-bar \
+          su - test-user -c "(/usr/local/bin/hirte-agent -c \
+          /hirte/example-hirte-agent.ini > bar.log 2>&1 &)"
+          podman exec -it hirte-agent-bar /usr/bin/pkill --signal TERM hirte-agent
+          podman exec -w /home/test-user -u test-user -it hirte-agent-bar \
+          grep "Registered.* as 'bar'" bar.log
+
+      - name: run hirte agent-foo
+        run: |
+          # Change node name in config file
+          podman exec -it hirte-agent-foo \
+          sed -i "s/\(Name=\)\(.*\)/\1foo/" /hirte/example-hirte-agent.ini
+          # Change manager address in config file
+          podman exec -it hirte-agent-foo \
+          sed -i "s/\(Host=\)\(.*\)/\1${{ env.PODMAN_NET }}/" /hirte/example-hirte-agent.ini
+          podman exec -t hirte-agent-foo \
+          su - test-user -c  "(/usr/local/bin/hirte-agent -c \
+          /hirte/example-hirte-agent.ini > foo.log 2>&1 &)"
+          podman exec -it hirte-agent-foo /usr/bin/pkill --signal TERM hirte-agent
+          podman exec -w /home/test-user -u test-user -it hirte-agent-foo \
+          grep "Registered.* as 'foo'" foo.log
+

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,7 +26,8 @@ jobs:
       - name: build hirte tests containers
         run: |
           podman run --rm --name hirte-builder \
-          -v  ${PWD}:/hirte:Z -it quay.io/yarboa/hirte-builder:1.0.0 \
+          -v  ${PWD}:/hirte:Z -it \
+          registry.gitlab.com/centos/automotive/sample-images/hirte/hirte-builder:1.0.0 \
           /bin/bash -c "rm -rf builddir; meson setup builddir; \
           meson install -C builddir --destdir bin"
           podman build -f tests/Containerfile -t hirte-image .

--- a/doc/test/hirte_e2e.md
+++ b/doc/test/hirte_e2e.md
@@ -11,9 +11,14 @@ Test directory contains two container files
 - Containerfile-build
 - Containerfile
 
-Containerfile-build published in quay
-quay.io/yarboa/hirte-builder
+Containerfile-build published in AutoSD registry
+registry.gitlab.com/centos/automotive/sample-images.
 It is used for hirte binary build on each PR,
 
 Containerfile create hirte-images contain systemd init to simulate
 systemd modules which are part of hirte solution
+
+Base workflows
+
+- Create and run simulated containers with systemd
+- Check Nodes registration complete

--- a/doc/test/hirte_e2e.md
+++ b/doc/test/hirte_e2e.md
@@ -2,23 +2,24 @@
 
 ## Environment Setup
 
-E2E tests rely on containers as seprate compute entities,
-Use of containers enble to simulaute hirte functional behaviour
-on single compute.
+E2E tests rely on containers as separate compute entities,
+containers simulate hirte functional behaviour
+on a single runner.
 
 Test directory contains two container files
 
 - Containerfile-build
 - Containerfile
 
-Containerfile-build published in AutoSD registry
-registry.gitlab.com/centos/automotive/sample-images.
-It is used for hirte binary build on each PR,
+Containerfile-build output image is published to
+[AutoSD registry](registry.gitlab.com/centos/automotive/sample-images).
+Usage: Container hirte base image (contains centosstream9 base image,
+systemd and devel packages), build hirte binaries.
 
-Containerfile create hirte-images contain systemd init to simulate
-systemd modules which are part of hirte solution
+Containerfile output image, hirte-images, layered above hirte-base image installed
+with hirte compiled products and configurations for e2e testing.
 
 Base workflows
 
 - Create and run simulated containers with systemd
-- Check Nodes registration complete
+- Check hirte-agents registration complete

--- a/doc/test/hirte_e2e.md
+++ b/doc/test/hirte_e2e.md
@@ -1,0 +1,19 @@
+# Hirte testing e2e
+
+## Environment Setup
+
+E2E tests rely on containers as seprate compute entities,
+Use of containers enble to simulaute hirte functional behaviour
+on single compute.
+
+Test directory contains two container files
+
+- Containerfile-build
+- Containerfile
+
+Containerfile-build published in quay
+quay.io/yarboa/hirte-builder
+It is used for hirte binary build on each PR,
+
+Containerfile create hirte-images contain systemd init to simulate
+systemd modules which are part of hirte solution

--- a/tests/Containerfile
+++ b/tests/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/yarboa/hirte-builder:1.0.1
+FROM registry.gitlab.com/centos/automotive/sample-images/hirte/hirte-builder:1.0.0
 COPY ./builddir/bin/usr/local/bin/* /usr/local/bin
 
 CMD mkdir -p /usr/local/share/dbus-1/interfaces/

--- a/tests/Containerfile
+++ b/tests/Containerfile
@@ -1,0 +1,12 @@
+FROM quay.io/yarboa/hirte-builder:1.0.1
+COPY ./builddir/bin/usr/local/bin/* /usr/local/bin
+
+CMD mkdir -p /usr/local/share/dbus-1/interfaces/
+COPY ./builddir/bin/usr/local/share/dbus-1/interfaces/* \
+     /usr/local/share/dbus-1/interfaces/
+COPY ./doc/example-hirte*.ini /hirte/
+
+CMD [ "/sbin/init" ]
+
+WORKDIR /hirte
+

--- a/tests/Containerfile-build
+++ b/tests/Containerfile-build
@@ -1,0 +1,12 @@
+FROM quay.io/centos/centos:stream9
+
+ARG USERNAME=test-user
+
+RUN dnf install -y dnf-plugin-config-manager
+RUN dnf config-manager -y --set-enabled crb && \
+    dnf install -y clang-tools-extra gcc make gtk3 \
+    meson systemd-devel systemd; dnf -y clean all
+
+RUN useradd -m $USERNAME
+
+WORKDIR /hirte


### PR DESCRIPTION
Resolve #118 
Adding hirte integration test
ubuntu support podman v3.44

hirte running as container with systemd installed
hirte containers should run as non root

Adding tests directory
Container files will be hosted here
Later on adding the test itself
run nodes ans orch in background

Currently testing functionality of node registration
Updated with latest changes
