### PR TITLE
Fix the start-unit example script

### DIFF
--- a/doc/api-examples/start-unit.py
+++ b/doc/api-examples/start-unit.py
@@ -17,8 +17,6 @@ manager = bus.get_proxy("org.containers.hirte",  "/org/containers/hirte")
 node_path = manager.GetNode(node_name)
 node = bus.get_proxy("org.containers.hirte",  node_path)
 
-
-my_job_path = node.StartUnit(unit_name, "replace")
 loop = EventLoop()
 
 def job_removed(id, job_path, node_name, unit, result):
@@ -27,5 +25,5 @@ def job_removed(id, job_path, node_name, unit, result):
         loop.quit()
 
 manager.JobRemoved.connect(job_removed)
-
+my_job_path = node.StartUnit(unit_name, "replace")
 loop.run()


### PR DESCRIPTION
Basically, if you were starting a service, the script was running fine. If you were running the agent under a regular user and had to input your password, the script was running fine.
But if you were running the script under a regular user for a more than one, without stopping the service between two runs, the script was just hanging without telling you anything.

The reason for that was simple: since the service is already running node.StartUnit() is returning really quickly, too quickly for python to have had the time to setup the EventLoop object and connecting the manager to JobRemoved... So node.StartUnit() had returned and sent its JobRemoved notification before we had a chance to catch it, this making the script wait for the next JobRemoved notification...

Simply moving the node.StartUnit after we're connected JobRemoved solve the issue!

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>

Fixes: https://github.com/containers/hirte/issues/124