### PR TITLE
Check SPDX license header in source codes

### DIFF
--- a/.automation/build-rpm.sh
+++ b/.automation/build-rpm.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -xe
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 source $(dirname "$(readlink -f "$0")")/build-srpm.sh
 

--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -xe
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 # Package version
 VERSION="0.0.1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,10 @@ jobs:
           # Use githash of a tested commit instead of merge commit
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Check SPDX headers
+        run: |
+          ./build-tools/spdx-header-chech.sh
+
       - name: Running source code format check
         run: |
           make check-fmt

--- a/build-tools/spdx-header-chech.sh
+++ b/build-tools/spdx-header-chech.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/bash -e
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 # Checked files regex
-CHECKED_FILES=".*\(\.c\|\.h\|\.xml\|meson\.build\)"
+CHECKED_FILES=".*\(\.c\|\.h\|\.sh\|\.xml\|meson\.build\)"
 
 #
 # List of licenses which are OK when found in a source code

--- a/build-tools/spdx-header-chech.sh
+++ b/build-tools/spdx-header-chech.sh
@@ -9,6 +9,8 @@ CHECKED_FILES="*.[c|h]"
 APPROVED_LICENSES=""
 # Used for hirte original code
 APPROVED_LICENSES="${APPROVED_LICENSES} GPL-2.0-or-later"
+# Used in src/libhirte/common/list.h
+APPROVED_LICENSES="${APPROVED_LICENSES} LGPL-2.1-or-later"
 
 
 result=0

--- a/build-tools/spdx-header-chech.sh
+++ b/build-tools/spdx-header-chech.sh
@@ -11,6 +11,8 @@ APPROVED_LICENSES=""
 APPROVED_LICENSES="${APPROVED_LICENSES} GPL-2.0-or-later"
 # Used in src/libhirte/common/list.h
 APPROVED_LICENSES="${APPROVED_LICENSES} LGPL-2.1-or-later"
+# Used in src/libhirte/ini/
+APPROVED_LICENSES="${APPROVED_LICENSES} BSD-3-Clause"
 
 
 result=0

--- a/build-tools/spdx-header-chech.sh
+++ b/build-tools/spdx-header-chech.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/bash -e
+
+# Checked files regex
+CHECKED_FILES="*.[c|h]"
+
+#
+# List of licenses which are OK when found in a source code
+#
+APPROVED_LICENSES=""
+
+
+result=0
+found_files="$(find -type f -name ${CHECKED_FILES} -not -path './builddir/*')"
+
+for f in ${found_files} ; do
+    # scan for license only within the 1st 5 lines of each file
+    license_found=$(head -n 5 ${f} | grep -Po '.*SPDX-License-Identifier\: \K\S+' || echo "-1")
+    if [ "${license_found}" == "-1" ]; then
+        result=1
+        echo "File '${f}' does not contain SPDX header!"
+    else
+        valid_license=1
+        for l in ${APPROVED_LICENSES} ; do
+            if [ "${license_found}" == "$l" ] ; then
+                valid_license=0
+            fi
+        done
+        if [ "${valid_license}" == "1" ] ; then
+            result=1
+            echo "File '${f}' contains unapproved license '${license_found}'"
+        fi
+    fi
+done
+
+exit ${result}

--- a/build-tools/spdx-header-chech.sh
+++ b/build-tools/spdx-header-chech.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash -e
 
 # Checked files regex
-CHECKED_FILES="*.[c|h]"
+CHECKED_FILES=".*\.\(c\|h\|xml\)"
 
 #
 # List of licenses which are OK when found in a source code
@@ -18,7 +18,11 @@ APPROVED_LICENSES="${APPROVED_LICENSES} MIT"
 
 
 result=0
-found_files="$(find -type f -name ${CHECKED_FILES} -not -path './builddir/*')"
+found_files="
+    $(find -type f -regex ${CHECKED_FILES} \
+        -not -path './builddir/*' \
+        -not -path './doc/arch/*')
+"
 
 for f in ${found_files} ; do
     # scan for license only within the 1st 5 lines of each file

--- a/build-tools/spdx-header-chech.sh
+++ b/build-tools/spdx-header-chech.sh
@@ -13,6 +13,8 @@ APPROVED_LICENSES="${APPROVED_LICENSES} GPL-2.0-or-later"
 APPROVED_LICENSES="${APPROVED_LICENSES} LGPL-2.1-or-later"
 # Used in src/libhirte/ini/
 APPROVED_LICENSES="${APPROVED_LICENSES} BSD-3-Clause"
+# Used in src/libhirte/hasmap/
+APPROVED_LICENSES="${APPROVED_LICENSES} MIT"
 
 
 result=0

--- a/build-tools/spdx-header-chech.sh
+++ b/build-tools/spdx-header-chech.sh
@@ -7,6 +7,8 @@ CHECKED_FILES="*.[c|h]"
 # List of licenses which are OK when found in a source code
 #
 APPROVED_LICENSES=""
+# Used for hirte original code
+APPROVED_LICENSES="${APPROVED_LICENSES} GPL-2.0-or-later"
 
 
 result=0

