### PR TITLE
Add systemd-devel and rpm-build to copr installdep

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,7 +1,7 @@
 .PHONY: installdeps srpm
 
 installdeps:
-	dnf -y install gcc git jq meson
+	dnf -y install gcc git jq meson systemd-devel rpm-build
 
 srpm: installdeps
 	./build-scripts/build-srpm.sh


### PR DESCRIPTION
PR #199  introduced a build time dependency in systemd-devel. While it updated the build.yml GH Action, it did not add it to the COPR Makefile.

In addition, this change adds the rpm-build to the dependencies in order to allow running the makefile locally