### PR TITLE
Improve on the help messages shown to the user

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -300,7 +300,9 @@ int client_call_manager(Client *client) {
                 return r;
         }
 
-        if (streq(client->op, "list-units")) {
+        if (streq(client->op, "help")) {
+                r = print_client_usage("hirte");
+        } else if (streq(client->op, "list-units")) {
                 if (client->opargc == 0) {
                         r = method_list_units_on_all(client);
                 } else {
@@ -329,4 +331,23 @@ int client_call_manager(Client *client) {
         }
 
         return r;
+}
+
+int print_client_usage(char *argv) {
+        printf("hirtectl is a convenience CLI tool to interact with hirte\n");
+        printf("Usage: %s COMMAND\n\n", argv);
+        printf("Available command:\n");
+        printf("  - help: shows this help message\n");
+        printf("    usage: help\n");
+        printf("  - list-units: returns the list of systemd service running on a specific not or on all the nodes\n");
+        printf("    usage: list-units [nodename]\n");
+        printf("  - start: starts a specific systemd service (or timer, or slice) on a specific node\n");
+        printf("    usage: start nodename unitname\n");
+        printf("  - stop: stop a specific systemd service (or timer, or slice) on a specific node\n");
+        printf("    usage: stop nodename unitname\n");
+        printf("  - reload: reloads a specific systemd service (or timer, or slice) on a specific node\n");
+        printf("    usage: reload nodename unitname\n");
+        printf("  - restart: restarts a specific systemd service (or timer, or slice) on a specific node\n");
+        printf("    usage: restart nodename unitname\n");
+        return 0;
 }

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -328,6 +328,8 @@ int client_call_manager(Client *client) {
                         return -EINVAL;
                 }
                 r = method_lifecycle_action_on(client, client->opargv[0], client->opargv[1], "ReloadUnit");
+        } else {
+                return -EINVAL;
         }
 
         return r;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -40,6 +40,7 @@ UnitList *unit_list_ref(UnitList *unit_list);
 void unit_list_unref(UnitList *unit_list);
 
 int client_call_manager(Client *client);
+int print_client_usage(char *argv);
 
 DEFINE_CLEANUP_FUNC(Client, client_unref)
 #define _cleanup_client_ _cleanup_(client_unrefp)

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -18,7 +18,7 @@ static int opargc;
 static bool no_action = false;
 
 static void usage(char *argv[]) {
-        printf("Usage: %s COMMAND ... \n", argv[0]);
+        print_client_usage(argv[0]);
 }
 
 static int get_opts(int argc, char *argv[]) {


### PR DESCRIPTION
This commit does a few things:
- We move the usage doc from main.c into a function in client.c
- This allows us to call that function from both main.c and client.c
- This allows us to print the same "usage" information when doing
  `hirtectl --help` and `hirtectl help`.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>