### PR TITLE
Update events and property handling

### DIFF
--- a/data/org.containers.hirte.Monitor.xml
+++ b/data/org.containers.hirte.Monitor.xml
@@ -14,6 +14,7 @@
     <signal name="UnitPropertiesChanged">
       <arg name="node" type="s" />
       <arg name="unit" type="s" />
+      <arg name="interface" type="s" />
       <arg name="props" type="a{sv}" />
     </signal>
     <signal name="UnitStateChanged">

--- a/data/org.containers.hirte.Monitor.xml
+++ b/data/org.containers.hirte.Monitor.xml
@@ -16,6 +16,13 @@
       <arg name="unit" type="s" />
       <arg name="props" type="a{sv}" />
     </signal>
+    <signal name="UnitStateChanged">
+      <arg name="node" type="s" />
+      <arg name="unit" type="s" />
+      <arg name="active_state" type="s" />
+      <arg name="sub_state" type="s" />
+      <arg name="reason" type="s" />
+    </signal>
     <signal name="UnitNew">
       <arg name="node" type="s" />
       <arg name="unit" type="s" />

--- a/data/org.containers.hirte.Monitor.xml
+++ b/data/org.containers.hirte.Monitor.xml
@@ -19,10 +19,12 @@
     <signal name="UnitNew">
       <arg name="node" type="s" />
       <arg name="unit" type="s" />
+      <arg name="reason" type="s" />
     </signal>
     <signal name="UnitRemoved">
       <arg name="node" type="s" />
       <arg name="unit" type="s" />
+      <arg name="reason" type="s" />
     </signal>
   </interface>
 </node>

--- a/data/org.containers.hirte.Node.xml
+++ b/data/org.containers.hirte.Node.xml
@@ -27,8 +27,8 @@
       <arg name="signal" type="i" direction="in" />
     </method>
     <method name="GetUnitProperties">
-      <arg name="interface" type="s" direction="in" />
       <arg name="name" type="s" direction="in" />
+      <arg name="interface" type="s" direction="in" />
       <arg name="props" type="a{sv}" direction="out" />
     </method>
     <method name="ListUnits">

--- a/data/org.containers.hirte.Node.xml
+++ b/data/org.containers.hirte.Node.xml
@@ -31,6 +31,17 @@
       <arg name="interface" type="s" direction="in" />
       <arg name="props" type="a{sv}" direction="out" />
     </method>
+    <method name="GetUnitProperty">
+      <arg name="name" type="s" direction="in" />
+      <arg name="interface" type="s" direction="in" />
+      <arg name="property" type="s" direction="in" />
+      <arg name="value" type="v" direction="out" />
+    </method>
+    <method name="SetUnitProperties">
+      <arg name="name" type="s" direction="in" />
+      <arg name="runtime" type="b" direction="in" />
+      <arg name="keyvalues" type="a(sv)" direction="in" />
+    </method>
     <method name="ListUnits">
       <arg name="units" type="a(ssssssouso)" direction="out" />
     </method>

--- a/data/org.containers.hirte.Node.xml
+++ b/data/org.containers.hirte.Node.xml
@@ -27,6 +27,7 @@
       <arg name="signal" type="i" direction="in" />
     </method>
     <method name="GetUnitProperties">
+      <arg name="interface" type="s" direction="in" />
       <arg name="name" type="s" direction="in" />
       <arg name="props" type="a{sv}" direction="out" />
     </method>

--- a/data/org.containers.hirte.internal.Agent.xml
+++ b/data/org.containers.hirte.internal.Agent.xml
@@ -27,6 +27,7 @@
       <arg name="signal" type="i" direction="in" />
     </method>
     <method name="GetUnitProperties">
+      <arg name="interface" type="s" direction="in" />
       <arg name="name" type="s" direction="in" />
       <arg name="props" type="a{sv}" direction="out" />
     </method>
@@ -63,6 +64,7 @@
     </signal>
     <signal name="UnitPropertiesChanged">
       <arg name="unit" type="s" />
+      <arg name="interface" type="s" />
       <arg name="props" type="a{sv}" />
     </signal>
     <signal name="ProxyNew">

--- a/data/org.containers.hirte.internal.Agent.xml
+++ b/data/org.containers.hirte.internal.Agent.xml
@@ -27,8 +27,8 @@
       <arg name="signal" type="i" direction="in" />
     </method>
     <method name="GetUnitProperties">
-      <arg name="interface" type="s" direction="in" />
       <arg name="name" type="s" direction="in" />
+      <arg name="interface" type="s" direction="in" />
       <arg name="props" type="a{sv}" direction="out" />
     </method>
     <method name="ListUnits">

--- a/data/org.containers.hirte.internal.Agent.xml
+++ b/data/org.containers.hirte.internal.Agent.xml
@@ -31,6 +31,17 @@
       <arg name="interface" type="s" direction="in" />
       <arg name="props" type="a{sv}" direction="out" />
     </method>
+    <method name="GetUnitProperty">
+      <arg name="name" type="s" direction="in" />
+      <arg name="interface" type="s" direction="in" />
+      <arg name="property" type="s" direction="in" />
+      <arg name="value" type="v" direction="out" />
+    </method>
+    <method name="SetUnitProperties">
+      <arg name="name" type="s" direction="in" />
+      <arg name="runtime" type="b" direction="in" />
+      <arg name="keyvalues" type="a(sv)" direction="in" />
+    </method>
     <method name="ListUnits">
       <arg name="units" type="a(ssssssouso)" direction="out" />
     </method>

--- a/data/org.containers.hirte.internal.Agent.xml
+++ b/data/org.containers.hirte.internal.Agent.xml
@@ -48,6 +48,19 @@
       <arg name="id" type="u" />
       <arg name="state" type="s" />
     </signal>
