### PR TITLE
Add support for conf.d configuration files

### DIFF
--- a/config/agent.conf.d/README.md
+++ b/config/agent.conf.d/README.md
@@ -1,0 +1,9 @@
+# agent configuration directory
+
+This directory is used for user configuration of `hirte-agent`.
+Each configuration file should end with `.conf` suffix, otherwise it's ignored.
+Configuration files from this directory are loaded by alphabetical order,
+configuration from a file loaded later overwrites the previous configuration.
+
+It's suggested to name configuration files using `<NN>-<FILE NAME>.conf` template,
+where `<NN>` is a number, for example `95-debug-logging.conf`.

--- a/config/hirte.conf.d/README.md
+++ b/config/hirte.conf.d/README.md
@@ -1,0 +1,9 @@
+# hirte configuration directory
+
+This directory is used for user configuration of `hirte`.
+Each configuration file should end with `.conf` suffix, otherwise it's ignored.
+Configuration files from this directory are loaded by alphabetical order,
+configuration from a file loaded later overwrites the previous configuration.
+
+It's suggested to name configuration files using `<NN>-<FILE NAME>.conf`template,
+where `<NN>` is a number, for example `95-debug-logging.conf`.

--- a/config/meson.build
+++ b/config/meson.build
@@ -14,3 +14,13 @@ install_data(
   'hirte/hirte-default.conf',
   install_dir : join_paths(get_option('datadir'), 'hirte', 'config')
 )
+
+install_data(
+  'agent.conf.d/README.md',
+  install_dir :  join_paths(get_option('sysconfdir') / 'hirte' / 'agent.conf.d')
+)
+
+install_data(
+  'hirte.conf.d/README.md',
+  install_dir :  join_paths(get_option('sysconfdir') / 'hirte' / 'hirte.conf.d')
+)

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -31,6 +31,8 @@ This package contains the controller and command line tool.
 
 %files
 %config(noreplace) %{_sysconfdir}/hirte/hirte.conf
+%dir %{_sysconfdir}/hirte
+%dir %{_sysconfdir}/hirte/hirte.conf.d
 %doc README.md
 %doc README.developer.md
 %license LICENSE
@@ -43,6 +45,7 @@ This package contains the controller and command line tool.
 %{_datadir}/hirte/config/hirte-default.conf
 %{_mandir}/man1/hirte.*
 %{_mandir}/man5/hirte.conf.*
+%{_sysconfdir}/hirte/hirte.conf.d/README.md
 %{_unitdir}/hirte.service
 %{_unitdir}/hirte.socket
 
@@ -68,6 +71,8 @@ This package contains the node agent.
 
 %files agent
 %config(noreplace) %{_sysconfdir}/hirte/agent.conf
+%dir %{_sysconfdir}/hirte
+%dir %{_sysconfdir}/hirte/agent.conf.d
 %doc README.md
 %license LICENSE
 %{_bindir}/hirte-agent
@@ -78,6 +83,7 @@ This package contains the node agent.
 %{_mandir}/man1/hirte-agent.*
 %{_mandir}/man1/hirte-proxy.*
 %{_mandir}/man5/hirte-agent.conf.*
+%{_sysconfdir}/hirte/agent.conf.d/README.md
 %{_unitdir}/hirte-agent.service
 %{_userunitdir}/hirte-agent.service
 %{_unitdir}/hirte-proxy@.service
@@ -122,4 +128,3 @@ This package contains the service controller command line tool.
 %changelog
 * Tue Mar 21 2023 Martin Perina <mperina@redhat.com> - 0.1.0-1
 - Initial release
-

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -478,9 +478,10 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
                         agent->config,
                         CFG_AGENT_DEFAULT_CONFIG,
                         CFG_ETC_HIRTE_AGENT_CONF,
-                        NULL); // TODO: https://github.com/containers/hirte/issues/148
-        if (result != 0 && result != -ENOENT) {
-                fprintf(stderr, "Error loading configuration: '%s'.\n", strerror(-result));
+                        CFG_ETC_AGENT_CONF_DIR);
+        if (result != 0) {
+                fprintf(stderr, "Error loading configuration: '%s'.", strerror(-result));
+                cfg_dispose(agent->config);
                 return false;
         }
 

