### PR TITLE
Parse project version from meson

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,7 +1,7 @@
 .PHONY: installdeps srpm
 
 installdeps:
-	dnf -y install git
+	dnf -y install gcc git jq meson
 
 srpm: installdeps
 	./build-scripts/build-srpm.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,10 +81,14 @@ jobs:
           dnf install \
                   createrepo_c \
                   dnf-utils \
+                  gcc \
                   git \
                   gzip \
+                  jq \
+                  meson \
                   rpm-build \
                   sed \
+                  systemd-devel \
                   tar \
                   golang-github-cpuguy83-md2man \
               -y

--- a/build-scripts/build-srpm.sh
+++ b/build-scripts/build-srpm.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -xe
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# Package version
-VERSION="0.0.1"
+# Parse package version from the project
+meson setup builddir
+VERSION="$(meson introspect --projectinfo builddir | jq -r '.version')"
 
 # Mark current directory as safe for git to be able to parse git hash
 git config --global --add safe.directory $(pwd)

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@
 project(
   'hirte',
   'c',
-  version: '0.0.1',
+  version: '0.1.0',
   license: 'GPL-2.0-or-later',
   default_options: [
     'c_std=gnu17',     # Adds "-std=gnu17".  Includes GNU 17 extensions.


### PR DESCRIPTION
Let's have the project version defined in `meson.build` and parse the
from during packaging to use that version also for RPM package.

Alternative approach to https://github.com/containers/hirte/pull/198
