### PR TITLE
Load initial config file with the default values

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -9,3 +9,15 @@ install_data(
   'agent/agent.conf',
   install_dir :  get_option('sysconfdir') / 'hirte'
 )
+
+install_data(
+  'agent/hirte-default.conf',
+  install_dir : join_paths(get_option('datadir'), 'hirte-agent', 'config')
+)
+
+install_data(
+  'hirte/hirte-default.conf',
+  install_dir : join_paths(get_option('datadir'), 'hirte', 'config')
+)
+
+

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -78,6 +78,7 @@ This package contains the node agent.
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Manager.xml
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Monitor.xml
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Node.xml
+%{_datadir}/hirte/config/hirte-default.conf
 %{_mandir}/man1/hirte.*
 %{_mandir}/man1/hirtectl.*
 %{_mandir}/man5/hirte.conf.*
@@ -89,6 +90,7 @@ This package contains the node agent.
 %doc README.md
 %license LICENSE
 %{_bindir}/hirte-agent
+%{_datadir}/hirte-agent/config/hirte-default.conf
 %{_mandir}/man1/hirte-agent.*
 %{_mandir}/man5/hirte-agent.conf.*
 %{_sysconfdir}/dbus-1/system.d/org.containers.hirte.Agent.conf

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -404,7 +404,7 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
 
         result = cfg_load_complete_configuration(
                         agent->config,
-                        NULL, // TODO: https://github.com/containers/hirte/issues/147
+                        CFG_AGENT_DEFAULT_CONFIG,
                         CFG_ETC_HIRTE_AGENT_CONF,
                         NULL); // TODO: https://github.com/containers/hirte/issues/148
         if (result != 0) {

--- a/src/libhirte/common/cfg.h
+++ b/src/libhirte/common/cfg.h
@@ -41,6 +41,8 @@ typedef struct config config;
  */
 #define CFG_ETC_HIRTE_CONF CONFIG_H_SYSCONFDIR "/hirte/hirte.conf"
 #define CFG_ETC_HIRTE_AGENT_CONF CONFIG_H_SYSCONFDIR "/hirte/agent.conf"
+#define CFG_AGENT_DEFAULT_CONFIG CONFIG_H_DATADIR "/hirte-agent/config/hirte-default.conf"
+#define CFG_HIRTE_DEFAULT_CONFIG CONFIG_H_DATADIR "/hirte/config/hirte-default.conf"
 
 /*
  * An item in a configuration map

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -278,7 +278,7 @@ bool manager_parse_config(Manager *manager, const char *configfile) {
 
         result = cfg_load_complete_configuration(
                         manager->config,
-                        NULL, // TODO: https://github.com/containers/hirte/issues/147
+                        CFG_HIRTE_DEFAULT_CONFIG,
                         CFG_ETC_HIRTE_CONF,
                         NULL); // TODO: https://github.com/containers/hirte/issues/148
         if (result != 0) {


### PR DESCRIPTION
For a full description please read here
https://github.com/containers/hirte/issues/147.
For each of the node types [hirte, agent] hirte
will get the default config from the default
files located in /usr/shar/hirte/{hirte|agent}
into the hashmap and only after that it will
get the custome config that the usr changed

Fixes: https://github.com/containers/hirte/issues/147