### PR TITLE
Install default config files

### DIFF
--- a/config/hirte-agent.conf
+++ b/config/hirte-agent.conf
@@ -1,0 +1,9 @@
+[Node]
+Name=foo
+Host=127.0.0.1
+Port=2020
+
+[Logging]
+Level=DEBUG
+Target=stderr
+Quiet=false

--- a/config/hirte.conf
+++ b/config/hirte.conf
@@ -1,0 +1,8 @@
+[Manager]
+Port=2020
+
+
+[Logging]
+Level=DEBUG
+Target=stderr
+Quiet=false

--- a/config/meson.build
+++ b/config/meson.build
@@ -1,0 +1,9 @@
+install_data(
+  'hirte.conf',
+  install_dir : get_option('sysconfdir')
+)
+
+install_data(
+  'hirte-agent.conf',
+  install_dir :  get_option('sysconfdir')
+)

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -50,9 +50,10 @@ This package contains the node agent.
 
 
 %files
-%license LICENSE
+%config %{_sysconfdir}/hirte.conf
 %doc README.md
 %doc README.developer.md
+%license LICENSE
 %{_bindir}/hirte
 %{_bindir}/hirtectl
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Job.xml
@@ -61,8 +62,9 @@ This package contains the node agent.
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Node.xml
 
 %files agent
-%license LICENSE
+%config %{_sysconfdir}/hirte-agent.conf
 %doc README.md
+%license LICENSE
 %{_bindir}/hirte-agent
 
 

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,9 @@ endif
 # Subdirectory for the shared library.
 subdir('src/libhirte')
 
+# Configuration files
+subdir('config')
+
 # build each binary
 subdir('src/manager')
 subdir('src/agent')


### PR DESCRIPTION
Installs default config files to `/etc` directory:

* `hirte.conf` - a configuration file for the hirte daemon
* `hirte-agent.conf` - a configuration file for the hirte-agent daemon

Signed-off-by: ArtiomDivak <adivak@redhat.com>
