### PR TITLE
meson: Default the api bus to system

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,7 +28,7 @@ jobs:
           podman run --rm --name hirte-builder \
           -v  ${PWD}:/hirte:Z -it \
           registry.gitlab.com/centos/automotive/sample-images/hirte/hirte-builder:1.0.0 \
-          /bin/bash -c "rm -rf builddir; meson setup builddir; \
+          /bin/bash -c "rm -rf builddir; meson setup builddir -Dapi_bus=user; \
           meson install -C builddir --destdir bin"
           podman build -f tests/Containerfile -t hirte-image .
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,5 @@
 option('api_bus', type: 'combo', 
-    choices: ['user', 'system'], value: 'user', 
+    choices: ['user', 'system'], value: 'system',
     description: 'The D-Bus daemon on which the public hirte API is provided')
 
 option('man', type : 'combo', 


### PR DESCRIPTION
This is how we will run in production, so it should be the default. Using the user bus is really just a helper for development.