### PR TITLE
Allow specifying when building what bus to expose the API on

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project(
   license: 'GPL-2.0-or-later',
   default_options: [
     'c_std=gnu17',     # Adds "-std=gnu17".  Includes GNU 17 extensions.
-    'warning_level=2', # Adds "-Wextra".  Enables additional warnings. 
+    'warning_level=2', # Adds "-Wextra".  Enables additional warnings.
     'debug=true',      # Adds "-g".  Object files include debugging symbols.
     'werror=true'      # Adds "-Werror".  Treat warnings as errors.
   ]

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,11 @@ common_cflags = cc.get_supported_arguments(test_cflags)
 # Link with systemd shared library.
 systemd_dep = dependency('libsystemd')
 
+api_bus = get_option('api_bus')
+if api_bus == 'user'
+   common_cflags += '-DUSE_USER_API_BUS'
+endif
+
 # Subdirectory for the shared library.
 subdir('src/libhirte')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('api_bus', type: 'combo', choices: ['user', 'system'], value: 'user')

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -918,7 +918,11 @@ bool agent_start(Agent *agent) {
                 return false;
         }
 
+#ifdef USE_USER_API_BUS
         agent->api_bus = user_bus_open(agent->event);
+#else
+        agent->api_bus = system_bus_open(agent->event);
+#endif
         if (agent->api_bus == NULL) {
                 hirte_log_error("Failed to open user dbus");
                 return false;

--- a/src/agent/agent.h
+++ b/src/agent/agent.h
@@ -43,11 +43,11 @@ struct Agent {
         int port;
 
         char *orch_addr;
-        char *user_bus_service_name;
+        char *api_bus_service_name;
 
         sd_event *event;
 
-        sd_bus *user_dbus;
+        sd_bus *api_bus;
         sd_bus *systemd_dbus;
         sd_bus *peer_dbus;
 

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -22,7 +22,7 @@ int list_units_on(const char *name, Client *client) {
         }
 
         r = sd_bus_call_method(
-                        client->user_bus,
+                        client->api_bus,
                         HIRTE_INTERFACE_BASE_NAME,
                         client->object_path,
                         NODE_INTERFACE,
@@ -88,8 +88,8 @@ void client_unref(Client *client) {
                 return;
         }
 
-        if (client->user_bus != NULL) {
-                sd_bus_unrefp(&client->user_bus);
+        if (client->api_bus != NULL) {
+                sd_bus_unrefp(&client->api_bus);
         }
         if (client->object_path != NULL) {
                 free(client->object_path);
@@ -163,7 +163,7 @@ void nodes_unit_list_unref(NodesUnitList *nodes_unit_list) {
 int client_call_manager(Client *client) {
         int r = 0;
 
-        r = sd_bus_open_user(&(client->user_bus));
+        r = sd_bus_open_user(&(client->api_bus));
         if (r < 0) {
                 fprintf(stderr, "Failed to connect to system bus: %s\n", strerror(-r));
                 return r;

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -163,7 +163,11 @@ void nodes_unit_list_unref(NodesUnitList *nodes_unit_list) {
 int client_call_manager(Client *client) {
         int r = 0;
 
+#ifdef USE_USER_API_BUS
         r = sd_bus_open_user(&(client->api_bus));
+#else
+        r = sd_bus_open_system(&(client->api_bus));
+#endif
         if (r < 0) {
                 fprintf(stderr, "Failed to connect to system bus: %s\n", strerror(-r));
                 return r;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -13,7 +13,7 @@ struct Client {
         int opargc;
         char **opargv;
 
-        sd_bus *user_bus;
+        sd_bus *api_bus;
         char *object_path;
 
         Printer printer;

--- a/src/libhirte/meson.build
+++ b/src/libhirte/meson.build
@@ -30,6 +30,7 @@ hirte_lib = static_library('hirte',
                             dependencies: [
                                 systemd_dep
                             ],
+                            c_args: common_cflags,
                             include_directories: include_directories('..'))
 
 

--- a/src/manager/job.c
+++ b/src/manager/job.c
@@ -91,7 +91,7 @@ bool job_export(Job *job) {
         Manager *manager = node->manager;
 
         int r = sd_bus_add_object_vtable(
-                        manager->user_dbus, &job->export_slot, job->object_path, JOB_INTERFACE, job_vtable, job);
+                        manager->api_bus, &job->export_slot, job->object_path, JOB_INTERFACE, job_vtable, job);
         if (r < 0) {
                 hirte_log_errorf("Failed to add job vtable: %s", strerror(-r));
                 return false;
@@ -107,7 +107,7 @@ void job_set_state(Job *job, JobState state) {
         job->state = state;
 
         int r = sd_bus_emit_properties_changed(
-                        manager->user_dbus, job->object_path, JOB_INTERFACE, "State", NULL);
+                        manager->api_bus, job->object_path, JOB_INTERFACE, "State", NULL);
         if (r < 0) {
                 hirte_log_errorf("Failed to emit status property changed: %s", strerror(-r));
         }

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -809,7 +809,11 @@ bool manager_start(Manager *manager) {
                 return false;
         }
 
+#ifdef USE_USER_API_BUS
         manager->api_bus = user_bus_open(manager->event);
+#else
+        manager->api_bus = system_bus_open(manager->event);
+#endif
         if (manager->api_bus == NULL) {
                 hirte_log_error("Failed to open user dbus");
                 return false;

--- a/src/manager/manager.h
+++ b/src/manager/manager.h
@@ -11,12 +11,12 @@ struct Manager {
         int ref_count;
 
         uint16_t port;
-        char *user_bus_service_name;
+        char *api_bus_service_name;
 
         sd_event *event;
         sd_event_source *node_connection_source;
 
-        sd_bus *user_dbus;
+        sd_bus *api_bus;
         sd_bus_slot *manager_slot;
         sd_bus_slot *filter_slot;
         sd_bus_slot *name_owner_changed_slot;

--- a/src/manager/monitor.c
+++ b/src/manager/monitor.c
@@ -112,7 +112,7 @@ bool monitor_export(Monitor *monitor) {
         Manager *manager = monitor->manager;
 
         int r = sd_bus_add_object_vtable(
-                        manager->user_dbus,
+                        manager->api_bus,
                         &monitor->export_slot,
                         monitor->object_path,
                         MONITOR_INTERFACE,
@@ -232,11 +232,7 @@ int monitor_emit_unit_property_changed(Monitor *monitor, const char *node, const
 
         _cleanup_sd_bus_message_ sd_bus_message *sig = NULL;
         int r = sd_bus_message_new_signal(
-                        manager->user_dbus,
-                        &sig,
-                        monitor->object_path,
-                        MONITOR_INTERFACE,
-                        "UnitPropertiesChanged");
+                        manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "UnitPropertiesChanged");
         if (r < 0) {
                 return r;
         }
@@ -255,7 +251,7 @@ int monitor_emit_unit_property_changed(Monitor *monitor, const char *node, const
                 return r;
         }
 
-        r = sd_bus_send_to(manager->user_dbus, sig, monitor->client, NULL);
+        r = sd_bus_send_to(manager->api_bus, sig, monitor->client, NULL);
         if (r < 0) {
                 return r;
         }
@@ -267,18 +263,12 @@ int monitor_emit_unit_new(Monitor *monitor, const char *node, const char *unit) 
         Manager *manager = monitor->manager;
 
         return sd_bus_emit_signal(
-                        manager->user_dbus, monitor->object_path, MONITOR_INTERFACE, "UnitNew", "ss", node, unit);
+                        manager->api_bus, monitor->object_path, MONITOR_INTERFACE, "UnitNew", "ss", node, unit);
 }
 
 int monitor_emit_unit_removed(Monitor *monitor, const char *node, const char *unit) {
         Manager *manager = monitor->manager;
 
         return sd_bus_emit_signal(
-                        manager->user_dbus,
-                        monitor->object_path,
-                        MONITOR_INTERFACE,
-                        "UnitRemoved",
-                        "ss",
-                        node,
-                        unit);
+                        manager->api_bus, monitor->object_path, MONITOR_INTERFACE, "UnitRemoved", "ss", node, unit);
 }

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -138,12 +138,7 @@ bool node_export(Node *node) {
         assert(node->name != NULL);
 
         int r = sd_bus_add_object_vtable(
-                        manager->user_dbus,
-                        &node->export_slot,
-                        node->object_path,
-                        NODE_INTERFACE,
-                        node_vtable,
-                        node);
+                        manager->api_bus, &node->export_slot, node->object_path, NODE_INTERFACE, node_vtable, node);
         if (r < 0) {
                 hirte_log_errorf("Failed to add node vtable: %s", strerror(-r));
                 return false;
@@ -349,7 +344,7 @@ bool node_set_agent_bus(Node *node, sd_bus *bus) {
                 }
 
                 r = sd_bus_emit_properties_changed(
-                                node->manager->user_dbus, node->object_path, NODE_INTERFACE, "Status", NULL);
+                                node->manager->api_bus, node->object_path, NODE_INTERFACE, "Status", NULL);
                 if (r < 0) {
                         hirte_log_errorf("Failed to emit status property changed: %s", strerror(-r));
                 }
@@ -396,7 +391,7 @@ void node_unset_agent_bus(Node *node) {
 
         if (was_online) {
                 int r = sd_bus_emit_properties_changed(
-                                node->manager->user_dbus, node->object_path, NODE_INTERFACE, "Status", NULL);
+                                node->manager->api_bus, node->object_path, NODE_INTERFACE, "Status", NULL);
                 if (r < 0) {
                         hirte_log_errorf("Failed to emit status property changed: %s", strerror(-r));
                 }


### PR DESCRIPTION
This helps fix https://github.com/containers/hirte/issues/107

Initially I thought to make this a runtime config option, but its kind of a pain, because all the client calls have to be the same too, and I think in production we should always use the system bus.

For now though, the default is still user.