### PR TITLE
installing the XML files of the public API

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,7 @@
+install_data(
+    'org.containers.hirte.Job.xml',
+    'org.containers.hirte.Manager.xml',
+    'org.containers.hirte.Monitor.xml',
+    'org.containers.hirte.Node.xml',
+    install_dir: get_option('datadir') / 'dbus-1' / 'interfaces',
+)

--- a/meson.build
+++ b/meson.build
@@ -29,3 +29,6 @@ subdir('src/libhirte')
 subdir('src/manager')
 subdir('src/agent')
 subdir('src/client')
+
+# Subdirectory for the API description
+subdir('data')


### PR DESCRIPTION
This PR adds the meson command for installing the public API description to `/usr/share/dbus-1/interfaces`. 