### PR TITLE
Small fixes around ManagerAddress documentation

### DIFF
--- a/config/agent/agent.conf
+++ b/config/agent/agent.conf
@@ -12,5 +12,5 @@ NodeName=
 
 #
 # The IP address that hirte-agent can use to connect to hirte manager. It must be a valid IPv4 or IPv6 address.
-# It's mandatory to set this option for each hirte-agent.
+# It's mandatory to set either ManagerHost or ManagerAddress option for each hirte-agent.
 ManagerHost=

--- a/config/agent/hirte-default.conf
+++ b/config/agent/hirte-default.conf
@@ -8,13 +8,19 @@ NodeName=
 
 #
 # The IP address that hirte-agent can use to connect to hirte manager. It must be a valid IPv4 or IPv6 address.
-# It's mandatory to set this option for each hirte-agent.
+# It's mandatory to set either ManagerHost or ManagerAddress option for each hirte-agent.
 ManagerHost=
 
 #
 # The port the manager listens on to establish connections with the hirte
 # agents.
 ManagerPort=842
+
+#
+# SD Bus address used by hirte-agent to connect to hirte. See `man sd_bus_set_address` for its format.
+# Overrides any setting of ManagerHost or ManagerPort defined in the configuration file as well as the respective
+# CLI options.
+ManagerAddress=
 
 #
 # The level used for logging. Supported values are: DEBUG, INFO, WARN and ERROR.


### PR DESCRIPTION
1. Adds ManagerAddress option to
   `/usr/share/hirte-agent/config/hirte-default.conf`
2. Mention in configuration files, that either `ManagerHost` or
   `ManagerAddress` need to be set for each agent

Signed-off-by: Martin Perina <mperina@redhat.com>