+    <signal name="UnitNew">
+      <arg name="unit" type="s" />
+      <arg name="reason" type="s" />
+    </signal>
+    <signal name="UnitRemoved">
+      <arg name="unit" type="s" />
+    </signal>
+    <signal name="UnitStateChanged">
+      <arg name="unit" type="s" />
+      <arg name="active_state" type="s" />
+      <arg name="sub_state" type="s" />
+      <arg name="reason" type="s" />
+    </signal>
     <signal name="UnitPropertiesChanged">
       <arg name="unit" type="s" />
       <arg name="props" type="a{sv}" />

--- a/doc/api-examples/get-cpuweight.py
+++ b/doc/api-examples/get-cpuweight.py
@@ -2,21 +2,20 @@
 
 import sys
 from dasbus.typing import get_native
+from dasbus.typing import Variant
 import dasbus.connection
 bus = dasbus.connection.SessionMessageBus()
 
-if len(sys.argv) != 5:
-    print("No node name, unit, interface and property supplied")
+if len(sys.argv) != 3:
+    print("No node name, unit supplied")
     sys.exit(1)
 
 node_name = sys.argv[1]
 unit_name = sys.argv[2]
-iface_name = sys.argv[3]
-property_name = sys.argv[4]
 
 manager = bus.get_proxy("org.containers.hirte",  "/org/containers/hirte")
 node_path = manager.GetNode(node_name)
 node = bus.get_proxy("org.containers.hirte",  node_path)
 
-val = node.GetUnitProperty(unit_name, iface_name, property_name)
-print(f"{property_name}: {get_native(val)}")
+value = node.GetUnitProperty(unit_name, "org.freedesktop.systemd1.Service", "CPUWeight")
+print(value)

--- a/doc/api-examples/get-unit-properties.py
+++ b/doc/api-examples/get-unit-properties.py
@@ -5,18 +5,21 @@ from dasbus.typing import get_native
 import dasbus.connection
 bus = dasbus.connection.SessionMessageBus()
 
-if len(sys.argv) != 5:
-    print("No node name, unit, interface and property supplied")
+if len(sys.argv) != 3:
+    print("No node name and unit supplied")
     sys.exit(1)
 
 node_name = sys.argv[1]
 unit_name = sys.argv[2]
-iface_name = sys.argv[3]
-property_name = sys.argv[4]
 
 manager = bus.get_proxy("org.containers.hirte",  "/org/containers/hirte")
 node_path = manager.GetNode(node_name)
 node = bus.get_proxy("org.containers.hirte",  node_path)
 
-val = node.GetUnitProperty(unit_name, iface_name, property_name)
-print(f"{property_name}: {get_native(val)}")
+properties = node.GetUnitProperties(unit_name, "org.freedesktop.systemd1.Unit")
+print("Unit properties:")
+print(get_native(properties))
+
+print("Service properties:")
+properties = node.GetUnitProperties(unit_name, "org.freedesktop.systemd1.Service")
+print(get_native(properties))

--- a/doc/api-examples/get-unit-property.py
+++ b/doc/api-examples/get-unit-property.py
@@ -16,10 +16,10 @@ manager = bus.get_proxy("org.containers.hirte",  "/org/containers/hirte")
 node_path = manager.GetNode(node_name)
 node = bus.get_proxy("org.containers.hirte",  node_path)
 
-properties = node.GetUnitProperties("org.freedesktop.systemd1.Unit", unit_name)
+properties = node.GetUnitProperties(unit_name, "org.freedesktop.systemd1.Unit")
 print("Unit properties:")
 print(get_native(properties))
 
 print("Service properties:")
-properties = node.GetUnitProperties("org.freedesktop.systemd1.Service", unit_name)
+properties = node.GetUnitProperties(unit_name, "org.freedesktop.systemd1.Service")
 print(get_native(properties))

--- a/doc/api-examples/get-unit-property.py
+++ b/doc/api-examples/get-unit-property.py
@@ -16,5 +16,10 @@ manager = bus.get_proxy("org.containers.hirte",  "/org/containers/hirte")
 node_path = manager.GetNode(node_name)
 node = bus.get_proxy("org.containers.hirte",  node_path)
 
-properties = node.GetUnitProperties(unit_name)
+properties = node.GetUnitProperties("org.freedesktop.systemd1.Unit", unit_name)
+print("Unit properties:")
+print(get_native(properties))
+
+print("Service properties:")
+properties = node.GetUnitProperties("org.freedesktop.systemd1.Service", unit_name)
 print(get_native(properties))

--- a/doc/api-examples/monitor-unit.py
+++ b/doc/api-examples/monitor-unit.py
@@ -49,6 +49,9 @@ def unit_property_changed(node, unit, props):
 def unit_new(node, unit, reason):
     print(f"New Unit {unit} on node {node}, reason: {reason}")
 
+def unit_state_changed(node, unit, active_state, substate, reason):
+    print(f"Unit {unit} on node {node}, changed to state: {active_state} ({substate}), reason: {reason}")
+
 def unit_removed(node, unit, reason):
     print(f"Removed Unit {unit} on node {node}, reason: {reason}")
     if node in old_values:
@@ -56,6 +59,7 @@ def unit_removed(node, unit, reason):
 
 monitor.UnitPropertiesChanged.connect(unit_property_changed)
 monitor.UnitNew.connect(unit_new)
+monitor.UnitStateChanged.connect(unit_state_changed)
 monitor.UnitRemoved.connect(unit_removed)
 
 monitor.Subscribe(node_name, unit_name);

--- a/doc/api-examples/monitor-unit.py
+++ b/doc/api-examples/monitor-unit.py
@@ -47,11 +47,13 @@ def unit_property_changed(node, unit, props):
     old_values[node] = new_value;
 
 def unit_new(node, unit):
-    print(f"New Unit {unit} on node {node}")
+    reason=""
+    print(f"New Unit {unit} on node {node}, reason: {reason}")
 
 def unit_removed(node, unit):
     print(f"Removed Unit {unit} on node {node}")
