### PR TITLE
Additional Fedora packaging fixes

### DIFF
--- a/build-scripts/build-srpm.sh
+++ b/build-scripts/build-srpm.sh
@@ -25,7 +25,8 @@ sed \
 
 # Prepare source archive
 [[ -d rpmbuild/SOURCES ]] || mkdir -p rpmbuild/SOURCES
-git archive --format=tar --add-file=hirte.spec HEAD | gzip -9 > rpmbuild/SOURCES/hirte-$VERSION.tar.gz
+git archive --format=tar --prefix=hirte-$VERSION/ --add-file=hirte.spec HEAD \
+    | gzip -9 > rpmbuild/SOURCES/hirte-$VERSION.tar.gz
 
 # Build source package
 rpmbuild \

--- a/data/meson.build
+++ b/data/meson.build
@@ -10,7 +10,7 @@ install_data(
 )
 
 # Installing the DBus permission configuration files
-dbus_service_dir = join_paths(get_option('sysconfdir'), 'dbus-1', 'system.d')
+dbus_service_dir = join_paths(get_option('datadir'), 'dbus-1', 'system.d')
 dbus_srv_user = get_option('dbus-srv-user')
 if dbus_srv_user == ''
     dbus_srv_user = 'root'

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -39,10 +39,10 @@ This package contains the controller and command line tool.
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Manager.xml
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Monitor.xml
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Node.xml
+%{_datadir}/dbus-1/system.d/org.containers.hirte.conf
 %{_datadir}/hirte/config/hirte-default.conf
 %{_mandir}/man1/hirte.*
 %{_mandir}/man5/hirte.conf.*
-%{_sysconfdir}/dbus-1/system.d/org.containers.hirte.conf
 %{_unitdir}/hirte.service
 %{_unitdir}/hirte.socket
 
@@ -71,10 +71,10 @@ This package contains the node agent.
 %doc README.md
 %license LICENSE
 %{_bindir}/hirte-agent
+%{_datadir}/dbus-1/system.d/org.containers.hirte.Agent.conf
 %{_datadir}/hirte-agent/config/hirte-default.conf
 %{_mandir}/man1/hirte-agent.*
 %{_mandir}/man5/hirte-agent.conf.*
-%{_sysconfdir}/dbus-1/system.d/org.containers.hirte.Agent.conf
 %{_unitdir}/hirte-agent.service
 %{_userunitdir}/hirte-agent.service
 

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -2,7 +2,7 @@ Name:    hirte
 Version: @VERSION@
 Release: @RELEASE@%{?dist}
 Summary: A systemd service controller for multi-nodes environments
-License: GPLv2
+License: GPLv2+
 URL:     https://github.com/containers/hirte
 Source0: %{url}/archive/%{name}-%{version}.tar.gz
 

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -4,7 +4,7 @@ Release:	@RELEASE@%{?dist}
 Summary:	A systemd service controller for multi-nodes environments
 License:	GPLv2
 URL:		https://github.com/containers/hirte
-Source0:	https://github.com/containers/hirte/archive/refs/tags/%{name}-%{version}.tar.gz
+Source0:	%{url}/archive/%{name}-%{version}.tar.gz
 
 BuildRequires:	gcc
 BuildRequires:	meson
@@ -96,7 +96,7 @@ This package contains the service controller command line tool.
 %{_mandir}/man1/hirtectl.*
 
 %prep
-%setup -c -q
+%autosetup
 
 
 %build

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -1,18 +1,18 @@
-Name:		hirte
-Version:	@VERSION@
-Release:	@RELEASE@%{?dist}
-Summary:	A systemd service controller for multi-nodes environments
-License:	GPLv2
-URL:		https://github.com/containers/hirte
-Source0:	%{url}/archive/%{name}-%{version}.tar.gz
+Name:    hirte
+Version: @VERSION@
+Release: @RELEASE@%{?dist}
+Summary: A systemd service controller for multi-nodes environments
+License: GPLv2
+URL:     https://github.com/containers/hirte
+Source0: %{url}/archive/%{name}-%{version}.tar.gz
 
-BuildRequires:	gcc
-BuildRequires:	meson
-BuildRequires:	systemd-devel
-BuildRequires:	systemd-rpm-macros
-BuildRequires:	golang-github-cpuguy83-md2man
+BuildRequires: gcc
+BuildRequires: meson
+BuildRequires: systemd-devel
+BuildRequires: systemd-rpm-macros
+BuildRequires: golang-github-cpuguy83-md2man
 
-Requires:	systemd
+Requires: systemd
 
 %description
 Hirte is a systemd service controller for multi-nodes environements with a
@@ -48,8 +48,8 @@ This package contains the controller and command line tool.
 
 
 %package agent
-Summary:	Hirte service controller agent
-Requires:	systemd
+Summary:  Hirte service controller agent
+Requires: systemd
 
 %description agent
 Hirte is a systemd service controller for multi-nodes environements with a
@@ -80,8 +80,8 @@ This package contains the node agent.
 
 
 %package ctl
-Summary:	Hirte service controller command line tool
-Requires:	%{name} = %{version}-%{release}
+Summary:  Hirte service controller command line tool
+Requires: %{name} = %{version}-%{release}
 
 %description ctl
 Hirte is a systemd service controller for multi-nodes environements with a


### PR DESCRIPTION
- Align source archive content with the one generated on GitHub
- Replace tabs with spaces in the spec file
- Align source code license with RPM license
- Move DBus configuration from /etc to /usr/share
