### PR TITLE
Agent - allow the user to set the agent address - ManagerAddress

### DIFF
--- a/doc/example-hirte-agent.ini
+++ b/doc/example-hirte-agent.ini
@@ -4,6 +4,7 @@
 NodeName=foo
 ManagerHost=127.0.0.1
 ManagerPort=2020
+ManagerAddress=tcp:host=127.0.0.1,port=2020
 LogLevel=DEBUG
 LogTarget=stderr
 LogIsQuiet=false

--- a/doc/man/hirte-agent.1.md
+++ b/doc/man/hirte-agent.1.md
@@ -30,6 +30,11 @@ The host used by `hirte-agent` to connect to `hirte`. Must be a valid IPv4 or IP
 
 The port on which `hirte` is listening for connection request and the `hirte-agent` is connecting to. This option will overwrite the port defined in the configuration file.
 
+#### **--address**, **-a**
+
+DBus address used by `hirte-agent` to connect to `hirte`. See `man sd_bus_set_address` for its format.
+Overrides any setting of `ManagerHost` or `ManagerPort` defined in the configuration file as well as the respective CLI options.
+
 #### **--name**, **-n**
 
 The unique name of this `hirte-agent` used for registering at `hirte`. This option will overwrite the port defined in the configuration file.

--- a/doc/man/hirte-agent.conf.5.md
+++ b/doc/man/hirte-agent.conf.5.md
@@ -21,6 +21,11 @@ All fields to bootstrap the hirte-agent are contained in the **hirte-agent** sec
 
 The unique name of this agent.
 
+#### **ManagerAddress** (string)
+
+SD Bus address used by `hirte-agent` to connect to `hirte`. See `man sd_bus_set_address` for its format.
+Overrides any setting of `ManagerHost` or `ManagerPort` defined in the configuration file as well as the respective CLI options.
+
 #### **ManagerHost** (string)
 
 The host used by `hirte-agent` to connect to `hirte`. Must be a valid IPv4 or IPv6.

--- a/src/agent/agent.h
+++ b/src/agent/agent.h
@@ -87,6 +87,7 @@ void agent_unref(Agent *agent);
 
 bool agent_set_port(Agent *agent, const char *port);
 bool agent_set_host(Agent *agent, const char *host);
+bool agent_set_orch_address(Agent *agent, const char *address);
 bool agent_set_name(Agent *agent, const char *name);
 bool agent_parse_config(Agent *agent, const char *configfile);
 

--- a/src/agent/main.c
+++ b/src/agent/main.c
@@ -12,20 +12,23 @@
 
 const struct option options[] = { { ARG_HOST, required_argument, 0, ARG_HOST_SHORT },
                                   { ARG_PORT, required_argument, 0, ARG_PORT_SHORT },
+                                  { ARG_ADDRESS, required_argument, 0, ARG_ADDRESS_SHORT },
                                   { ARG_NAME, required_argument, 0, ARG_NAME_SHORT },
                                   { ARG_CONFIG, required_argument, 0, ARG_CONFIG_SHORT },
                                   { ARG_HELP, no_argument, 0, ARG_HELP_SHORT },
                                   { NULL, 0, 0, '\0' } };
 
-#define OPTIONS_STR ARG_PORT_SHORT_S ARG_HOST_SHORT_S ARG_HELP_SHORT_S ARG_CONFIG_SHORT_S ARG_NAME_SHORT_S
+#define OPTIONS_STR \
+        ARG_PORT_SHORT_S ARG_HOST_SHORT_S ARG_ADDRESS_SHORT_S ARG_HELP_SHORT_S ARG_CONFIG_SHORT_S ARG_NAME_SHORT_S
 
 static const char *opt_port = 0;
 static const char *opt_host = NULL;