-    del old_values[node]
+    if node in old_values:
+        del old_values[node]
 
 monitor.UnitPropertiesChanged.connect(unit_property_changed)
 monitor.UnitNew.connect(unit_new)

--- a/doc/api-examples/monitor-unit.py
+++ b/doc/api-examples/monitor-unit.py
@@ -41,17 +41,16 @@ def unit_property_changed(node, unit, props):
     old_value = old_values.get(node, {})
     new_value = get_native(props)
 
-    print(f"Unit {unit} on node {node} changed::")
+    print(f"Unit {unit} on node {node} changed:")
     print_dict_changes(old_value, new_value)
 
     old_values[node] = new_value;
 
-def unit_new(node, unit):
-    reason=""
+def unit_new(node, unit, reason):
     print(f"New Unit {unit} on node {node}, reason: {reason}")
 
-def unit_removed(node, unit):
-    print(f"Removed Unit {unit} on node {node}")
+def unit_removed(node, unit, reason):
+    print(f"Removed Unit {unit} on node {node}, reason: {reason}")
     if node in old_values:
         del old_values[node]
 

--- a/doc/api-examples/monitor-unit.py
+++ b/doc/api-examples/monitor-unit.py
@@ -10,9 +10,7 @@ def print_dict_changes(old, new):
     for key in sorted(set(old.keys()) | set(new.keys())):
         if key not in old:
             print(f" {key}: {new[key]}")
-        elif key not in new:
-            print(f" {key}: deleted")
-        else:
+        elif key in new:
             o = old[key]
             n = new[key]
             if o != n:
@@ -37,14 +35,14 @@ monitor = bus.get_proxy("org.containers.hirte",  monitor_path)
 
 old_values = {}
 
-def unit_property_changed(node, unit, props):
+def unit_property_changed(node, unit, interface, props):
     old_value = old_values.get(node, {})
     new_value = get_native(props)
 
-    print(f"Unit {unit} on node {node} changed:")
+    print(f"Unit {unit} on node {node} changed for iface {interface}:")
     print_dict_changes(old_value, new_value)
 
-    old_values[node] = new_value;
+    old_values[node] = { **old_value, **new_value};
 
 def unit_new(node, unit, reason):
     print(f"New Unit {unit} on node {node}, reason: {reason}")

--- a/doc/api-examples/set-cpuweight.py
+++ b/doc/api-examples/set-cpuweight.py
@@ -2,21 +2,23 @@
 
 import sys
 from dasbus.typing import get_native
+from dasbus.typing import Variant
 import dasbus.connection
 bus = dasbus.connection.SessionMessageBus()
 
-if len(sys.argv) != 5:
-    print("No node name, unit, interface and property supplied")
+if len(sys.argv) != 4:
+    print("No node name, unit and value supplied")
     sys.exit(1)
 
 node_name = sys.argv[1]
 unit_name = sys.argv[2]
-iface_name = sys.argv[3]
-property_name = sys.argv[4]
+value = int(sys.argv[3])
+
+# Don't persist change
+runtime = True
 
 manager = bus.get_proxy("org.containers.hirte",  "/org/containers/hirte")
 node_path = manager.GetNode(node_name)
 node = bus.get_proxy("org.containers.hirte",  node_path)
 
-val = node.GetUnitProperty(unit_name, iface_name, property_name)
-print(f"{property_name}: {get_native(val)}")
+node.SetUnitProperties(unit_name, runtime, [("CPUWeight", Variant("t", value))])

--- a/doc/dbus-interfaces.md
+++ b/doc/dbus-interfaces.md
@@ -105,6 +105,13 @@ Object path: `/org/containers/hirte/monitor/$id`
     for a previously offline node and the unit was already running
     on the node.
 
+  * UnitStateChanged(s node, s unit, s active_state, s substate, s reason)
+
+    Emited when the active state (and substate) of a monitored unit
+    changes. Additionally, when a new subscription is added to a unit that
+    is already active, a virtual event is sent. This makes it very easy
+    to track the current active state of a unit.
+
   * UnitRemove(s node, s unit, s reason)
 
     Emitted when a unit is unloaded by systemd (reason=`real`), or

--- a/doc/dbus-interfaces.md
+++ b/doc/dbus-interfaces.md
@@ -94,9 +94,16 @@ Object path: `/org/containers/hirte/monitor/$id`
     emitted. Additionally it is emitted initially once for each matched unit. This allows you to easily monitor and get
     the current state in a race-free way without missing any changes.
 
-  * `UnitNew(s node, s unit)`
+  * UnitNew(s node, s unit, s reason)
 
-    Emitted when a new unit is created, for example when a service is started.
+    Emitted when a new unit is loaded by systemd, for example when a
+    service is started (reason=real), or if hirte learns of an
+    already loaded unit (reason=virtual).
+
+    The later can happen for two reasons, either hirte knows already
+    that the unit is loaded. Or, at a later time a new agent connects
+    for a previously offline node and the unit was already running
+    on the node.
 
   * `UnitRemove(s node, s unit)`
 

--- a/doc/dbus-interfaces.md
+++ b/doc/dbus-interfaces.md
@@ -88,7 +88,7 @@ Object path: `/org/containers/hirte/monitor/$id`
 
 * Signals:
 
-  * `UnitPropertiesChanged(s node, s unit, a{sv} props)`
+  * `UnitPropertiesChanged(s node, s unit, s interface, a{sv} props)`
 
     Whenever the properties changes for any of the units that are currently subscribed to changes, this signal is
     emitted. Additionally it is emitted initially once for each matched unit. This allows you to easily monitor and get
@@ -152,7 +152,7 @@ Object path: `/org/containers/hirte/node/$name`
 
     Kill a unit on the node. Arguments and semantics are equivalent to the systemd `KillUnit()` method.
 
-  * `GetUnitProperties(in name, out a{sv} props)`
+  * `GetUnitProperties(in interface, in name, out a{sv} props)`
 
     Returns the current properties for for a named unit on the node. The returned properties are the same as you would
     get in the systemd properties apis, but filtered to the following subset: `LoadState`, `ActiveState`, `SubState`,
