### PR TITLE
add 'list-units on all' functionality to hirtectl

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -35,21 +35,9 @@ UnitList *new_unit_list();
 UnitList *unit_list_ref(UnitList *unit_list);
 void unit_list_unref(UnitList *unit_list);
 
-struct NodesUnitList {
-        int ref_count;
-
-        LIST_HEAD(UnitList, nodes_units);
-};
-
-NodesUnitList *new_nodes_unit_list();
-NodesUnitList *nodes_unit_list_ref(NodesUnitList *nodes_unit_list);
-void nodes_unit_list_unref(NodesUnitList *nodes_unit_list);
-
 int client_call_manager(Client *client);
 
 DEFINE_CLEANUP_FUNC(Client, client_unref)
 #define _cleanup_client_ _cleanup_(client_unrefp)
 DEFINE_CLEANUP_FUNC(UnitList, unit_list_unref)
 #define _cleanup_unit_list_ _cleanup_(unit_list_unrefp)
-DEFINE_CLEANUP_FUNC(NodesUnitList, nodes_unit_list_unref)
-#define _cleanup_nodes_unit_list_ _cleanup_(nodes_unit_list_unrefp)

--- a/src/client/printer.c
+++ b/src/client/printer.c
@@ -14,8 +14,11 @@ void print_unit_list_simple(UnitList *unit_list) {
         }
 }
 
-void print_nodes_unit_list_simple(UNUSED NodesUnitList *nodes_unit_list) {
-        printf("Printing Nodes Unit List\n");
+void print_nodes_unit_list_simple(UnitList *unit_list) {
+        UnitInfo *unit = NULL;
+        LIST_FOREACH(units, unit, unit_list->units) {
+                printf("%s: %s\n", unit->node, unit->id);
+        }
 }
 
 Printer get_simple_printer() {
@@ -28,6 +31,6 @@ void print_unit_list(Printer *p, UnitList *unit_list) {
         (*p->print_unit_list)(unit_list);
 }
 
-void print_nodes_unit_list(Printer *p, NodesUnitList *nodes_unit_list) {
-        (*p->print_nodes_unit_list)(nodes_unit_list);
+void print_nodes_unit_list(Printer *p, UnitList *unit_list) {
+        (*p->print_nodes_unit_list)(unit_list);
 }

--- a/src/client/printer.h
+++ b/src/client/printer.h
@@ -4,10 +4,10 @@
 
 struct Printer {
         void (*print_unit_list)(UnitList *);
-        void (*print_nodes_unit_list)(NodesUnitList *);
+        void (*print_nodes_unit_list)(UnitList *);
 };
 
 Printer get_simple_printer();
 
 void print_unit_list(Printer *p, UnitList *unit_list);
-void print_nodes_unit_list(Printer *p, NodesUnitList *nodes_unit_list);
+void print_nodes_unit_list(Printer *p, UnitList *nodes_unit_list);

--- a/src/client/types.h
+++ b/src/client/types.h
@@ -2,5 +2,4 @@
 
 typedef struct Client Client;
 typedef struct UnitList UnitList;
-typedef struct NodesUnitList NodesUnitList;
 typedef struct Printer Printer;

--- a/src/libhirte/bus/utils.h
+++ b/src/libhirte/bus/utils.h
@@ -12,17 +12,17 @@ typedef struct UnitInfo UnitInfo;
 struct UnitInfo {
         int ref_count;
 
-        const char *node;
-        const char *id;
-        const char *description;
-        const char *load_state;
-        const char *active_state;
-        const char *sub_state;
-        const char *following;
-        const char *unit_path;
+        char *node;
+        char *id;
+        char *description;
+        char *load_state;
+        char *active_state;
+        char *sub_state;
+        char *following;
+        char *unit_path;
         uint32_t job_id;
-        const char *job_type;
-        const char *job_path;
+        char *job_type;
+        char *job_path;
 
         LIST_FIELDS(UnitInfo, units);
 };
@@ -32,6 +32,7 @@ UnitInfo *unit_ref(UnitInfo *unit);
 void unit_unref(UnitInfo *unit);
 
 int bus_parse_unit_info(sd_bus_message *message, UnitInfo *u);
+int bus_parse_unit_on_node_info(sd_bus_message *message, UnitInfo *u);
 
 int assemble_object_path_string(const char *prefix, const char *name, char **res);
 


### PR DESCRIPTION
Now running `hirtectl list-units` shows all the units running on all nodes.

Signed-off-by: Mark Kemel <mkemel@redhat.com>