### PR TITLE
Add markdown linter to the project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: bug
-assignees: 
+assignees:
 ---
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -3,7 +3,7 @@ name: Documentation request
 about: If you think something is not well described
 title: ''
 labels: documentation
-assignees: 
+assignees:
 ---
 
 ## Please describe what information you were trying to find

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: ''
 labels: feature
-assignees: 
+assignees:
 ---
 
 ## Please describe what you would like to see

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,9 @@ jobs:
         run: |
           make codespell
 
+      - name: Running markdown lint
+        uses: DavidAnson/markdownlint-cli2-action@v9
+
   rpmbuild:
     needs: lint
     runs-on: ubuntu-latest

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,7 @@
+config:
+  MD013:
+    line_length: 120
+    tables: false
+
+globs:
+  - "**/*.md"

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,15 @@ fmt:
 check-fmt:
 	eval $(ALL_SRC_FILES) | xargs -0 -I {} clang-format  --dry-run -Werror {}
 
-lint: 
+lint-c:
 	eval $(ALL_SRC_FILES) | xargs -0 -I {} clang-tidy --quiet {} -- -I src/ -D_GNU_SOURCE
 
-lint-fix: 
+lint-markdown:
+	markdownlint-cli2 | echo "markdownlint-cli2 not found, skipping markdown lint"
+
+lint: lint-c lint-markdown
+
+lint-fix:
 	eval $(ALL_SRC_FILES) | xargs -0 -I {} clang-tidy --quiet {} --fix -- -I src/ -D_GNU_SOURCE
 
 codespell:

--- a/README.developer.md
+++ b/README.developer.md
@@ -9,6 +9,7 @@ In order to develop the project you need to install following dependencies.
 #### Prerequisites
 
 To build the project on CentOS Stream 9 you need to enable CodeReady Build repository:
+
 ```bash
 sudo dnf install dnf-plugin-config-manager
 sudo dnf config-manager --set-enabled crb
@@ -22,15 +23,20 @@ sudo dnf install clang-tools-extra gcc make meson systemd-devel
 
 ### Code Style
 
-[clang-format](https://clang.llvm.org/docs/ClangFormat.html) is used to enforce a unified code style. All source files can be formatted via:
+[clang-format](https://clang.llvm.org/docs/ClangFormat.html) is used to enforce a unified code style. All source files
+can be formatted via:
+
 ```bash
 make fmt
 ```
 
-For the most part, this project follows systemd coding style: [systemd-coding-style](https://github.com/systemd/systemd/blob/main/docs/CODING_STYLE.md).
-Also, this project borrows some of the coding conventions from systemd.  For example, function names pertaining to D-Bus services look like <code>bus_service_set_property()</code>.
+For the most part, this project follows systemd coding style:
+[systemd-coding-style](https://github.com/systemd/systemd/blob/main/docs/CODING_STYLE.md).
+Also, this project borrows some of the coding conventions from systemd.  For example, function names pertaining
+to D-Bus services look like `bus_service_set_property()`.
 
 A formatting check of existing files can be executed by:
+
 ```bash
 make check-fmt
 ```
@@ -38,11 +44,13 @@ make check-fmt
 ### Linting
 
 [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) is used for static analysis. All source files can be checked via:
+
 ```bash
 make lint
 ```
 
 Some errors detected by `clang-tidy` can be fixed automatically via:
+
 ```bash
 make lint-fix
 ```
@@ -52,29 +60,36 @@ make lint-fix
 The project is using [meson](https://mesonbuild.com/) build system.
 
 The binaries can be built via
+
 ```bash
 meson setup builddir
 meson compile -C builddir
 ```
 
-After successfully compiling the binaries, they can be installed into a destination directory (by default `/usr/local/bin`) using:
+After successfully compiling the binaries, they can be installed into a destination directory (by default
+`/usr/local/bin`) using:
+
 ```bash
 meson install -C builddir
 ```
 
 To install it into `builddir/bin` use:
+
 ```bash
 meson install -C builddir --destdir bin
 ```
 
 After building, three binaries are available:
-- __hirte__: the orchestrator which is run on the main machine, sending commands to the agents and monitoring the progress
+
+- __hirte__: the orchestrator which is run on the main machine, sending commands to the agents and monitoring
+  the progress
 - __hirte-agent__: the node agent unit which connects with the orchestrator and executes commands on the node machine
 - __hirtectl__: a helper (CLI) program to send an commands to the orchestrator
 
 ### Unit tests
 
 Unit tests can be executed using following commands
+
 ```bash
 meson setup builddir
 meson compile -C builddir