--- a/build-tools/spdx-header-chech.sh
+++ b/build-tools/spdx-header-chech.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash -e
 
 # Checked files regex
-CHECKED_FILES=".*\.\(c\|h\|xml\)"
+CHECKED_FILES=".*\(\.c\|\.h\|\.xml\|meson\.build\)"
 
 #
 # List of licenses which are OK when found in a source code

--- a/config/meson.build
+++ b/config/meson.build
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 install_data(
   'hirte.conf',
   install_dir : get_option('sysconfdir')

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,10 +1,12 @@
-# Installing the public DBus API 
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Installing the public DBus API
 install_data(
     'org.containers.hirte.Job.xml',
     'org.containers.hirte.Manager.xml',
     'org.containers.hirte.Monitor.xml',
     'org.containers.hirte.Node.xml',
-    install_dir: join_paths(get_option('datadir'), 'dbus-1', 'interfaces'), 
+    install_dir: join_paths(get_option('datadir'), 'dbus-1', 'interfaces'),
 )
 
 # Installing the DBus permission configuration files
@@ -19,13 +21,13 @@ conf.set('dbus_srv_user', dbus_srv_user)
 
 configure_file(
     output: 'org.containers.hirte.conf',
-    input: 'org.containers.hirte.conf.in', 
+    input: 'org.containers.hirte.conf.in',
     configuration: conf,
     install_dir: dbus_service_dir,
 )
 configure_file(
     output: 'org.containers.hirte.Agent.conf',
-    input: 'org.containers.hirte.Agent.conf.in', 
+    input: 'org.containers.hirte.Agent.conf.in',
     configuration: conf,
     install_dir: dbus_service_dir,
 )

--- a/data/org.containers.hirte.Job.xml
+++ b/data/org.containers.hirte.Job.xml
@@ -1,4 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
 <node>
   <interface name="org.containers.hirte.Job">
     <method name="Cancel" />

--- a/data/org.containers.hirte.Manager.xml
+++ b/data/org.containers.hirte.Manager.xml
@@ -1,4 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
 <node>
   <interface name="org.containers.hirte.Manager">
     <method name="ListUnits">

--- a/data/org.containers.hirte.Monitor.xml
+++ b/data/org.containers.hirte.Monitor.xml
@@ -1,4 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
 <node>
   <interface name="org.freedesktop.systemd1.Manager">
     <method name="Close" />

--- a/data/org.containers.hirte.Node.xml
+++ b/data/org.containers.hirte.Node.xml
@@ -1,4 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
 <node>
   <interface name="org.containers.hirte.Node">
     <method name="StartUnit">

--- a/data/org.containers.hirte.internal.Agent.xml
+++ b/data/org.containers.hirte.internal.Agent.xml
@@ -1,4 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
 <node>
   <interface name="org.containers.hirte.internal.Agent">
     <method name="StartUnit">

--- a/data/org.containers.hirte.internal.Manager.xml
+++ b/data/org.containers.hirte.internal.Manager.xml
@@ -1,4 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
 <node>
   <interface name="org.containers.hirte.internal.Manager">
     <method name="Register">

--- a/data/org.containers.hirte.internal.Proxy.xml
+++ b/data/org.containers.hirte.internal.Proxy.xml
@@ -1,4 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
 <node>
   <interface name="org.containers.hirte.internal.Proxy">
     <method name="Ready">

--- a/doc/man/meson.build
+++ b/doc/man/meson.build
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 want_man = get_option('man') == 'true'
 md2man = find_program('go-md2man', required : false)
 if want_man and not md2man.found()

--- a/meson.build
+++ b/meson.build
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 project(
   'hirte',
   'c',

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <arpa/inet.h>
 #include <errno.h>
 

--- a/src/agent/agent.h
+++ b/src/agent/agent.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include <netinet/in.h>

--- a/src/agent/main.c
+++ b/src/agent/main.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <errno.h>
 #include <getopt.h>
 #include <stdio.h>

--- a/src/agent/meson.build
+++ b/src/agent/meson.build
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 # node build configuration
 
 node_src = [

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <errno.h>
 
 #include "client.h"

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include "libhirte/bus/utils.h"

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <errno.h>
 #include <getopt.h>
 #include <stdlib.h>

--- a/src/client/meson.build
+++ b/src/client/meson.build
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 # client build configuration
 
 client_src = [

--- a/src/client/printer.c
+++ b/src/client/printer.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <stdio.h>
 
 #include "libhirte/bus/utils.h"

--- a/src/client/printer.h
+++ b/src/client/printer.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include "types.h"

--- a/src/client/types.h
+++ b/src/client/types.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 typedef struct Client Client;

--- a/src/libhirte/bus/bus.c
+++ b/src/libhirte/bus/bus.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <arpa/inet.h>
 #include <errno.h>
 

--- a/src/libhirte/bus/bus.h
+++ b/src/libhirte/bus/bus.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include <netinet/in.h>

--- a/src/libhirte/bus/utils.c
+++ b/src/libhirte/bus/utils.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <errno.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>

--- a/src/libhirte/bus/utils.h
+++ b/src/libhirte/bus/utils.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include <stdint.h>

--- a/src/libhirte/common/common.h
+++ b/src/libhirte/common/common.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include <stdlib.h>

--- a/src/libhirte/common/event-util.c
+++ b/src/libhirte/common/event-util.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/libhirte/common/event-util.h
+++ b/src/libhirte/common/event-util.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include <stdbool.h>

--- a/src/libhirte/common/opt.h
+++ b/src/libhirte/common/opt.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #define ARG_PORT "port"

--- a/src/libhirte/common/parse-util.c
+++ b/src/libhirte/common/parse-util.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <errno.h>
 #include <limits.h>
 #include <stdlib.h>

--- a/src/libhirte/common/parse-util.h
+++ b/src/libhirte/common/parse-util.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include <inttypes.h>

--- a/src/libhirte/common/protocol.c
+++ b/src/libhirte/common/protocol.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include "common.h"
 
 const char *job_state_to_string(JobState s) {

--- a/src/libhirte/common/protocol.h
+++ b/src/libhirte/common/protocol.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include "errno.h"

--- a/src/libhirte/hashmap/hashmap.c
+++ b/src/libhirte/hashmap/hashmap.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT */
 // Copyright 2020 Joshua J Baker. All rights reserved.
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/src/libhirte/hashmap/hashmap.h
+++ b/src/libhirte/hashmap/hashmap.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT */
 // Copyright 2020 Joshua J Baker. All rights reserved.
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/src/libhirte/ini/config.c
+++ b/src/libhirte/ini/config.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <assert.h>
 #include <stdlib.h>
 

--- a/src/libhirte/ini/config.h
+++ b/src/libhirte/ini/config.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include "libhirte/hashmap/hashmap.h"

--- a/src/libhirte/log/log.c
+++ b/src/libhirte/log/log.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <errno.h>
 
 #include "libhirte/common/common.h"

--- a/src/libhirte/log/log.h
+++ b/src/libhirte/log/log.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include <systemd/sd-journal.h>

--- a/src/libhirte/meson.build
+++ b/src/libhirte/meson.build
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 libhirte_src = [
     'bus/bus.c',
     'bus/bus.h',

--- a/src/libhirte/service/service.c
+++ b/src/libhirte/service/service.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include "service.h"
 #include "libhirte/common/common.h"
 #include "libhirte/log/log.h"

--- a/src/libhirte/service/service.h
+++ b/src/libhirte/service/service.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 char *assemble_interface_name(char *name_postfix);

--- a/src/libhirte/service/shutdown.c
+++ b/src/libhirte/service/shutdown.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <errno.h>
 #include <systemd/sd-bus-vtable.h>
 

--- a/src/libhirte/service/shutdown.h
+++ b/src/libhirte/service/shutdown.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include <stdbool.h>

--- a/src/libhirte/socket.c
+++ b/src/libhirte/socket.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <errno.h>
 #include <netinet/in.h>
 #include <stdio.h>

--- a/src/libhirte/socket.h
+++ b/src/libhirte/socket.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include <inttypes.h>

--- a/src/libhirte/test/list_test.c
+++ b/src/libhirte/test/list_test.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <stdio.h>
 
 #include "libhirte/common/common.h"

--- a/src/libhirte/test/meson.build
+++ b/src/libhirte/test/meson.build
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 # common test configuration
 
 list_src = [

--- a/src/libhirte/test/parse-util_test.c
+++ b/src/libhirte/test/parse-util_test.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/src/manager/job.c
+++ b/src/manager/job.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <stddef.h>
 
 #include "job.h"

--- a/src/manager/job.h
+++ b/src/manager/job.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include "libhirte/common/common.h"

--- a/src/manager/main.c
+++ b/src/manager/main.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <errno.h>
 #include <getopt.h>
 #include <stdlib.h>

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include <string.h>
 
 #include "libhirte/bus/bus.h"

--- a/src/manager/manager.h
+++ b/src/manager/manager.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include <inttypes.h>

--- a/src/manager/meson.build
+++ b/src/manager/meson.build
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 # orch build configuration
 
 orch_src = [

--- a/src/manager/monitor.c
+++ b/src/manager/monitor.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include "libhirte/log/log.h"
 
 #include "job.h"

--- a/src/manager/monitor.h
+++ b/src/manager/monitor.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include "libhirte/common/common.h"

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include "libhirte/bus/utils.h"
 #include "libhirte/log/log.h"
 

--- a/src/manager/node.h
+++ b/src/manager/node.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 #include "libhirte/common/common.h"

--- a/src/manager/types.h
+++ b/src/manager/types.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
 typedef struct Manager Manager;


### PR DESCRIPTION
Each source file should contain SPDX license header to clearly identify
the license it's published with.
More information about SPDX can be found at:

* https://opensource.com/article/18/1/spdx-and-licensing
* https://spdx.dev/

This PR adds checking SPDX headers in C, shell, XML and meson.build files.

Signed-off-by: Martin Perina <mperina@redhat.com>