@@ -275,7 +275,7 @@ This is the main interface that the node implements and that is used by the mana
 
     Forwards the job state property changes from systemd to the manager.
 
-  * `UnitPropertiesChanged(s unit, a{sv} props)`
+  * `UnitPropertiesChanged(s unit, s interface, a{sv} props)`
 
     This is equivalent to the Monitor signal, but for this node only. The same set of properties described there is
     supported here.

--- a/doc/dbus-interfaces.md
+++ b/doc/dbus-interfaces.md
@@ -152,7 +152,7 @@ Object path: `/org/containers/hirte/node/$name`
 
     Kill a unit on the node. Arguments and semantics are equivalent to the systemd `KillUnit()` method.
 
-  * `GetUnitProperties(in interface, in name, out a{sv} props)`
+  * `GetUnitProperties(in name, in interface, out a{sv} props)`
 
     Returns the current properties for for a named unit on the node. The returned properties are the same as you would
     get in the systemd properties apis, but filtered to the following subset: `LoadState`, `ActiveState`, `SubState`,

--- a/doc/dbus-interfaces.md
+++ b/doc/dbus-interfaces.md
@@ -96,18 +96,20 @@ Object path: `/org/containers/hirte/monitor/$id`
 
   * UnitNew(s node, s unit, s reason)
 
-    Emitted when a new unit is loaded by systemd, for example when a
-    service is started (reason=real), or if hirte learns of an
-    already loaded unit (reason=virtual).
+     Emitted when a new unit is loaded by systemd, for example when a
+     service is started (reason=`real`), or if hirte learns of an
+     already loaded unit (reason=`virtual`).
 
     The later can happen for two reasons, either hirte knows already
     that the unit is loaded. Or, at a later time a new agent connects
     for a previously offline node and the unit was already running
     on the node.
 
-  * `UnitRemove(s node, s unit)`
+  * UnitRemove(s node, s unit, s reason)
 
-    Emitted when a unit is removed.
+    Emitted when a unit is unloaded by systemd (reason=`real`), or
+    when the agent disconnects and we previously reported the unit
+    as loaded (reason=`virtual`).
 
 ### interface org.containers.hirte.Node
 

--- a/doc/dbus-interfaces.md
+++ b/doc/dbus-interfaces.md
@@ -152,11 +152,19 @@ Object path: `/org/containers/hirte/node/$name`
 
     Kill a unit on the node. Arguments and semantics are equivalent to the systemd `KillUnit()` method.
 
-  * `GetUnitProperties(in name, in interface, out a{sv} props)`
+  * `GetUnitProperties(in s name, in s interface, out a{sv} props)`
 
     Returns the current properties for for a named unit on the node. The returned properties are the same as you would