@@ -88,11 +103,14 @@ At the moment the hirtectl binary do only print a simple greeting and exit.
 #### hirte
 
 Hirte, the orchestrator can be run via:
+
 ```bash
 hirte -c ./doc/example.ini
 ```
+
 It starts a tcp socket and accepts connections, but does not do much more at this point.
 This can be tested manually via
+
 ```bash
 nc <host> <port>
 ```
@@ -100,10 +118,13 @@ nc <host> <port>
 #### hirte-node
 
 Nodes can be run via:
+
 ```bash
 ./bin/hirte-agent -n <agent name> -H <host> -P <port>
 ```
-It creates a new dbus which tries to connect to the specified host. The host will print out a message if the request was accepted. It does not do much more at this point.
+
+It creates a new dbus which tries to connect to the specified host. The host will print out a message if the request
+was accepted. It does not do much more at this point.
 
 ## Documentation
 

--- a/README.developer.md
+++ b/README.developer.md
@@ -21,6 +21,11 @@ sudo dnf config-manager --set-enabled crb
 sudo dnf install clang-tools-extra gcc make meson systemd-devel
 ```
 
+[markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) can be used for static analysis of
+markdown files. Unfortunately it's not available as RPM, so please check its
+[installation guide](https://github.com/DavidAnson/markdownlint-cli2#install) and use the most appropriate way of
+installation for your setup.
+
 ### Code Style
 
 [clang-format](https://clang.llvm.org/docs/ClangFormat.html) is used to enforce a unified code style. All source files
@@ -43,7 +48,10 @@ make check-fmt
 
 ### Linting
 
-[clang-tidy](https://clang.llvm.org/extra/clang-tidy/) is used for static analysis. All source files can be checked via:
+[clang-tidy](https://clang.llvm.org/extra/clang-tidy/) is used for static analysis of C source codes.
+[markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) is used for static analysis of markdown files.
+
+All source files can be checked via:
 
 ```bash
 make lint

