### PR TITLE
Add support for automatic COPR builds

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,8 @@
+.PHONY: installdeps srpm
+
+installdeps:
+	dnf -y install git
+
+srpm: installdeps
+	./.automation/build-srpm.sh
+	cp rpmbuild/SRPMS/*.src.rpm $(outdir)


### PR DESCRIPTION
Adds support for automatic COPR builds using the `make srpm` method.

Signed-off-by: Martin Perina <mperina@redhat.com>
