### PR TITLE
Add clangd configuration for meson builds

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: builddir/       # Search builddir/ directory for compile_commands.json produced by meson


### PR DESCRIPTION
clangd by default searches for `compile_commands.json` in the `build`
directory, but for meson we are using `builddir`, so we need to update
configuration for clangd (without this for example C language support
in vscodium doesn't work).

Signed-off-by: Martin Perina <mperina@redhat.com>
