### PR TITLE
Adjust the description of the project

### DIFF
--- a/README.developer.md
+++ b/README.developer.md
@@ -88,9 +88,10 @@ meson install -C builddir --destdir bin
 
 After building, three binaries are available:
 
-- `hirte`: the orchestrator which is run on the main machine, sending commands to the agents and monitoring the progress
-- `hirte-agent`: the node agent unit which connects with the orchestrator and executes commands on the node machine
-- `hirtectl`: a helper (CLI) program to send an commands to the orchestrator
+- `hirte`: the systemd service controller which is run on the main machine, sending commands to the agents and
+  monitoring the progress
+- `hirte-agent`: the node agent unit which connects with the controller and executes commands on the node machine
+- `hirtectl`: a helper (CLI) program to send an commands to the controller
 
 ### Unit tests
 
@@ -108,7 +109,7 @@ At the moment the `hirtectl` binary does not implement any logic. It only prints
 
 #### hirte
 
-The orchestrator can be run via:
+The controller can be run via:
 
 ```bash
 hirte

--- a/README.md
+++ b/README.md
@@ -2,24 +2,28 @@
 
 [![Copr build status](https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/package/hirte/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/package/hirte/)
 
-Hirte is a service orchestrator tool intended for multi-node device clusters with a predefined number of nodes and with
-a focus on highly regulated environments such as those requiring functional safety. Potential use cases can be found in
-domains such as transportation, where services need to be orchestrated across different edge devices managed in clusters
-but traditional orchestration tools are not compliant with regulatory requirements.
+Hirte is a systemd service controller intended for multi-node environments with
+a predefined number of nodes and with a focus on highly regulated ecosystems
+such as those requiring functional safety.
+Potential use cases can be found in domains such as transportation, where
+services need to be controlled across different edge devices and where
+traditional orchestration tools are not compliant with regulatory requirements.
 
-Hirte is relying on [systemd](https://github.com/systemd/systemd) and its D-Bus API, which it extends for multi-node use
-case.
+Hirte is relying on [systemd](https://github.com/systemd/systemd) and its D-Bus
+API, which it extends for multi-node use case.
 
-Hirte can also be used to orchestrate containers using [Podman](https://github.com/containers/podman/) and its ability
-to generate systemd service configuration to run a container.
+Hirte can also be used to control systemd services for containerized applications
+using [Podman](https://github.com/containers/podman/) and its ability
+to generate systemd service configuration to run a container via
+[quadlet](https://www.redhat.com/sysadmin/quadlet-podman).
 
 ## How to contribute
 
 ### Testing
 
 RPM packages for the Hirte project are available on
-[hirte-snapshot](https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/) COPR repo. To install hirte packages
-on your system please add that repo using:
+[hirte-snapshot](https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/)
+COPR repo. To install hirte packages on your system please add that repo using:
 
 ```bash
 dnf copr enable mperina/hirte-snapshot
@@ -35,11 +39,11 @@ dnf install hirte hirte-agent
 
 Patches are welcome!
 