--- a/src/libhirte/common/cfg.h
+++ b/src/libhirte/common/cfg.h
@@ -45,6 +45,8 @@ typedef struct config config;
 #define CFG_ETC_HIRTE_AGENT_CONF CONFIG_H_SYSCONFDIR "/hirte/agent.conf"
 #define CFG_AGENT_DEFAULT_CONFIG CONFIG_H_DATADIR "/hirte-agent/config/hirte-default.conf"
 #define CFG_HIRTE_DEFAULT_CONFIG CONFIG_H_DATADIR "/hirte/config/hirte-default.conf"
+#define CFG_ETC_AGENT_CONF_DIR CONFIG_H_SYSCONFDIR "/hirte/agent.conf.d"
+#define CFG_ETC_HIRTE_CONF_DIR CONFIG_H_SYSCONFDIR "/hirte/hirte.conf.d"
 
 /*
  * An item in a configuration map
@@ -92,6 +94,14 @@ int cfg_load_complete_configuration(
  * Returns 0 if successful, otherwise standard error code.
  */
 int cfg_load_from_file(struct config *config, const char *config_file);
+
+
+/*
+ * Load the application configuration from files inside the specified directory and override any existing options values.
+ *
+ * Returns 0 if successful, otherwise standard error code.
+ */
+int cfg_load_from_dir(struct config *config, const char *custom_config_directory);
 
 /*
  * Load the application configuration from the predefined environment variables and override any existing

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -280,15 +280,10 @@ bool manager_parse_config(Manager *manager, const char *configfile) {
         }
 
         result = cfg_load_complete_configuration(
-                        manager->config,
-                        CFG_HIRTE_DEFAULT_CONFIG,
-                        CFG_ETC_HIRTE_CONF,
-                        NULL); // TODO: https://github.com/containers/hirte/issues/148
-        if (result != 0 && result != -ENOENT) {
-                fprintf(stderr,
-                        "Error loading configuration '%s': '%s'.\n",
-                        CFG_ETC_HIRTE_CONF,
-                        strerror(-result));
+                        manager->config, CFG_HIRTE_DEFAULT_CONFIG, CFG_ETC_HIRTE_CONF, CFG_ETC_HIRTE_CONF_DIR);
+        if (result != 0) {
+                fprintf(stderr, "Error loading configuration '%s'.", strerror(result));
+                cfg_dispose(manager->config);
                 return false;
         }
 


### PR DESCRIPTION
This is a follow-up of #147 where it's suggested to use /etc/hirte/hirte.conf and /etc/hirte/agent.conf as configuration files, which could be modified by users to specify custom options.

But for automation it's not easy to parse current configuration file and save a new one with modified values, it would be much easier to use conf.d directory with custom user configuration files.

Here is the suggestion for the whole configuration files lineup for hirte manager:

    /usr/share/hirte/config/hirte-default.conf
        The base configuration file provided project defaults, which should not be modified by users
    /etc/hirte/hirte.conf
        The configurations file, where users can modified default values
    /etc/hirte/hirte.conf.d/
        Configuration directory where users might insert a configuration file (for example 99-custom-logging.conf)
        Only files with .conf suffix are used to load configuration changes
        Files in this directory are loaded in alphabetical order, so it's suggested to use number prefix to ease understanding of loading (for example 95-my-manager.conf and 99-custom-logging.conf)

Similar structure should be used also for hirte-agent:

    /usr/share/hirte-agent/config/hirte-default.conf
    /etc/hirte/agent.conf
    /etc/hirte/agent.conf.d/

Using above configuration files structure should also change the order of loading configurations files during hirte/hirte-agent startup:

    1)Load the default configuration values from /usr/share and store them to the configuration hash map
    2)Load user customizations from /etc/hirte/{hirte|agent}.conf and overwrite updated values in the configuration hash map
    3)Load user customizations files from /etc/hirte/{hirte|agent}.conf.d/ by alphabetical order and overwrite updated values in the configuration hash map
    4)Check if all required options have a valid value

Fixes: #148
Signed-off-by: Artiom Divak adivak@redhat.com