### PR TITLE
Fix memory leak in manager

### DIFF
--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -33,6 +33,7 @@ Manager *manager_new(void) {
 
         Manager *manager = malloc0(sizeof(Manager));
         if (manager != NULL) {
+                manager->ref_count = 1;
                 manager->port = HIRTE_DEFAULT_PORT;
                 manager->api_bus_service_name = steal_pointer(&service_name);
                 manager->event = steal_pointer(&event);

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -258,7 +258,7 @@ static int node_match_heartbeat(UNUSED sd_bus_message *m, UNUSED void *userdata,
 
         static bool first_heartbeat_received;
         if (!first_heartbeat_received) {
-                hirte_log_infof("First heartbeat received from %s\n", node_name);
+                hirte_log_infof("First heartbeat received from %s", node_name);
                 first_heartbeat_received = true;
         }
 


### PR DESCRIPTION
Currently ```manager_unref()``` doesn't free memory because the manager object's reference count was never incremented.  This code change fixes that by setting the reference count to 1 when the manager object is allocated in ```manager_new()```.


Signed-off-by: Steve Dunnagan <sdunnaga@redhat.com>