### PR TITLE
Move hirtectl into separate package

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dnf copr enable mperina/hirte-snapshot
 When done you can install relevant hirte packages using:
 
 ```bash
-dnf install hirte hirte-agent
+dnf install hirte hirte-agent hirte-ctl
 ```
 
 ### Submitting patches

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -35,14 +35,12 @@ This package contains the controller and command line tool.
 %doc README.developer.md
 %license LICENSE
 %{_bindir}/hirte
-%{_bindir}/hirtectl
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Job.xml
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Manager.xml
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Monitor.xml
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Node.xml
 %{_datadir}/hirte/config/hirte-default.conf
 %{_mandir}/man1/hirte.*
-%{_mandir}/man1/hirtectl.*
 %{_mandir}/man5/hirte.conf.*
 %{_sysconfdir}/dbus-1/system.d/org.containers.hirte.conf
 %{_unitdir}/hirte.service
@@ -80,6 +78,22 @@ This package contains the node agent.
 %{_unitdir}/hirte-agent.service
 %{_userunitdir}/hirte-agent.service
 
+
+%package ctl
+Summary:	Hirte service controller command line tool
+Requires:	%{name} = %{version}-%{release}
+
+%description ctl
+Hirte is a systemd service controller for multi-nodes environements with a
+predefined number of nodes and with a focus on highly regulated environment
+such as those requiring functional safety (for example in cars).
+This package contains the service controller command line tool.
+
+%files ctl
+%doc README.md
+%license LICENSE
+%{_bindir}/hirtectl
+%{_mandir}/man1/hirtectl.*
 
 %prep
 %setup -c -q

--- a/tests/Containerfile
+++ b/tests/Containerfile
@@ -3,7 +3,7 @@ RUN mkdir -p /tmp/rpms
 COPY ./exported-artifacts/ /tmp/rpms/
 RUN dnf install -y --repo local-hirte-snapshot \
     --repofrompath local-hirte-snapshot,file:///tmp/rpms \
-    --nogpgcheck hirte hirte-agent
+    --nogpgcheck hirte hirte-agent hirte-ctl
 CMD [ "/sbin/init" ]
 
 WORKDIR /hirte


### PR DESCRIPTION
Moves hirtectl into separate package as the tool is primarily used for
development and debugging, so it doesn't need to be installed in
production.

Signed-off-by: Martin Perina <mperina@redhat.com>