-Please submit patches to [github.com/containers/hirte](https://github.com/containers/hirte). More information about the
-development can be found in [README.developer.md](README.developer.md).
+Please submit patches to [github.com/containers/hirte](https://github.com/containers/hirte).
+More information about the development can be found in [README.developer.md](README.developer.md).
 
-You can read [Get started with GitHub](https://docs.github.com/en/get-started) if you are not familiar with the
-development process to learn more about it.
+You can read [Get started with GitHub](https://docs.github.com/en/get-started)
+if you are not familiar with the development process to learn more about it.
 
 ### Found a bug or documentation issue?
 

--- a/doc/man/hirte-agent.1.md
+++ b/doc/man/hirte-agent.1.md
@@ -10,7 +10,7 @@ hirte-agent - Agent managing services on the local machine
 
 ## DESCRIPTION
 
-Hirte is a service orchestrator tool intended for multi-node devices (e.g.: edge devices) clusters with a predefined number of nodes and with a focus on highly regulated environment such as those requiring functional safety (for example in cars).
+Hirte is a systemd service controller intended for multi-node environment with a predefined number of nodes and with a focus on highly regulated environment such as those requiring functional safety (for example in cars).
 
 A `hirte-agent` establishes a peer-to-peer connection to `hirte` and exposes its API to manage systemd units on it.
 

--- a/doc/man/hirte.1.md
+++ b/doc/man/hirte.1.md
@@ -10,7 +10,7 @@ hirte - Manager of services across agents
 
 ## DESCRIPTION
 
-Hirte is a service orchestrator tool intended for multi-node devices (e.g.: edge devices) clusters with a predefined number of nodes and with a focus on highly regulated environment such as those requiring functional safety (for example in cars).
+Hirte is a systemd service controller intended for multi-nodes environments with a predefined number of nodes and with a focus on highly regulated environment such as those requiring functional safety (for example in cars).
 
 The hirte manager offers its public API on the local DBus and uses the DBus APIs provided by all connected `hirte-agents` to manage systemd services on those remote systems.
 

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -1,7 +1,7 @@
 Name:		hirte
 Version:	@VERSION@
 Release:	@RELEASE@%{?dist}
-Summary:	A service orchestrator tool for multi-node devices (e.g.: edge devices)
+Summary:	A systemd service controller for multi-nodes environments
 License:	GPLv2
 URL:		https://github.com/containers/hirte
 Source0:	https://github.com/containers/hirte/archive/refs/tags/%{name}-%{version}.tar.gz
@@ -15,11 +15,10 @@ BuildRequires:	golang-github-cpuguy83-md2man
 Requires:	systemd
 
 %description
-Hirte is a service orchestrator tool intended for multi-node devices (e.g.:
-edge devices) clusters with a predefined number of nodes and with a focus on
-highly regulated environment such as those requiring functional safety (for
-example in cars).
-This package contains the orchestrator and command line tool.
+Hirte is a systemd service controller for multi-nodes environements with a
+predefined number of nodes and with a focus on highly regulated environment
+such as those requiring functional safety (for example in cars).
+This package contains the controller and command line tool.
 
 %post
 %systemd_post hirte.service
@@ -51,14 +50,13 @@ This package contains the orchestrator and command line tool.
 
 
 %package agent
-Summary:	Hirte service orchestrator agent
+Summary:	Hirte service controller agent
 Requires:	systemd
 
 %description agent
-Hirte is a service orchestrator tool intended for multi-node devices (e.g.:
-edge devices) clusters with a predefined number of nodes and with a focus on
-highly regulated environment such as those requiring functional safety (for
-example in cars).
+Hirte is a systemd service controller for multi-nodes environements with a
+predefined number of nodes and with a focus on highly regulated environment
+such as those requiring functional safety (for example in cars).
 This package contains the node agent.
 
 %post agent

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -1584,7 +1584,7 @@ bool agent_stop(Agent *agent) {
 static bool agent_connect(Agent *agent) {
         peer_bus_close(agent->peer_dbus);
 
-        agent->peer_dbus = peer_bus_open(agent->event, "peer-bus-to-orchestrator", agent->orch_addr);
+        agent->peer_dbus = peer_bus_open(agent->event, "peer-bus-to-controller", agent->orch_addr);
         if (agent->peer_dbus == NULL) {
                 hirte_log_error("Failed to open peer dbus");
                 return false;

--- a/src/libhirte/bus/bus.c
+++ b/src/libhirte/bus/bus.c
@@ -43,10 +43,10 @@ static sd_bus *peer_bus_new(sd_event *event, const char *dbus_description) {
         }
         (void) sd_bus_set_description(dbus, dbus_description);
 
-        // trust everything to/from the orchestrator
+        // trust everything to/from the controller
         r = sd_bus_set_trusted(dbus, true);
         if (r < 0) {
-                hirte_log_errorf("Failed to trust orchestrator: %s", strerror(-r));
+                hirte_log_errorf("Failed to trust controller: %s", strerror(-r));
                 return NULL;
         }
 

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -38,7 +38,7 @@ static int node_property_get_status(
                 void *userdata,
                 sd_bus_error *ret_error);
 
-static const sd_bus_vtable internal_manager_orchestrator_vtable[] = {
+static const sd_bus_vtable internal_manager_controller_vtable[] = {
         SD_BUS_VTABLE_START(0), SD_BUS_METHOD("Register", "s", "", node_method_register, 0), SD_BUS_VTABLE_END
 };
 
@@ -396,7 +396,7 @@ bool node_set_agent_bus(Node *node, sd_bus *bus) {
                                 &node->internal_manager_slot,
                                 INTERNAL_MANAGER_OBJECT_PATH,
                                 INTERNAL_MANAGER_INTERFACE,
-                                internal_manager_orchestrator_vtable,
+                                internal_manager_controller_vtable,
                                 node);
                 if (r < 0) {
                         node_unset_agent_bus(node);

--- a/systemd-units/hirte-agent-user.service
+++ b/systemd-units/hirte-agent-user.service
@@ -3,7 +3,7 @@
 #  This file is part of hirte-agent.
 #
 [Unit]
-Description=Hirte service orchestrator agent daemon
+Description=Hirte systemd service controller agent daemon
 Documentation=man:hirte-agent(1) man:hirte-agent.conf(5)
 After=network.target
 

--- a/systemd-units/hirte-agent.service
+++ b/systemd-units/hirte-agent.service
@@ -3,7 +3,7 @@
 #  This file is part of hirte-agent.
 #
 [Unit]
-Description=Hirte service orchestrator agent daemon
+Description=Hirte systemd service controller agent daemon
 Documentation=man:hirte-agent(1) man:hirte-agent.conf(5)
 After=network.target
 

--- a/systemd-units/hirte.service
+++ b/systemd-units/hirte.service
@@ -3,7 +3,7 @@
 #  This file is part of hirte.
 #
 [Unit]
-Description=Hirte service orchestrator manager daemon
+Description=Hirte systemd service controller manager daemon
 Documentation=man:hirte(1) man:hirte.conf(5)
 After=network.target
 


### PR DESCRIPTION
Replace the use of the words "services orchestrator" by "services controller". Orchestrator comes with a certain understanding and expectations, especially around the management of containers, and we do not want to set these expectations for hirte.
In addition, hirte isn't really an orchestrator by itself, it is just a part of an architecture that would be responsible for managing services.

This commit thus adjusts the wording around the description of the project.