### PR TITLE
New un-overwriable conf file with deafult values

### DIFF
--- a/config/hirte-default.conf
+++ b/config/hirte-default.conf
@@ -1,0 +1,23 @@
+# That file provides you with all the default values possible 
+# and explanation .That file cannot be overwritten if you want 
+# to overwrite the default values please do it in the hirte.conf
+#  and hirte-agent.conf files.
+
+[Manager] # This is default values for manager node that can be changed in hirte-agent.conf 
+Port=2020 # Port to run on. Possible values int
+# Nodes=foo,bar // Example of how to add hirte agend nodes for the manager to connect with. Possiable values ip, str(sqdn)
+
+[Logging] # Logging configuration can be change on both file hirte.conf and hirte-agent.conf
+Level=DEBUG # The level of loggin. Possiable values str[DEBUG, INFO, WARN, ERROR, INVALID]
+Target=stderr # The output file for the logs. Possiable values str
+Quiet=false # Configure the loggin to be quiet or not. Possiable values str[true, false]
+
+# Another examples for your usage
+#
+# [Node foo] // This is an example of how to add configurations to added foo node for manger node. This values can be change in hirte.conf
+# Ip=1.2.3.4 // Sets the ip of the node . Possiable values str(ip or sqdn)
+#
+# [Node] // creates Node for the manger to work with. Can be change in hirte-agent.conf 
+# Name=foo // Sets a name for the node so the manager will differ between diffrent nodes. Possiable values str
+# Host=127.0.0.1 // Sets an ip to work with. Possiable values str(ip or sqdn) 
+# Port=2020 // Sets a port to run on. Pssiable values int

--- a/config/meson.build
+++ b/config/meson.build
@@ -7,3 +7,8 @@ install_data(
   'hirte-agent.conf',
   install_dir :  get_option('sysconfdir')
 )
+
+install_data(
+  'hirte-default.conf',
+  install_dir :  '/usr/share'
+)

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -302,8 +302,18 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
         _cleanup_config_ config *config = NULL;
         topic *topic = NULL;
         const char *name = NULL, *host = NULL, *port = NULL;
+        char * default_conf = "/usr/share/hirte_default.conf";
+        config = parsing_ini_file(default_conf, NULL);
+        if (config == NULL) {
+                return false;
+        }
 
-        config = parsing_ini_file(configfile);
+        if( configfile == NULL) {
+                config = parsing_ini_file("/etc/hirte_agent.conf", config);
+
+        } else {
+                config = parsing_ini_file(configfile, config);
+        }
         if (config == NULL) {
                 return false;
         }

--- a/src/agent/main.c
+++ b/src/agent/main.c
@@ -74,10 +74,8 @@ int main(int argc, char *argv[]) {
         }
 
         /* First load config */
-        if (opt_config) {
-                if (!agent_parse_config(agent, opt_config)) {
-                        return EXIT_FAILURE;
-                }
+        if (!agent_parse_config(agent, opt_config)) {
+                return EXIT_FAILURE;
         }
 
         /* Then override individual options */

--- a/src/libhirte/ini/config.c
+++ b/src/libhirte/ini/config.c
@@ -151,8 +151,10 @@ config *new_config(void) {
 /* Get the file path
     if it can't find the or can't parse the path it will return configurationOrch
     with nulls else will return configurationOrch with all the data */
-config *parsing_ini_file(const char *file) {
-        config *config = new_config();
+config *parsing_ini_file(const char *file, config *config) {
+        if (config == NULL) {
+                config = new_config();
+        }
         if (config == NULL) {
                 return NULL; /* oom */
         }

--- a/src/libhirte/ini/config.h
+++ b/src/libhirte/ini/config.h
@@ -6,7 +6,7 @@ typedef struct hashmap config;
 typedef struct topic topic;
 
 
-config *parsing_ini_file(const char *file);
+config *parsing_ini_file(const char *file, config *config);
 config *new_config(void);
 void free_config(config *config);
 void free_configp(config **configp);

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -316,7 +316,18 @@ bool manager_parse_config(Manager *manager, const char *configfile) {
         topic *topic = NULL;
         const char *port = NULL;
 
-        config = parsing_ini_file(configfile);
+               char * default_conf = "/usr/share/hirte_default.conf";
+        config = parsing_ini_file(default_conf, NULL);
+        if (config == NULL) {
+                return false;
+        }
+
+        if( configfile == NULL) {
+                config = parsing_ini_file("/etc/hirte.conf", config);
+
+        } else {
+                config = parsing_ini_file(configfile, config);
+        }
         if (config == NULL) {
                 return false;
         }


### PR DESCRIPTION
Adding hirte-default.conf file with all the necessary defaults and in addition, I added some examples that can be useful for the user. This file cannot be
overwritten itself but its values will be overwritten by hirte.conf and hirte-agent.conf