-    get in the systemd properties apis, but filtered to the following subset: `LoadState`, `ActiveState`, `SubState`,
-    `UnitFileState`, `LoadState`, `Result`.
+    get in the systemd properties apis.
+
+  * `GetUnitProperty(in s name, in s interface, in property, out v value)`
+
+    Get one named property, otherwise similar to GetUnitProperties
+
+  * `SetUnitProperties(in s name, in b runtime, in a(sv) keyvalues)`
+
+    Set named properties. If runtime is true the property changes do not persist across
+    reboots.
 
   * `ListUnits(out a(ssssssouso) units)`
 

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -529,7 +529,7 @@ static int agent_method_get_unit_properties(sd_bus_message *m, void *userdata, U
         const char *unit = NULL;
         _cleanup_free_ char *unit_path = NULL;
 
-        int r = sd_bus_message_read(m, "ss", &interface, &unit);
+        int r = sd_bus_message_read(m, "ss", &unit, &interface);
         if (r < 0) {
                 return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Internal Error");
         }

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -16,6 +16,10 @@
 #define DEBUG_SYSTEMD_MESSAGES 0
 #define DEBUG_SYSTEMD_MESSAGES_CONTENT 0
 
+typedef struct AgentUnitInfoKey {
+        char *object_path;
+} AgentUnitInfoKey;
+
 struct JobTracker {
         char *job_object_path;
         job_tracker_callback callback;
@@ -344,13 +348,13 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
 
 static void agent_update_unit_infos_for(Agent *agent, AgentUnitInfo *info) {
         if (!info->subscribed && !info->loaded) {
-                AgentUnitInfo key = { info->object_path, NULL, false, false };
+                AgentUnitInfoKey key = { info->object_path };
                 hashmap_delete(agent->unit_infos, &key);
         }
 }
 
 static AgentUnitInfo *agent_get_unit_info(Agent *agent, const char *unit_path) {
-        AgentUnitInfo key = { (char *) unit_path, NULL, false, false };
+        AgentUnitInfoKey key = { (char *) unit_path };
 
         return hashmap_get(agent->unit_infos, &key);
 }

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -627,7 +627,7 @@ static void agent_job_done(UNUSED sd_bus_message *m, const char *result, void *u
         AgentJobOp *op = userdata;
         Agent *agent = op->agent;
 
-        hirte_log_debugf("Sending notification JobDone with results: %s", result);
+        hirte_log_debugf("Sending JobDone %u, result: %s", op->hirte_job_id, result);
 
         int r = sd_bus_emit_signal(
                         agent->peer_dbus,
@@ -746,6 +746,7 @@ static int agent_method_reload_unit(sd_bus_message *m, void *userdata, UNUSED sd
  ************************************************************************/
 
 static void agent_emit_unit_new(Agent *agent, AgentUnitInfo *info, const char *reason) {
+        hirte_log_debugf("Sending UnitNew %s, reason: %s", info->unit, reason);
         int r = sd_bus_emit_signal(
                         agent->peer_dbus,
                         INTERNAL_AGENT_OBJECT_PATH,
@@ -760,6 +761,8 @@ static void agent_emit_unit_new(Agent *agent, AgentUnitInfo *info, const char *r
 }
 
 static void agent_emit_unit_removed(Agent *agent, AgentUnitInfo *info) {
+        hirte_log_debugf("Sending UnitRemoved %s", info->unit);
+
         int r = sd_bus_emit_signal(
                         agent->peer_dbus,
                         INTERNAL_AGENT_OBJECT_PATH,
@@ -773,6 +776,12 @@ static void agent_emit_unit_removed(Agent *agent, AgentUnitInfo *info) {
 }
 
 static void agent_emit_unit_state_changed(Agent *agent, AgentUnitInfo *info, const char *reason) {
+        hirte_log_debugf(
+                        "Sending UnitStateChanged %s %s(%s) reason: %s",
+                        info->unit,
+                        active_state_to_string(info->active_state),
+                        unit_info_get_substate(info),
+                        reason);
         int r = sd_bus_emit_signal(
                         agent->peer_dbus,
                         INTERNAL_AGENT_OBJECT_PATH,
@@ -1003,6 +1012,8 @@ static int agent_match_unit_changed(sd_bus_message *m, void *userdata, UNUSED sd
         /* Rewind and skip to copy content again */
         (void) sd_bus_message_rewind(m, true);
         (void) sd_bus_message_skip(m, "s"); // re-skip interface
+
+        hirte_log_debugf("Sending UnitPropertiesChanged %s", info->unit);
 
         /* Forward the property changes */
         _cleanup_sd_bus_message_ sd_bus_message *sig = NULL;

--- a/src/agent/agent.h
+++ b/src/agent/agent.h
@@ -55,8 +55,15 @@ struct Agent {
 
         LIST_HEAD(JobTracker, tracked_jobs);
 
-        struct hashmap *unit_subscriptions;
+        struct hashmap *unit_infos;
 };
+
+typedef struct AgentUnitInfo {
+        char *object_path; /* key */
+        char *unit;
+        bool subscribed;
+} AgentUnitInfo;
+
 
 Agent *agent_new(void);
 Agent *agent_ref(Agent *agent);

--- a/src/agent/agent.h
+++ b/src/agent/agent.h
@@ -63,6 +63,8 @@ typedef struct AgentUnitInfo {
         char *unit;
         bool subscribed;
         bool loaded;
+        UnitActiveState active_state;
+        char *substate;
 } AgentUnitInfo;
 
 

--- a/src/agent/agent.h
+++ b/src/agent/agent.h
@@ -62,6 +62,7 @@ typedef struct AgentUnitInfo {
         char *object_path; /* key */
         char *unit;
         bool subscribed;
+        bool loaded;
 } AgentUnitInfo;
 
 

--- a/src/libhirte/bus/utils.h
+++ b/src/libhirte/bus/utils.h
@@ -5,6 +5,11 @@
 
 #include "libhirte/common/common.h"
 
+/* return < 0 for error, 0 to continue, 1 to stop, 2 to continue and skip (if value was not consumed) */
+typedef int (*bus_property_cb)(const char *key, const char *value_type, sd_bus_message *m, void *userdata);
+
+int bus_parse_properties_foreach(sd_bus_message *m, bus_property_cb cb, void *userdata);
+
 int bus_parse_property_string(sd_bus_message *m, const char *name, const char **value);
 char *bus_path_escape(const char *str);
 

--- a/src/libhirte/common/protocol.c
+++ b/src/libhirte/common/protocol.c
@@ -19,3 +19,26 @@ JobState job_state_from_string(const char *s) {
         }
         return JOB_INVALID;
 }
+
+static const char * const unit_active_state_table[_UNIT_ACTIVE_STATE_MAX] = {
+        [UNIT_ACTIVE] = "active",           [UNIT_RELOADING] = "reloading",
+        [UNIT_INACTIVE] = "inactive",       [UNIT_FAILED] = "failed",
+        [UNIT_ACTIVATING] = "activating",   [UNIT_DEACTIVATING] = "deactivating",
+        [UNIT_MAINTENANCE] = "maintenance",
+};
+
+const char *active_state_to_string(UnitActiveState s) {
+        if (s >= 0 && s < _UNIT_ACTIVE_STATE_MAX) {
+                return unit_active_state_table[s];
+        }
+        return "invalid";
+}
+
+UnitActiveState active_state_from_string(const char *s) {
+        for (int i = 0; i < _UNIT_ACTIVE_STATE_MAX; i++) {
+                if (streq(unit_active_state_table[i], s)) {
+                        return i;
+                }
+        }
+        return _UNIT_ACTIVE_STATE_INVALID;
+}

--- a/src/libhirte/common/protocol.h
+++ b/src/libhirte/common/protocol.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "errno.h"
+
 #define HIRTE_DEFAULT_PORT 808 /* TODO: Pick a better default */
 
 #define HIRTE_DBUS_NAME "org.containers.hirte"
@@ -61,6 +63,21 @@ typedef enum JobState {
 
 const char *job_state_to_string(JobState s);
 JobState job_state_from_string(const char *s);
+
+typedef enum UnitActiveState {
+        UNIT_ACTIVE,
+        UNIT_RELOADING,
+        UNIT_INACTIVE,
+        UNIT_FAILED,
+        UNIT_ACTIVATING,
+        UNIT_DEACTIVATING,
+        UNIT_MAINTENANCE,
+        _UNIT_ACTIVE_STATE_MAX,
+        _UNIT_ACTIVE_STATE_INVALID = -EINVAL,
+} UnitActiveState;
+
+const char *active_state_to_string(UnitActiveState s);
+UnitActiveState active_state_from_string(const char *s);
 
 /* Agent to Hirte heartbeat signals */
 

--- a/src/libhirte/log/log.c
+++ b/src/libhirte/log/log.c
@@ -80,10 +80,17 @@ int hirte_log_to_stderr_with_location(
         timebuf[strftime(timebuf, sizeof(timebuf), "%H:%M:%S", localtime(&t))] = '\0';
 
         // clang-format off
-        fprintf(stderr, "%s %s\t%s:%s %s\tmsg=\"%s\", data=\"%s\"\n", 
-                timebuf, log_level_to_string(lvl), 
-                file, line, func,
-                msg, data);
+        if (data && *data) {
+                fprintf(stderr, "%s %s\t%s:%s %s\tmsg=\"%s\", data=\"%s\"\n",
+                        timebuf, log_level_to_string(lvl),
+                        file, line, func,
+                        msg, data);
+        } else {
+                fprintf(stderr, "%s %s\t%s:%s %s\tmsg=\"%s\"\n",
+                        timebuf, log_level_to_string(lvl),
+                        file, line, func,
+                        msg);
+        }
         // clang-format on
         return 0;
 }

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -151,12 +151,12 @@ void manager_add_subscription(Manager *manager, Subscription *sub) {
 
         if (*sub->node == 0) {
                 LIST_FOREACH(nodes, node, manager->nodes) {
-                        node_subscribe(node, sub->unit);
+                        node_subscribe(node, sub);
                 }
         } else {
                 node = manager_find_node(manager, sub->node);
                 if (node) {
-                        node_subscribe(node, sub->unit);
+                        node_subscribe(node, sub);
                 } else {
                         hirte_log_errorf("Warning: Subscription to non-existing node %s", sub->node);
                 }
@@ -170,12 +170,12 @@ void manager_remove_subscription(Manager *manager, Subscription *sub) {
 
         if (*sub->node == 0) {
                 LIST_FOREACH(nodes, node, manager->nodes) {
-                        node_unsubscribe(node, sub->unit);
+                        node_unsubscribe(node, sub);
                 }
         } else {
                 node = manager_find_node(manager, sub->node);
                 if (node) {
-                        node_unsubscribe(node, sub->unit);
+                        node_unsubscribe(node, sub);
                 }
         }
 

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -95,57 +95,6 @@ void manager_unref(Manager *manager) {
         free(manager);
 }
 
-void manager_unit_properties_changed(Manager *manager, const char *node, sd_bus_message *m) {
-        const char *unit = NULL;
-
-        int r = sd_bus_message_read(m, "s", &unit);
-        if (r >= 0) {
-                r = sd_bus_message_rewind(m, false);
-        }
-        if (r < 0) {
-                hirte_log_error("Invalid UnitPropertiesChanged signal");
-                return;
-        }
-
-        Subscription *sub = NULL;
-        LIST_FOREACH(all_subscriptions, sub, manager->all_subscriptions) {
-                if ((*sub->node == 0 || streq(sub->node, node)) && streq(sub->unit, unit)) {
-                        r = monitor_emit_unit_property_changed(sub->monitor, node, unit, m);
-                        if (r < 0) {
-                                hirte_log_error("Failed to emit UnitPropertiesChanged signal");
-                                return;
-                        }
-                }
-        }
-}
-
-void manager_unit_new(Manager *manager, const char *node, const char *unit) {
-        Subscription *sub = NULL;
-        LIST_FOREACH(all_subscriptions, sub, manager->all_subscriptions) {
-                if ((*sub->node == 0 || streq(sub->node, node)) && streq(sub->unit, unit)) {
-                        int r = monitor_emit_unit_new(sub->monitor, node, unit);
-                        if (r < 0) {
-                                hirte_log_error("Failed to emit UnitNew signal");
-                                return;
-                        }
-                }
-        }
-}
-
-void manager_unit_removed(Manager *manager, const char *node, const char *unit) {
-        Subscription *sub = NULL;
-        LIST_FOREACH(all_subscriptions, sub, manager->all_subscriptions) {
-                if ((*sub->node == 0 || streq(sub->node, node)) && streq(sub->unit, unit)) {
-                        int r = monitor_emit_unit_removed(sub->monitor, node, unit);
-                        if (r < 0) {
-                                hirte_log_error("Failed to emit UnitRemoved signal");
-                                return;
-                        }
-                }
-        }
-}
-
-
 void manager_add_subscription(Manager *manager, Subscription *sub) {
         Node *node = NULL;
 

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -70,25 +70,29 @@ void manager_unref(Manager *manager) {
         sd_bus_unrefp(&manager->api_bus);
 
         Node *node = NULL;
-        LIST_FOREACH(nodes, node, manager->nodes) {
+        Node *next_node = NULL;
+        LIST_FOREACH_SAFE(nodes, node, next_node, manager->nodes) {
                 node_unref(node);
         }
-        LIST_FOREACH(nodes, node, manager->anonymous_nodes) {
+        LIST_FOREACH_SAFE(nodes, node, next_node, manager->anonymous_nodes) {
                 node_unref(node);
         }
 
         Job *job = NULL;
-        LIST_FOREACH(jobs, job, manager->jobs) {
+        Job *next_job = NULL;
+        LIST_FOREACH_SAFE(jobs, job, next_job, manager->jobs) {
                 job_unref(job);
         }
 
         Subscription *sub = NULL;
-        LIST_FOREACH(all_subscriptions, sub, manager->all_subscriptions) {
+        Subscription *next_sub = NULL;
+        LIST_FOREACH_SAFE(all_subscriptions, sub, next_sub, manager->all_subscriptions) {
                 subscription_unref(sub);
         }
 
         Monitor *monitor = NULL;
-        LIST_FOREACH(monitors, monitor, manager->monitors) {
+        Monitor *next_monitor = NULL;
+        LIST_FOREACH_SAFE(monitors, monitor, next_monitor, manager->monitors) {
                 monitor_unref(monitor);
         }
 

--- a/src/manager/manager.h
+++ b/src/manager/manager.h
@@ -55,9 +55,6 @@ void manager_remove_monitor(Manager *manager, Monitor *monitor);
 
 void manager_add_subscription(Manager *manager, Subscription *sub);
 void manager_remove_subscription(Manager *manager, Subscription *sub);
-void manager_unit_properties_changed(Manager *manager, const char *node, sd_bus_message *m);
-void manager_unit_new(Manager *manager, const char *node, const char *unit);
-void manager_unit_removed(Manager *manager, const char *node, const char *unit);
 
 DEFINE_CLEANUP_FUNC(Manager, manager_unref)
 #define _cleanup_manager_ _cleanup_(manager_unrefp)

--- a/src/manager/monitor.c
+++ b/src/manager/monitor.c
@@ -259,16 +259,30 @@ int monitor_emit_unit_property_changed(Monitor *monitor, const char *node, const
         return sd_bus_message_rewind(m, false);
 }
 
-int monitor_emit_unit_new(Monitor *monitor, const char *node, const char *unit) {
+int monitor_emit_unit_new(Monitor *monitor, const char *node, const char *unit, const char *reason) {
         Manager *manager = monitor->manager;
 
         return sd_bus_emit_signal(
-                        manager->api_bus, monitor->object_path, MONITOR_INTERFACE, "UnitNew", "ss", node, unit);
+                        manager->api_bus,
+                        monitor->object_path,
+                        MONITOR_INTERFACE,
+                        "UnitNew",
+                        "sss",
+                        node,
+                        unit,
+                        reason);
 }
 
-int monitor_emit_unit_removed(Monitor *monitor, const char *node, const char *unit) {
+int monitor_emit_unit_removed(Monitor *monitor, const char *node, const char *unit, const char *reason) {
         Manager *manager = monitor->manager;
 
         return sd_bus_emit_signal(
-                        manager->api_bus, monitor->object_path, MONITOR_INTERFACE, "UnitRemoved", "ss", node, unit);
+                        manager->api_bus,
+                        monitor->object_path,
+                        MONITOR_INTERFACE,
+                        "UnitRemoved",
+                        "sss",
+                        node,
+                        unit,
+                        reason);
 }

--- a/src/manager/monitor.c
+++ b/src/manager/monitor.c
@@ -61,6 +61,12 @@ static const sd_bus_vtable monitor_vtable[] = {
                         SD_BUS_PARAM(node) SD_BUS_PARAM(unit) SD_BUS_PARAM(properties),
                         0),
         SD_BUS_SIGNAL_WITH_NAMES("UnitNew", "ss", SD_BUS_PARAM(node) SD_BUS_PARAM(unit), 0),
+        SD_BUS_SIGNAL_WITH_NAMES(
+                        "UnitStateChanged",
+                        "sssss",
+                        SD_BUS_PARAM(node) SD_BUS_PARAM(unit) SD_BUS_PARAM(active_state)
+                                        SD_BUS_PARAM(substate) SD_BUS_PARAM(reason),
+                        0),
         SD_BUS_SIGNAL_WITH_NAMES("UnitRemoved", "ss", SD_BUS_PARAM(node) SD_BUS_PARAM(unit), 0),
         SD_BUS_VTABLE_END
 };
@@ -270,6 +276,28 @@ int monitor_emit_unit_new(Monitor *monitor, const char *node, const char *unit, 
                         "sss",
                         node,
                         unit,
+                        reason);
+}
+
+int monitor_emit_unit_state_changed(
+                Monitor *monitor,
+                const char *node,
+                const char *unit,
+                const char *active_state,
+                const char *substate,
+                const char *reason) {
+        Manager *manager = monitor->manager;
+
+        return sd_bus_emit_signal(
+                        manager->api_bus,
+                        monitor->object_path,
+                        MONITOR_INTERFACE,
+                        "UnitStateChanged",
+                        "sssss",
+                        node,
+                        unit,
+                        active_state,
+                        substate,
                         reason);
 }
 

--- a/src/manager/monitor.h
+++ b/src/manager/monitor.h
@@ -45,7 +45,8 @@ void monitor_close(Monitor *monitor);
 
 bool monitor_export(Monitor *monitor);
 
-int monitor_emit_unit_property_changed(Monitor *monitor, const char *node, const char *unit, sd_bus_message *m);
+int monitor_emit_unit_property_changed(
+                Monitor *monitor, const char *node, const char *unit, const char *interface, sd_bus_message *m);
 int monitor_emit_unit_new(Monitor *monitor, const char *node, const char *unit, const char *reason);
 int monitor_emit_unit_state_changed(
                 Monitor *monitor,
@@ -55,7 +56,6 @@ int monitor_emit_unit_state_changed(
                 const char *substate,
                 const char *reason);
 int monitor_emit_unit_removed(Monitor *monitor, const char *node, const char *unit, const char *reason);
-
 
 DEFINE_CLEANUP_FUNC(Monitor, monitor_unref)
 #define _cleanup_monitor_ _cleanup_(monitor_unrefp)

--- a/src/manager/monitor.h
+++ b/src/manager/monitor.h
@@ -46,8 +46,8 @@ void monitor_close(Monitor *monitor);
 bool monitor_export(Monitor *monitor);
 
 int monitor_emit_unit_property_changed(Monitor *monitor, const char *node, const char *unit, sd_bus_message *m);
-int monitor_emit_unit_new(Monitor *monitor, const char *node, const char *unit);
-int monitor_emit_unit_removed(Monitor *monitor, const char *node, const char *unit);
+int monitor_emit_unit_new(Monitor *monitor, const char *node, const char *unit, const char *reason);
+int monitor_emit_unit_removed(Monitor *monitor, const char *node, const char *unit, const char *reason);
 
 
 DEFINE_CLEANUP_FUNC(Monitor, monitor_unref)

--- a/src/manager/monitor.h
+++ b/src/manager/monitor.h
@@ -47,6 +47,13 @@ bool monitor_export(Monitor *monitor);
 
 int monitor_emit_unit_property_changed(Monitor *monitor, const char *node, const char *unit, sd_bus_message *m);
 int monitor_emit_unit_new(Monitor *monitor, const char *node, const char *unit, const char *reason);
+int monitor_emit_unit_state_changed(
+                Monitor *monitor,
+                const char *node,
+                const char *unit,
+                const char *active_state,
+                const char *substate,
+                const char *reason);
 int monitor_emit_unit_removed(Monitor *monitor, const char *node, const char *unit, const char *reason);
 
 

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -202,8 +202,9 @@ static int node_match_unit_new(sd_bus_message *m, void *userdata, UNUSED sd_bus_
         Node *node = userdata;
         Manager *manager = node->manager;
         const char *unit = NULL;
+        const char *reason = NULL;
 
-        int r = sd_bus_message_read(m, "s", &unit);
+        int r = sd_bus_message_read(m, "ss", &unit, &reason);
         if (r < 0) {
                 hirte_log_error("Invalid UnitNew signal");
                 return 0;

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -853,7 +853,7 @@ static int node_method_get_unit_properties(sd_bus_message *m, void *userdata, UN
         const char *interface = NULL;
         const char *unit = NULL;
 
-        int r = sd_bus_message_read(m, "ss", &interface, &unit);
+        int r = sd_bus_message_read(m, "ss", &unit, &interface);
         if (r < 0) {
                 return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Internal Error");
         }
@@ -868,7 +868,7 @@ static int node_method_get_unit_properties(sd_bus_message *m, void *userdata, UN
                 return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Internal error");
         }
 
-        r = sd_bus_message_append(req->message, "ss", interface, unit);
+        r = sd_bus_message_append(req->message, "ss", unit, interface);
         if (r < 0) {
                 return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Internal error");
         }

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -65,6 +65,10 @@ typedef struct {
         bool loaded;
 } UnitSubscriptions;
 
+typedef struct {
+        char *unit;
+} UnitSubscriptionsKey;
+
 static void unit_subscriptions_clear(void *item) {
         UnitSubscriptions *usub = item;
         free(usub->unit);
@@ -212,7 +216,7 @@ static int node_match_unit_properties_changed(sd_bus_message *m, void *userdata,
                 return 0;
         }
 
-        const UnitSubscriptions key = { (char *) unit, NULL, false };
+        const UnitSubscriptionsKey key = { (char *) unit };
         UnitSubscriptions *usubs = NULL;
 
         usubs = hashmap_get(node->unit_subscriptions, &key);
@@ -243,7 +247,7 @@ static int node_match_unit_new(sd_bus_message *m, void *userdata, UNUSED sd_bus_
                 return 0;
         }
 
-        const UnitSubscriptions key = { (char *) unit, NULL, false };
+        const UnitSubscriptionsKey key = { (char *) unit };
         UnitSubscriptions *usubs = NULL;
 
         usubs = hashmap_get(node->unit_subscriptions, &key);
@@ -274,7 +278,7 @@ static int node_match_unit_removed(sd_bus_message *m, void *userdata, UNUSED sd_
                 return 0;
         }
 
-        const UnitSubscriptions key = { (char *) unit, NULL, false };
+        const UnitSubscriptionsKey key = { (char *) unit };
         UnitSubscriptions *usubs = NULL;
 
         usubs = hashmap_get(node->unit_subscriptions, &key);
@@ -1007,7 +1011,7 @@ static void node_send_agent_subscribe_all(Node *node) {
 }
 
 void node_subscribe(Node *node, Subscription *sub) {
-        const UnitSubscriptions key = { (char *) sub->unit, NULL, false };
+        const UnitSubscriptionsKey key = { sub->unit };
         UnitSubscriptions *usubs = NULL;
 
         _cleanup_free_ UnitSubscription *usub = malloc0(sizeof(UnitSubscription));
@@ -1051,7 +1055,7 @@ void node_subscribe(Node *node, Subscription *sub) {
 }
 
 void node_unsubscribe(Node *node, Subscription *sub) {
-        UnitSubscriptions key = { (char *) sub->unit, NULL, false };
+        UnitSubscriptionsKey key = { sub->unit };
         UnitSubscriptions *usubs = NULL;
         UnitSubscription *usub = NULL;
         UnitSubscription *found = NULL;

--- a/src/manager/node.h
+++ b/src/manager/node.h
@@ -62,8 +62,8 @@ void node_unset_agent_bus(Node *node);
 AgentRequest *node_request_list_units(
                 Node *node, agent_request_response_t cb, void *userdata, free_func_t free_userdata);
 
-void node_subscribe(Node *node, const char *unit);
-void node_unsubscribe(Node *node, const char *unit);
+void node_subscribe(Node *node, Subscription *sub);
+void node_unsubscribe(Node *node, Subscription *sub);
 
 DEFINE_CLEANUP_FUNC(Node, node_unref)
 #define _cleanup_node_ _cleanup_(node_unrefp)


### PR DESCRIPTION
As discussed in https://github.com/containers/hirte/issues/138, our current setup for events is not ideal. 

For example, its not easy to track the current known state of a service (i.e. is is running atm). 
We only get events when the state changes, so you have to combine two operations like first "is it currently running", and then set up a monitor of changes to this. Not only is this more work, it is also potentially racy and with tricky ordering. Additionally this is not the whole truth, because at any time a node could go offline and then we may lose events about the changes to the state. It might be possible to handle this by also listening for node state events and then trying to recreate state on connect, but all this way to complex.

With this change we add a new type of signal for "state change" which is emitted whenever the active state (running or not) changes. In addition, we always keep track of the current known state of this in the agent and manager, which allows us to generate virtual events so that a monitor can easily know the latest state. 

For example, the first time a unit is monitored the agent emits a virtual state change, and while there are any monitors for the unit the manager keeps track of the latest state. This means any time we add a new unit to a monitor we will get a virual event saying the unit is running if it was already running. No need for getting the current state first. In addition, when an agent goes offline we synthesize a virutal state change to not running, and when it reconnects a new virual state change to running.

This is very useful to clients, but in addition it matches exactly what we need to implement proxy service state tracking.

This also tweaks the get property methods a bit and adds a way to set properties.



