### PR TITLE
Fix journal logging

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,9 +67,6 @@ jobs:
           ManagerPort=8420
           LogLevel=DEBUG
           _EOF"
-          # TODO: Remove when journald logging is fixed
-          podman exec -it hirte-node-bar \
-               bash -c 'echo "LogTarget=stderr" >> /etc/hirte/agent.conf'
           podman exec -d hirte-node-bar \
                bash -c "systemctl start hirte-agent.service"
           podman exec -it hirte-node-bar \
@@ -86,9 +83,6 @@ jobs:
           ManagerPort=8420
           LogLevel=DEBUG
           _EOF"
-          # TODO: Remove when journald logging is fixed
-          podman exec -it hirte-node-foo \
-               bash -c 'echo "LogTarget=stderr" >> /etc/hirte/agent.conf'
           podman exec -d hirte-node-foo \
                bash -c "systemctl start hirte-agent.service"
           podman exec -it hirte-node-foo \


### PR DESCRIPTION
We need to pass MESSAGE, not HIRTE_MESSAGE, or the messages will never be seen by the journal users. We also want to convert the log level to syslog prios so that regular log filtering tools work.

Also, don't pass the DATA unless it is used.