### PR TITLE
Mention default values in configuration files and man pages

### DIFF
--- a/config/agent/agent.conf
+++ b/config/agent/agent.conf
@@ -14,3 +14,27 @@ NodeName=
 # The IP address that hirte-agent can use to connect to hirte manager. It must be a valid IPv4 or IPv6 address.
 # It's mandatory to set either ManagerHost or ManagerAddress option for each hirte-agent.
 ManagerHost=
+
+#
+# The port the manager listens on to establish connections with the hirte
+# agents.
+#ManagerPort=842
+
+#
+# SD Bus address used by hirte-agent to connect to hirte. See `man sd_bus_set_address` for its format.
+# Overrides any setting of ManagerHost or ManagerPort defined in the configuration file as well as the respective
+# CLI options.
+#ManagerAddress=
+
+#
+# The level used for logging. Supported values are: DEBUG, INFO, WARN and ERROR.
+#LogLevel=INFO
+
+#
+# The target where logs are written to. Supported values are: journald and
+# stderr.
+#LogTarget=journald
+
+#
+# If this flag is set to true, no logs are written by hirte.
+#LogIsQuiet=false

--- a/config/hirte/hirte.conf
+++ b/config/hirte/hirte.conf
@@ -11,3 +11,21 @@
 # hirte manager. These names are defined in the agent's configuration file under `NodeName` option
 # (see `hirte-agent.conf(5)`).
 AllowedNodeNames=
+
+#
+# The port the manager listens on to establish connections with the hirte
+# agents.
+#ManagerPort=842
+
+#
+# The level used for logging. Supported values are: DEBUG, INFO, WARN and ERROR.
+#LogLevel=INFO
+
+#
+# The target where logs are written to. Supported values are: journald and
+# stderr.
+#LogTarget=journald
+
+#
+# If this flag is set to true, no logs are written by hirte.
+#LogIsQuiet=false

--- a/doc/man/hirte-agent.conf.5.md
+++ b/doc/man/hirte-agent.conf.5.md
@@ -15,24 +15,30 @@ The hirte-agent configuration file is using the
 
 ### **hirte-agent** section
 
-All fields to bootstrap the hirte-agent are contained in the **hirte-agent** section. The following keys are understood by `hirte-agent`.
+All fields to bootstrap the hirte-agent are contained in the **hirte-agent** section. The following keys are understood
+by `hirte-agent`.
 
 #### **NodeName** (string)
 
-The unique name of this agent.
+The unique name of this agent. The option doesn't have a default value, it's mandatory to set this option for each
+`hirte-agent`.
 
 #### **ManagerAddress** (string)
 
 SD Bus address used by `hirte-agent` to connect to `hirte`. See `man sd_bus_set_address` for its format.
-Overrides any setting of `ManagerHost` or `ManagerPort` defined in the configuration file as well as the respective CLI options.
+Overrides any setting of `ManagerHost` or `ManagerPort` defined in the configuration file as well as the respective CLI
+options. The option doesn't have a default value.
+
 
 #### **ManagerHost** (string)
 
-The host used by `hirte-agent` to connect to `hirte`. Must be a valid IPv4 or IPv6.
+The host used by `hirte-agent` to connect to `hirte`. Must be a valid IPv4 or IPv6. The option doesn't have a default
+value, it's mandatory to set this option for each hirte-agent.
 
 #### **ManagerPort** (uint16_t)
 
-The port on which `hirte` is listening for connection request and the `hirte-agent` is connecting to.
+The port on which `hirte` is listening for connection request and the `hirte-agent` is connecting to. By default port
+`842` is used.
 
 #### **LogLevel** (string)
 
@@ -43,6 +49,8 @@ The level used for logging. Supported values are:
 - `WARN`
 - `ERROR`
 
+By default `INFO` level is used for logging.
+
 #### **LogTarget** (string)
 
 The target where logs are written to. Supported values are:
@@ -51,17 +59,32 @@ The target where logs are written to. Supported values are:
 - `stderr-full`
 - `journald`
 
+By default `journald` is used as the target.
+
 #### **LogIsQuiet** (string)
 
-If this flag is set to `true`, no logs are written by hirte.
+If this flag is set to `true`, no logs are written by hirte. By default the flag is set to `false`.
 
 ## Example
+
+Using `ManagerHost` and `ManagerPort` options:
 
 ```
 [hirte-agent]
 NodeName=agent-007
 ManagerHost=127.0.0.1
 ManagerPort=842
+LogLevel=DEBUG
+LogTarget=journald
+LogIsQuiet=false
+```
+
+Using `ManagerAddress` option:
+
+```
+[hirte-agent]
+NodeName=agent-007
+ManagerAddress=tcp:host=127.0.0.1,port=842
 LogLevel=DEBUG
 LogTarget=journald
 LogIsQuiet=false

--- a/doc/man/hirte.conf.5.md
+++ b/doc/man/hirte.conf.5.md
@@ -15,15 +15,18 @@ The hirte configuration file is using the
 
 ### **hirte** section
 
-All fields to bootstrap the hirte manager are contained in the **hirte** section. The following keys are understood by `hirte`.
+All fields to bootstrap the hirte manager are contained in the **hirte** section. The following keys are understood by
+`hirte`.
 
 #### **ManagerPort** (uint16_t)
 
-The port the manager listens on to establish connections with the `hirte-agent`.
+The port the manager listens on to establish connections with the `hirte-agent`. By default port `842` is used.
 
 #### **AllowedNodeNames** (string)
 
-A comma separated list of unique hirte-agent names. Only nodes with names mentioned in the list can connect to `hirte` manager. These names are defined in the agent's configuration file under `NodeName` option (see `hirte-agent.conf(5)`).
+A comma separated list of unique hirte-agent names. It's mandatory to set the option, only nodes with names mentioned
+in the list can connect to `hirte` manager. These names are defined in the agent's configuration file under `NodeName`
+option (see `hirte-agent.conf(5)`).
 
 #### **LogLevel** (string)
 
@@ -34,6 +37,8 @@ The level used for logging. Supported values are:
 - `WARN`
 - `ERROR`
 
+By default `INFO` level is used for logging.
+
 #### **LogTarget** (string)
 
 The target where logs are written to. Supported values are:
@@ -42,9 +47,11 @@ The target where logs are written to. Supported values are:
 - `stderr-full`
 - `journald`
 
+By default `journald` is used as the target.
+
 #### **LogIsQuiet** (string)
 
-If this flag is set to `true`, no logs are written by hirte.
+If this flag is set to `true`, no logs are written by hirte. By default the flag is set to `false`.
 
 ## Example
 


### PR DESCRIPTION
- Mention all existing config options in /etc/hirte files
- Mention default values of config options in man pages
