### PR TITLE
Use port 842 in hirte

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: run hirte containers
         run: |
-          podman run -d --net podman --rm -p 2020:2020 --name hirte-mgr \
+          podman run -d --net podman --rm -p 8420:8420 --name hirte-mgr \
           $(podman images *hirte-image --format {{.ID}})
           podman run -d --net podman --rm --name hirte-node-bar \
           $(podman images *hirte-image --format {{.ID}})
@@ -50,7 +50,7 @@ jobs:
                bash -c   "sed -i \"s/\(AllowedNodeNames=\)\(.*\)/\1foo,bar/\" /etc/hirte/hirte.conf"
           podman exec -it hirte-mgr \
                bash -c "cat >> /etc/hirte/hirte.conf << _EOF
-          ManagerPort=2020
+          ManagerPort=8420
           LogLevel=DEBUG
           _EOF"
           podman exec -it hirte-mgr \
@@ -64,7 +64,7 @@ jobs:
                bash -c "sed -i \"s/\(NodeName=\)\(.*\)/\1bar/\" /etc/hirte/agent.conf"
           podman exec -it hirte-node-bar \
                bash -c "cat >> /etc/hirte/agent.conf << _EOF
-          ManagerPort=2020
+          ManagerPort=8420
           LogLevel=DEBUG
           _EOF"
           # TODO: Remove when journald logging is fixed
@@ -83,7 +83,7 @@ jobs:
                bash -c "sed -i \"s/\(NodeName=\)\(.*\)/\1foo/\" /etc/hirte/agent.conf"
           podman exec -it hirte-node-foo \
                bash -c "cat >> /etc/hirte/agent.conf << _EOF
-          ManagerPort=2020
+          ManagerPort=8420
           LogLevel=DEBUG
           _EOF"
           # TODO: Remove when journald logging is fixed

--- a/config/agent/hirte-default.conf
+++ b/config/agent/hirte-default.conf
@@ -14,7 +14,7 @@ ManagerHost=
 #
 # The port the manager listens on to establish connections with the hirte
 # agents.
-ManagerPort=2020
+ManagerPort=842
 
 #
 # The level used for logging. Supported values are: DEBUG, INFO, WARN and ERROR.

--- a/config/hirte/hirte-default.conf
+++ b/config/hirte/hirte-default.conf
@@ -4,7 +4,7 @@
 #
 # The port the manager listens on to establish connections with the hirte
 # agents.
-ManagerPort=2020
+ManagerPort=842
 
 #
 # A comma separated list of unique hirte-agent names. Only nodes with names mentioned in the list can connect to

--- a/doc/example-hirte-agent.ini
+++ b/doc/example-hirte-agent.ini
@@ -3,8 +3,8 @@
 [hirte-agent]
 NodeName=foo
 ManagerHost=127.0.0.1
-ManagerPort=2020
-ManagerAddress=tcp:host=127.0.0.1,port=2020
+ManagerPort=842
+ManagerAddress=tcp:host=127.0.0.1,port=842
 LogLevel=DEBUG
 LogTarget=stderr
 LogIsQuiet=false

--- a/doc/example-hirte.ini
+++ b/doc/example-hirte.ini
@@ -1,7 +1,7 @@
 # This is a sample configuration file for hirte.
 
 [hirte]
-ManagerPort=2020
+ManagerPort=842
 AllowedNodeNames=foo,bar
 LogLevel=INFO
 LogTarget=stderr

--- a/doc/man/hirte-agent.conf.5.md
+++ b/doc/man/hirte-agent.conf.5.md
@@ -61,7 +61,7 @@ If this flag is set to `true`, no logs are written by hirte.
 [hirte-agent]
 NodeName=agent-007
 ManagerHost=127.0.0.1
-ManagerPort=2020
+ManagerPort=842
 LogLevel=DEBUG
 LogTarget=journald
 LogIsQuiet=false

--- a/doc/man/hirte.conf.5.md
+++ b/doc/man/hirte.conf.5.md
@@ -50,7 +50,7 @@ If this flag is set to `true`, no logs are written by hirte.
 
 ```
 [hirte]
-ManagerPort=2020
+ManagerPort=842
 AllowedNodeNames=agent-007,agent-123
 LogLevel=DEBUG
 LogTarget=journald

--- a/src/libhirte/common/protocol.h
+++ b/src/libhirte/common/protocol.h
@@ -3,7 +3,7 @@
 
 #include "errno.h"
 
-#define HIRTE_DEFAULT_PORT 808 /* TODO: Pick a better default */
+#define HIRTE_DEFAULT_PORT 842
 
 #define HIRTE_DBUS_NAME "org.containers.hirte"
 #define HIRTE_AGENT_DBUS_NAME "org.containers.hirte.Agent"

--- a/systemd-units/hirte.socket
+++ b/systemd-units/hirte.socket
@@ -1,5 +1,5 @@
 [Socket]
-ListenStream=2020
+ListenStream=842
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Use port `842` instead of `2020` for hirte

Fixes: https://github.com/containers/hirte/issues/87
Signed-off-by: Martin Perina <mperina@redhat.com>
