### PR TITLE
hirtectl: add unit lifecycle actions functionality

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -16,6 +16,9 @@ struct Client {
         sd_bus *api_bus;
         char *object_path;
 
+        char *pending_job_name;
+        sd_bus_message *pending_job_result;
+
         Printer printer;
 };
 


### PR DESCRIPTION
Added start/stop/restart/reload functionality to hirtectl. Example:
`hirtectl start foo httpd.service`
`hirtectl stop foo httpd.service`

Implementing #141 
Signed-off-by: Mark Kemel <mkemel@redhat.com>