### PR TITLE
Mention that AllowedNodeNames is mandatory option

### DIFF
--- a/config/hirte/hirte.conf
+++ b/config/hirte/hirte.conf
@@ -5,3 +5,9 @@
 #
 
 [hirte]
+
+#
+# A comma separated list of unique hirte-agent names. Only nodes with names mentioned in the list can connect to
+# hirte manager. These names are defined in the agent's configuration file under `NodeName` option
+# (see `hirte-agent.conf(5)`).
+AllowedNodeNames=

--- a/doc/man/hirte.conf.5.md
+++ b/doc/man/hirte.conf.5.md
@@ -19,11 +19,11 @@ All fields to bootstrap the hirte manager are contained in the **hirte** section
 
 #### **ManagerPort** (uint16_t)
 
-The port the manager listens on to establish connections with the `hirte-agents`.
+The port the manager listens on to establish connections with the `hirte-agent`.
 
 #### **AllowedNodeNames** (string)
 
-A comma separated list of unique hirte-agent names. Only node names mentioned in the list can connect to `hirte`.
+A comma separated list of unique hirte-agent names. Only nodes with names mentioned in the list can connect to `hirte` manager. These names are defined in the agent's configuration file under `NodeName` option (see `hirte-agent.conf(5)`).
 
 #### **LogLevel** (string)
 


### PR DESCRIPTION
1. Mention AllowedNodeNames option in `/etc/hirte/hirte.conf`, so it's
   more visible that it needs to be set properly
2. Unify AllowedNodeNames documentation between `hirte.conf` man page
   and `hirte-default.conf` configuration file.

Signed-off-by: Martin Perina <mperina@redhat.com>
