### PR TITLE
hirtectl: basic table for list-units output

### DIFF
--- a/src/client/printer.c
+++ b/src/client/printer.c
@@ -7,20 +7,27 @@
 #include "printer.h"
 #include "types.h"
 
+/* Prints 100-characters-wide table */
 void print_unit_list_simple(UnitList *unit_list) {
         UnitInfo *unit = NULL;
+        printf("%-80.80s|%9s|%9s\n", "ID", "ACTIVE", "SUB");
+        printf("====================================================================================================\n");
         LIST_FOREACH(units, unit, unit_list->units) {
-                printf("%s\n", unit->id);
+                printf("%-80.80s|%9s|%9s\n", unit->id, unit->active_state, unit->sub_state);
         }
 }
 
+/* Prints 100-characters-wide table */
 void print_nodes_unit_list_simple(UnitList *unit_list) {
         UnitInfo *unit = NULL;
+        printf("%-20.20s|%-59.59s|%9s|%9s\n", "NODE", "ID", "ACTIVE", "SUB");
+        printf("====================================================================================================\n");
         LIST_FOREACH(units, unit, unit_list->units) {
-                printf("%s: %s\n", unit->node, unit->id);
+                printf("%-20.20s|%-59.59s|%9s|%9s\n", unit->node, unit->id, unit->active_state, unit->sub_state);
         }
 }
 
+/* We can implement here other types of printers, e.g. json printer */
 Printer get_simple_printer() {
         Printer p = { .print_unit_list = &print_unit_list_simple,
                       .print_nodes_unit_list = &print_nodes_unit_list_simple };


### PR DESCRIPTION
Added a basic, 100-characters-wide table for list-units output.
E.g
```
$ hirtectl list-units
NODE                |ID                                                         |   ACTIVE|      SUB
====================================================================================================
foo                 |mcelog.service                                             |   active|  running
foo                 |systemd-userdbd.service                                    |   active|  running
foo                 |abrt-oops.service                                          |   failed|   failed
foo                 |dev-disk-by\x2did-nvme\x2deui.000000000000000100a075202c1cb|   active|  plugged
foo                 |sys-devices-pci0000:00-0000:00:1d.4-0000:2e:00.0-nvme-nvme0|   active|  plugged
foo                 |integritysetup.target                                      |   active|   active
foo                 |user-1000.slice                                            |   active|   active
foo                 |systemd-userdbd.socket                                     |   active|  running
foo                 |dev-snd-by\x2did-usb\x2d046d_0825_C270B810\x2d02.device    |   active|  plugged
foo                 |dev-snd-by\x2dpath-pci\x2d0000:00:14.0\x2dusb\x2d0:2.1.1.2:|   active|  plugged
foo                 |uresourced.service                                         |   active|  running
...
```


Signed-off-by: Mark Kemel <mkemel@redhat.com>