+static const char *opt_address = NULL;
 static const char *opt_name = NULL;
 static const char *opt_config = NULL;
 
 static void usage(char *argv[]) {
-        printf("Usage: %s [-H host] [-p port] [-c config] [-n name]\n", argv[0]);
+        printf("Usage: %s [-H host] [-p port] [-a address] [-c config] [-n name]\n", argv[0]);
 }
 
 static int get_opts(int argc, char *argv[]) {
@@ -43,6 +46,10 @@ static int get_opts(int argc, char *argv[]) {
 
                 case ARG_HOST_SHORT:
                         opt_host = optarg;
+                        break;
+
+                case ARG_ADDRESS_SHORT:
+                        opt_address = optarg;
                         break;
 
                 case ARG_CONFIG_SHORT:
@@ -86,6 +93,10 @@ int main(int argc, char *argv[]) {
         }
 
         if (opt_host && !agent_set_host(agent, opt_host)) {
+                return EXIT_FAILURE;
+        }
+
+        if (opt_address && !agent_set_orch_address(agent, opt_address)) {
                 return EXIT_FAILURE;
         }
 

--- a/src/libhirte/bus/utils.c
+++ b/src/libhirte/bus/utils.c
@@ -278,10 +278,23 @@ char *bus_path_escape(const char *s) {
         return r;
 }
 
+static bool is_socket_tcp(int fd) {
+        int type = 0;
+        socklen_t length = sizeof(int);
+
+        getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &type, &length);
+
+        return type == AF_INET || type == AF_INET6;
+}
+
 int bus_socket_set_no_delay(sd_bus *bus) {
         int fd = sd_bus_get_fd(bus);
         if (fd < 0) {
                 return fd;
+        }
+
+        if (!is_socket_tcp(fd)) {
+                return 0;
         }
 
         int flag = 1;
@@ -297,6 +310,10 @@ int bus_socket_set_keepalive(sd_bus *bus) {
         int fd = sd_bus_get_fd(bus);
         if (fd < 0) {
                 return fd;
+        }
+
+        if (!is_socket_tcp(fd)) {
+                return 0;
         }
 
         int flag = 1;

--- a/src/libhirte/common/cfg.h
+++ b/src/libhirte/common/cfg.h
@@ -13,6 +13,7 @@
 #define CFG_LOG_IS_QUIET "LogIsQuiet"
 #define CFG_MANAGER_HOST "ManagerHost"
 #define CFG_MANAGER_PORT "ManagerPort"
+#define CFG_MANAGER_ADDRESS "ManagerAddress"
 #define CFG_NODE_NAME "NodeName"
 #define CFG_ALLOWED_NODE_NAMES "AllowedNodeNames"
 

--- a/src/libhirte/common/common.c
+++ b/src/libhirte/common/common.c
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+bool copy_str(char **p, const char *s) {
+        char *dup = strdup(s);
+        if (dup == NULL) {
+                return false;
+        }
+        free(*p);
+        *p = dup;
+        return true;
+}

--- a/src/libhirte/common/common.h
+++ b/src/libhirte/common/common.h
@@ -104,3 +104,5 @@ static inline char *strcat_dup(const char *a, const char *b) {
 #define _cleanup_sd_bus_slot_ _cleanup_(sd_bus_slot_unrefp)
 #define _cleanup_sd_bus_message_ _cleanup_(sd_bus_message_unrefp)
 #define _cleanup_sd_bus_error_ _cleanup_(sd_bus_error_free)
+
+bool copy_str(char **p, const char *s);

--- a/src/libhirte/common/opt.h
+++ b/src/libhirte/common/opt.h
@@ -9,6 +9,10 @@
 #define ARG_HOST_SHORT 'H'
 #define ARG_HOST_SHORT_S "H:"
 
+#define ARG_ADDRESS "address"
+#define ARG_ADDRESS_SHORT 'a'
+#define ARG_ADDRESS_SHORT_S "a:"
+
 #define ARG_CONFIG "config"
 #define ARG_CONFIG_SHORT 'c'
 #define ARG_CONFIG_SHORT_S "c:"

--- a/src/libhirte/meson.build
+++ b/src/libhirte/meson.build
@@ -7,6 +7,7 @@ libhirte_src = [
     'bus/utils.h',
     'common/cfg.c',
     'common/cfg.h',
+    'common/common.c',
     'common/common.h',
     'common/event-util.c',
     'common/event-util.h',


### PR DESCRIPTION
Add a configuration flag in both the config file and command line arguments for setting the hirte bus address If the address is set via config or arguments use it instead of host and port

Add the configuration flag to the example config file Update the man page for the executable to conf file