--- a/README.md
+++ b/README.md
@@ -17,18 +17,17 @@ to generate systemd service configuration to run a container.
 Patches are welcome!
 
 Please submit patches to [github.com:containers/hirte](https://github.com/containers/hirte).
-More information about the development can be found in [README.developer](https://github.com/containers/hirte/README.developer.md).
+More information about the development can be found in [README.developer.md](README.developer.md).
 
 If you are not familiar with the development process you can read about it in
 [Get started with GitHub](https://docs.github.com/en/get-started).
 
-
 ### Found a bug or documentation issue?
+
 To submit a bug or suggest an enhancement for hirte please use
 [GitHub issues](https://github.com/containers/hirte/issues).
 
-
 ## Still need help?
-If you have any other questions, please join [CentOS Automotive SIG mailing list](https://lists.centos.org/mailman/listinfo/centos-automotive-sig/) and ask there.
 
-
+If you have any other questions, please join
+[CentOS Automotive SIG mailing list](https://lists.centos.org/mailman/listinfo/centos-automotive-sig/) and ask there.

--- a/doc/arch/README.md
+++ b/doc/arch/README.md
@@ -1,1 +1,3 @@
-This directory contains diagrams that visualize how the [POC](https://github.com/alexlarsson/orch) works. 
+# POC diagrams
+
+This directory contains diagrams that visualize how the [POC](https://github.com/alexlarsson/orch) works.

--- a/doc/dbus-interfaces.md
+++ b/doc/dbus-interfaces.md
@@ -25,206 +25,206 @@ can use to control the system. It is expected that highlevel control
 planes use this API directly, but there is also a hirtectl
 program that is useful for debugging and testing.
 
-# Hirte public DBus API
+## Hirte public DBus API
 
-The main entry point is at the /org/containers/hirte object path and
-implements the "org.containers.hirte.Manager" interface.
+The main entry point is at the `/org/containers/hirte` object path and
+implements the `org.containers.hirte.Manager` interface.
 
 Note that all properties also come with change events, so you can
 easily track when they change.
 
-## interface org.containers.hirte.Manager
+### interface org.containers.hirte.Manager
 
 * Methods:
-  * ListUnits(out a(sssssssouso) units)
+
+  * `ListUnits(out a(sssssssouso) units)`
 
     Returns an array with all currently loaded systemd units on all
     (online) nodes. This is equivalent to calling Node.ListUnits() on
     all the online nodes and adding the name of the node as the first
     element of each returned element struct.
 
-  * CreateMonitor(out o monitor)
+  * `CreateMonitor(out o monitor)`
 
     Creates a new monitor object, which can be used to monitor the
     state of selected units on the nodes. The monitor object returned
     will automatically be closed if the calling peer disconnects from
     the bus.
 
-   * ListNodes(out a(sos) nodes);
+  * `ListNodes(out a(sos) nodes)`
 
-     Returns information (name, object_path and status) of all know nodes.
+    Returns information (name, object_path and status) of all know nodes.
 
-   * GetNode(in s name, out o path);
+  * `GetNode(in s name, out o path)`
 
-     Returns the object path of a node given its name.
+    Returns the object path of a node given its name.
 
 * Signals:
-  * JobNew(u id,
-           o job,
-           s nodeName,
-           s unit)
+
+  * `JobNew(u id, o job, s nodeName, s unit)`
 
     Emitted each time a new hirte job is queued.
 
-  * JobRemoved(u id,
-               o job,
-               s nodeName,
-               s unit,
-               s result)
+  * `JobRemoved(u id, o job, s nodeName, s unit, s result)`
 
     Emitted each time a new job is dequeued or the underlying systemd
-    job finished. `result` is one of: "done", "failed", "cancelled",
-    "timeout", "dependency", "skipped". This is either the result
-    from systemd on the node, or "cancelled" if the job was cancelled
+    job finished. `result` is one of: `done`, `failed`, `cancelled`,
+    `timeout`, `dependency`, `skipped`. This is either the result
+    from systemd on the node, or `cancelled` if the job was cancelled
     in hirte before any systemd job was started for it.
 
 * Properties:
-  * Nodes - as
+
+  * `Nodes` - `as`
 
     A list with the names of all configured nodes managed by
     Hirte. Each name listed here also have a corresponding
     object under `/org/containers/hirte/node/$name` which
     implements the `org.containers.hirte.Node` interface.
 
+### interface org.containers.hirte.Monitor
 
-## interface org.containers.hirte.Monitor
+Object path: `/org/containers/hirte/monitor/$id`
 
-Object path: /org/containers/hirte/monitor/$id
+* Methods:
 
- * Methods:
-   * Close()
+  * `Close()`
 
-     Stop monitoring and delete the Monitor object, removing any
-     outstanding subscriptions.
+    Stop monitoring and delete the Monitor object, removing any
+    outstanding subscriptions.
 
-   * Subscribe(in node s, in unit s)
+  * `Subscribe(in node s, in unit s)`
 
-     Subscribe to changes in properties of a given unit on a given
-     node, or all nodes if the node name is empty. This will emit
-     the signal UnitChanged for all matching units in the system, and
-     then again whenever one of the properties of the unit changes.
+    Subscribe to changes in properties of a given unit on a given
+    node, or all nodes if the node name is empty. This will emit
+    the signal UnitChanged for all matching units in the system, and
+    then again whenever one of the properties of the unit changes.
 
-   * Unsubscribe(in node s, in unit s)
+  * `Unsubscribe(in node s, in unit s)`
 
-     Remove an earlier added subscription.
+    Remove an earlier added subscription.
 
- * Signals:
-   * UnitPropertiesChanged(s node, s unit, a{sv} props)
+* Signals:
 
-     Whenever the properties changes for any of the units that are
-     currently subscribed to changes, this signal is
-     emitted. Additionally it is emitted initially once for each
-     matched unit. This allows you to easily monitor and get
-     the current state in a race-free way without missing any
-     changes.
+  * `UnitPropertiesChanged(s node, s unit, a{sv} props)`
 
-   * UnitNew(s node, s unit)
+    Whenever the properties changes for any of the units that are
+    currently subscribed to changes, this signal is
+    emitted. Additionally it is emitted initially once for each
+    matched unit. This allows you to easily monitor and get
+    the current state in a race-free way without missing any
+    changes.
 
-     Emitted when a new unit is created, for example when a service is started.
+  * `UnitNew(s node, s unit)`
 
-   * UnitRemove(s node, s unit)
+    Emitted when a new unit is created, for example when a service is started.
 
-     Emitted when a unit is removed.
+  * `UnitRemove(s node, s unit)`
 
+    Emitted when a unit is removed.
 
-## interface org.containers.hirte.Node
+### interface org.containers.hirte.Node
 
 Each Node object represent a configured node in the system,
 independent on whether that node is connected to the manager or not,
 and the status can change over time.
 
-Object path: /org/containers/hirte/node/$name
+Object path: `/org/containers/hirte/node/$name`
 
- * Methods:
-   * StartUnit(in s name, in s mode, out o job)
+* Methods:
 
-     Queues a unit activate job for the named unit on this node. The
-     queue is per-unit name, which means there is only ever one active
-     job per unit. Mode can be one of "replace" or "fail". If there is
-     an outstanding queued (but not running) job, that is replaced
-     if mode is "replace", or the job fails if mode is "fail".
+  * `StartUnit(in s name, in s mode, out o job)`
 
-     The job returned is an object path for an object implementing
-     `org.containers.hirte.Job`, and which be monitored for the progress
-     of the job, or used to cancel the job. To track the result of
-     the job, follow the `JobRemoved` signal on the Manager.
+    Queues a unit activate job for the named unit on this node. The
+    queue is per-unit name, which means there is only ever one active
+    job per unit. Mode can be one of `replace` or `fail`. If there is
+    an outstanding queued (but not running) job, that is replaced
+    if mode is `replace`, or the job fails if mode is `fail`.
 
-   * StopUnit(in s name, in s mode, out o job)
+    The job returned is an object path for an object implementing
+    `org.containers.hirte.Job`, and which be monitored for the progress
+    of the job, or used to cancel the job. To track the result of
+    the job, follow the `JobRemoved` signal on the Manager.
 
-     StopUnit() is similar to StartUnit() but stops the specified unit rather than starting it.
+  * `StopUnit(in s name, in s mode, out o job)`
 
-   * ReloadUnit(in  s name, in  s mode, out o job)
-   * RestartUnit(in  s name, in  s mode, out o job)
+    `StopUnit()` is similar to `StartUnit()` but stops the specified unit rather than starting it.
 
-     Reload/RestartUnit is similar to StartUnit() but can be used to restart/reload a
-     unit instead. See equivalend systemd methods for details.
+  * `ReloadUnit(in  s name, in  s mode, out o job)`
 
-   * KillUnit(in  s name, in  s who, in  i signal)
+  * `RestartUnit(in  s name, in  s mode, out o job)`
 
-     Kill a unit on the node. Arguments and semantics are equivalent
-     to the systemd KillUnit() method.
+    `ReloadUnit()`/`RestartUnit()` is similar to `StartUnit()` but can be used to restart/reload a
+    unit instead. See equivalend systemd methods for details.
 
-   * GetUnitProperties(in name, out a{sv} props);
+  * `KillUnit(in  s name, in  s who, in  i signal)`
 
-     Returns the current properties for for a named unit on the
-     node. The returned properties are the same as you would get in
-     the systemd properties apis, but filtered to the following
-     subset: "LoadState", "ActiveState", "SubState", "UnitFileState",
-     "LoadState", "Result".
+    Kill a unit on the node. Arguments and semantics are equivalent
+    to the systemd `KillUnit()` method.
 
-   * ListUnits(out a(ssssssouso) units);
+  * `GetUnitProperties(in name, out a{sv} props)`
 
-     Returns all the currently loaded systemd units on this node. The returned
-     structure is the same as the one returned by the systemd ListUnits() call.
+    Returns the current properties for for a named unit on the
+    node. The returned properties are the same as you would get in
+    the systemd properties apis, but filtered to the following
+    subset: `LoadState`, `ActiveState`, `SubState`, `UnitFileState`,
+    `LoadState`, `Result`.
 
- * Properties:
-   * Name - s
+  * `ListUnits(out a(ssssssouso) units)`
 
-     The name of the node
+    Returns all the currently loaded systemd units on this node. The returned
+    structure is the same as the one returned by the systemd `ListUnits()` call.
 
-   * Status - s
+* Properties:
 
-     Status of the node, currently one of: "online", "offline".
-     Emits changed when this changes.
+  * `Name` - `s`
 
+    The name of the node
 
-## interface org.containers.hirte.Job
+  * `Status` - `s`
+
+    Status of the node, currently one of: `online`, `offline`.
+    Emits changed when this changes.
+
+### interface org.containers.hirte.Job
 
 Each potentially long-running operation returns a job object,
 which can be used to monitor the status of the job as well
 as cancelling it.
 
-Object path: /org/containers/hirte/job/$id
+Object path: `/org/containers/hirte/job/$id`
 
- * Methods:
-   * Cancel()
+* Methods:
 
-     Cancel the job, which means either cancelling the corresponding
-     systemd job if it was started, or directly cancelling or
-     replacing the hirte job if no systemd job was started for it yet
-     (i.e. it is in the queue).
+  * `Cancel()`
 
- * Properties
-   * Id u
+    Cancel the job, which means either cancelling the corresponding
+    systemd job if it was started, or directly cancelling or
+    replacing the hirte job if no systemd job was started for it yet
+    (i.e. it is in the queue).
 
-     An integer giving the id of the job
+* Properties
 
-   * Node - s
+  * `Id` - `u`
 
-     The name of the node the job is on
+    An integer giving the id of the job
 
-   * Unit - s
+  * `Node` - `s`
 
-     The name of the unit the job works on
+    The name of the node the job is on
 
-   * JobType - s
+  * `Unit` - `s`
 
-     Type of the job, either "Start" or "Stop".
+    The name of the unit the job works on
 
-   * State - s
+  * `JobType` - `s`
 
-     The current state of the job, one of: "waiting" or "running".
-     Waiting is for queued jobs.
+    Type of the job, either `Start` or `Stop`.
+
+  * `State` - `s`
+
+    The current state of the job, one of: `waiting` or `running`.
+    Waiting is for queued jobs.
 
 ## Internal Dbus APIs
 
@@ -240,89 +240,92 @@ but via a direct peer-to-peer connection. On this connection the
 regular Manager API is not available, instead we're using internal
 Manager object as the basic data.
 
-Object path: /org/containers/hirte/internal
+Object path: `/org/containers/hirte/internal`
 
- * Methods:
-   * Register(in st name)
+* Methods:
 
-     Before anything else can happen the node must call this method to
-     register with the manager, giving its unique name. If this
-     succeeds, then the manager will consider the node online and
-     start forwarding operations to it.
+  * `Register(in st name)`
+
+    Before anything else can happen the node must call this method to
+    register with the manager, giving its unique name. If this
+    succeeds, then the manager will consider the node online and
+    start forwarding operations to it.
 
 ### interface org.containers.hirte.internal.Agent
 
 This is the main interface that the node implements and that is used
 by the manager to affect change on the node.
 
- * Methods:
-   * StartUnit(in s name, in s mode, in u id)
-   * StopUnit(in s name, in s mode, in u id)
-   * ReloadUnit(in s name, in s mode, in u id)
-   * RestartUnit(in s name, in s mode, in u id)
-   * KillUnit(in s name, in s who, in i signal)
-   * GetUnitProperties(in name, out a{sv} props);
-   * ListUnits(out a(ssssssouso) units);
+* Methods:
 
-     These are all API mirrors of the respective method in
-     org.containers.hirte.Node, and all they do is forward
-     the same operation to the local systemd instance.
-     Similarly, any changes in the systemd job will be
-     forwarded to signals on the node job which will
-     then be forwareded to the manager job and reach
-     the user.
+  * `StartUnit(in s name, in s mode, in u id)`
 
-   * Subscribe(in unit s)
+  * `StopUnit(in s name, in s mode, in u id)`
 
-     Whenever some monitor object exists in the manager that
-     matches a specific the node name and unit name, this method
-     is called. (This can happen either when a monitor is created
-     or when a new node connects). Whenever *some* subscription
-     is active, the node will call the systemd "Subscribed" method,
-     and then register for UnitNew, UnitRemoved as well as for
-     property change events on units. Any time a Unit changes
-     it will emit the UnitPropertyChanged event if any of
-     the supported properties changed since last time.
+  * `ReloadUnit(in s name, in s mode, in u id)`
 
-   * Unsubscribe(in unit s)
+  * `RestartUnit(in s name, in s mode, in u id)`
 
-     Remove a subscription added via Subscribe. If there are
-     none left, call Unsubscribe() in the systemd API.
+  * `KillUnit(in s name, in s who, in i signal)`
+
+  * `GetUnitProperties(in name, out a{sv} props)`
+
+  * `ListUnits(out a(ssssssouso) units);`
+
+    These are all API mirrors of the respective method in
+    `org.containers.hirte.Node`, and all they do is forward
+    the same operation to the local systemd instance.
+    Similarly, any changes in the systemd job will be
+    forwarded to signals on the node job which will
+    then be forwarded to the manager job and reach
+    the user.
+
+  * `Subscribe(in unit s)`
+
+    Whenever some monitor object exists in the manager that
+    matches a specific the node name and unit name, this method
+    is called. (This can happen either when a monitor is created
+    or when a new node connects). Whenever *some* subscription
+    is active, the node will call the systemd "Subscribed" method,
+    and then register for UnitNew, UnitRemoved as well as for
+    property change events on units. Any time a Unit changes
+    it will emit the UnitPropertyChanged event if any of
+    the supported properties changed since last time.
+
+  * `Unsubscribe(in unit s)`
+
+    Remove a subscription added via `Subscribe()`. If there are
+    none left, call `Unsubscribe()` in the systemd API.
 
 * Signals:
-   * JobDone(u id,
-             s result)
 
-     Mirrors of the job signals in the manager and used to
-     forward state changes from systemd to the manager.
+  * `JobDone(u id, s result)`
 
-   * JobStateChanged(u id,
-                     s state)
+    Mirrors of the job signals in the manager and used to
+    forward state changes from systemd to the manager.
 
-     Forwards the job state property changes from systemd to the manager.
+  * `JobStateChanged(u id, s state)`
 
-   * UnitPropertiesChanged(s unit, a{sv} props)
+    Forwards the job state property changes from systemd to the manager.
 
-     This is equivalend to the Monitor signal, but for this node
-     only. The same set of properties described there is supported
-     here.
+  * `UnitPropertiesChanged(s unit, a{sv} props)`
 
-  * ProxyNew(s nodeName,
-             s unitName,
-             o proxy)
+    This is equivalend to the Monitor signal, but for this node
+    only. The same set of properties described there is supported
+    here.
+
+  * `ProxyNew(s nodeName, s unitName, o proxy)`
 
     Whenever a proxy service is running on the system with the node it
     calls into the node service, and the node service creates a new
-    org.containers.internal.Proxy` object and emits this signal to
+    `org.containers.internal.Proxy` object and emits this signal to
     tell the manager about it. The manager will notice this
     and try to arrange that the requested unit is running on the
     requested node.  If the unit is already running, when it is
     started, or when the start fails, the manager will call the
-    Ready() method on it.
+    `Ready()` method on it.
 
-  * ProxyRemoved(s nodeName,
-                 s unitName,
-                 o proxy)
+  * `ProxyRemoved(s nodeName, s unitName, o proxy)`
 
     This is emitted when a proxy is not needed anymore because the
     proxy service died.
@@ -333,8 +336,9 @@ The node creates one of these by request from a proxy service,
 it is used to synchronize the state of the remote service with
 the proxy.
 
- * Methods:
-  * Ready(in s result)
+* Methods:
+
+  * `Ready(in s result)`
 
     Called by the manager when the corresponding service is
     active (either was running already, or was started), or when


### PR DESCRIPTION
- Add markdownlint-cli2 linter to the project
- Fix markdown syntax issues in doc/arch/README.md
- Fix markdown syntax issues in GH issue templates
- Fix markdown syntax issues in dbus-interfaces.md
- Fix markdown syntax issues in README*md
