### PR TITLE
Load project version from version.sh

### DIFF
--- a/build-scripts/build-srpm.sh
+++ b/build-scripts/build-srpm.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -xe
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# Package version
-VERSION="0.0.1"
+# Package version - loaded from version.sh
+VERSION="$("$(dirname "$(readlink -f "$0")")"/version.sh)"
 
 # Mark current directory as safe for git to be able to parse git hash
 git config --global --add safe.directory $(pwd)

--- a/build-scripts/version.sh
+++ b/build-scripts/version.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Project version
+VERSION="0.1.0"
+
+echo ${VERSION}

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@
 project(
   'hirte',
   'c',
-  version: '0.0.1',
+  version: run_command('./build-scripts/version.sh', check: true).stdout().strip(),
   license: 'GPL-2.0-or-later',
   default_options: [
     'c_std=gnu17',     # Adds "-std=gnu17".  Includes GNU 17 extensions.


### PR DESCRIPTION
Introduce script `version.sh`, which holds project version and can be
reused for both meson and RPM package build without having the version
definition on both places.

Alternative approach to https://github.com/containers/hirte/pull/199
