### PR TITLE
Backport changes around Fedora packaging

### DIFF
--- a/README.developer.md
+++ b/README.developer.md
@@ -88,9 +88,10 @@ meson install -C builddir --destdir bin
 
 After building, three binaries are available:
 
-- `hirte`: the orchestrator which is run on the main machine, sending commands to the agents and monitoring the progress
-- `hirte-agent`: the node agent unit which connects with the orchestrator and executes commands on the node machine
-- `hirtectl`: a helper (CLI) program to send an commands to the orchestrator
+- `hirte`: the systemd service controller which is run on the main machine, sending commands to the agents and
+  monitoring the progress
+- `hirte-agent`: the node agent unit which connects with the controller and executes commands on the node machine
+- `hirtectl`: a helper (CLI) program to send an commands to the controller
 
 ### Unit tests
 
@@ -108,7 +109,7 @@ At the moment the `hirtectl` binary does not implement any logic. It only prints
 
 #### hirte
 
-The orchestrator can be run via:
+The controller can be run via:
 
 ```bash
 hirte

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dnf copr enable mperina/hirte-snapshot
 When done you can install relevant hirte packages using:
 
 ```bash
-dnf install hirte hirte-agent
+dnf install hirte hirte-agent hirte-ctl
 ```
 
 ### Submitting patches

--- a/README.md
+++ b/README.md
@@ -2,24 +2,28 @@
 
 [![Copr build status](https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/package/hirte/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/package/hirte/)
 
-Hirte is a service orchestrator tool intended for multi-node device clusters with a predefined number of nodes and with
-a focus on highly regulated environments such as those requiring functional safety. Potential use cases can be found in
-domains such as transportation, where services need to be orchestrated across different edge devices managed in clusters
-but traditional orchestration tools are not compliant with regulatory requirements.
+Hirte is a systemd service controller intended for multi-node environments with
+a predefined number of nodes and with a focus on highly regulated ecosystems
+such as those requiring functional safety.
+Potential use cases can be found in domains such as transportation, where
+services need to be controlled across different edge devices and where
+traditional orchestration tools are not compliant with regulatory requirements.
 
-Hirte is relying on [systemd](https://github.com/systemd/systemd) and its D-Bus API, which it extends for multi-node use
-case.
+Hirte is relying on [systemd](https://github.com/systemd/systemd) and its D-Bus
+API, which it extends for multi-node use case.
 
-Hirte can also be used to orchestrate containers using [Podman](https://github.com/containers/podman/) and its ability
-to generate systemd service configuration to run a container.
+Hirte can also be used to control systemd services for containerized applications
+using [Podman](https://github.com/containers/podman/) and its ability
+to generate systemd service configuration to run a container via
+[quadlet](https://www.redhat.com/sysadmin/quadlet-podman).
 
 ## How to contribute
 
 ### Testing
 
 RPM packages for the Hirte project are available on
-[hirte-snapshot](https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/) COPR repo. To install hirte packages
-on your system please add that repo using:
+[hirte-snapshot](https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/)
+COPR repo. To install hirte packages on your system please add that repo using:
 
 ```bash
 dnf copr enable mperina/hirte-snapshot
@@ -35,11 +39,11 @@ dnf install hirte hirte-agent
 
 Patches are welcome!
 
-Please submit patches to [github.com/containers/hirte](https://github.com/containers/hirte). More information about the
-development can be found in [README.developer.md](README.developer.md).
+Please submit patches to [github.com/containers/hirte](https://github.com/containers/hirte).
+More information about the development can be found in [README.developer.md](README.developer.md).
 
-You can read [Get started with GitHub](https://docs.github.com/en/get-started) if you are not familiar with the
-development process to learn more about it.
+You can read [Get started with GitHub](https://docs.github.com/en/get-started)
+if you are not familiar with the development process to learn more about it.
 
 ### Found a bug or documentation issue?
 

--- a/build-scripts/build-srpm.sh
+++ b/build-scripts/build-srpm.sh
@@ -25,7 +25,8 @@ sed \
 
 # Prepare source archive
 [[ -d rpmbuild/SOURCES ]] || mkdir -p rpmbuild/SOURCES
-git archive --format=tar --add-file=hirte.spec HEAD | gzip -9 > rpmbuild/SOURCES/hirte-$VERSION.tar.gz
+git archive --format=tar --prefix=hirte-$VERSION/ --add-file=hirte.spec HEAD \
+    | gzip -9 > rpmbuild/SOURCES/hirte-$VERSION.tar.gz
 
 # Build source package
 rpmbuild \

--- a/data/meson.build
+++ b/data/meson.build
@@ -10,7 +10,7 @@ install_data(
 )
 
 # Installing the DBus permission configuration files
-dbus_service_dir = join_paths(get_option('sysconfdir'), 'dbus-1', 'system.d')
+dbus_service_dir = join_paths(get_option('datadir'), 'dbus-1', 'system.d')
 dbus_srv_user = get_option('dbus-srv-user')
 if dbus_srv_user == ''
     dbus_srv_user = 'root'

--- a/doc/man/hirte-agent.1.md
+++ b/doc/man/hirte-agent.1.md
@@ -10,7 +10,7 @@ hirte-agent - Agent managing services on the local machine
 
 ## DESCRIPTION
 
-Hirte is a service orchestrator tool intended for multi-node devices (e.g.: edge devices) clusters with a predefined number of nodes and with a focus on highly regulated environment such as those requiring functional safety (for example in cars).
+Hirte is a systemd service controller intended for multi-node environment with a predefined number of nodes and with a focus on highly regulated environment such as those requiring functional safety (for example in cars).
 
 A `hirte-agent` establishes a peer-to-peer connection to `hirte` and exposes its API to manage systemd units on it.
 

--- a/doc/man/hirte.1.md
+++ b/doc/man/hirte.1.md
@@ -10,7 +10,7 @@ hirte - Manager of services across agents
 
 ## DESCRIPTION
 
-Hirte is a service orchestrator tool intended for multi-node devices (e.g.: edge devices) clusters with a predefined number of nodes and with a focus on highly regulated environment such as those requiring functional safety (for example in cars).
+Hirte is a systemd service controller intended for multi-nodes environments with a predefined number of nodes and with a focus on highly regulated environment such as those requiring functional safety (for example in cars).
 
 The hirte manager offers its public API on the local DBus and uses the DBus APIs provided by all connected `hirte-agents` to manage systemd services on those remote systems.
 

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -1,7 +1,7 @@
 Name:		hirte
 Version:	@VERSION@
 Release:	@RELEASE@%{?dist}
-Summary:	Hirte is a service orchestrator tool intended for multi-node devices (e.g.: edge devices) clusters
+Summary:	A service orchestrator tool for multi-node devices (e.g.: edge devices)
 License:	GPLv2
 URL:		https://github.com/containers/hirte
 Source0:	%{name}-%{version}.tar.gz
@@ -31,7 +31,7 @@ This package contains the orchestrator and command line tool.
 
 
 %package agent
-Summary:	Hirte container orchestrator agent
+Summary:	Hirte service orchestrator agent
 Requires:	systemd
 
 %post agent

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -24,9 +24,10 @@ Requires:	systemd
 %systemd_postun_with_restart hirte.service
 
 %description
-Hirte is a service orchestrator tool intended for multi-node devices (e.g.: edge devices) clusters with a predefined
-number of nodes and with a focus on highly regulated environment such as those requiring functional safety (for example
-in cars).
+Hirte is a service orchestrator tool intended for multi-node devices (e.g.:
+edge devices) clusters with a predefined number of nodes and with a focus on
+highly regulated environment such as those requiring functional safety (for
+example in cars).
 This package contains the orchestrator and command line tool.
 
 
@@ -44,9 +45,10 @@ Requires:	systemd
 %systemd_postun_with_restart hirte-agent.service
 
 %description agent
-Hirte is a service orchestrator tool intended for multi-node devices (e.g.: edge devices) clusters with a predefined
-number of nodes and with a focus on highly regulated environment such as those requiring functional safety (for example
-in cars).
+Hirte is a service orchestrator tool intended for multi-node devices (e.g.:
+edge devices) clusters with a predefined number of nodes and with a focus on
+highly regulated environment such as those requiring functional safety (for
+example in cars).
 This package contains the node agent.
 
 

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -39,10 +39,10 @@ This package contains the controller and command line tool.
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Manager.xml
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Monitor.xml
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Node.xml
+%{_datadir}/dbus-1/system.d/org.containers.hirte.conf
 %{_datadir}/hirte/config/hirte-default.conf
 %{_mandir}/man1/hirte.*
 %{_mandir}/man5/hirte.conf.*
-%{_sysconfdir}/dbus-1/system.d/org.containers.hirte.conf
 %{_unitdir}/hirte.service
 %{_unitdir}/hirte.socket
 
@@ -71,10 +71,10 @@ This package contains the node agent.
 %doc README.md
 %license LICENSE
 %{_bindir}/hirte-agent
+%{_datadir}/dbus-1/system.d/org.containers.hirte.Agent.conf
 %{_datadir}/hirte-agent/config/hirte-default.conf
 %{_mandir}/man1/hirte-agent.*
 %{_mandir}/man5/hirte-agent.conf.*
-%{_sysconfdir}/dbus-1/system.d/org.containers.hirte.Agent.conf
 %{_unitdir}/hirte-agent.service
 %{_userunitdir}/hirte-agent.service
 

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -35,14 +35,12 @@ This package contains the controller and command line tool.
 %doc README.developer.md
 %license LICENSE
 %{_bindir}/hirte
-%{_bindir}/hirtectl
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Job.xml
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Manager.xml
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Monitor.xml
 %{_datadir}/dbus-1/interfaces/org.containers.hirte.Node.xml
 %{_datadir}/hirte/config/hirte-default.conf
 %{_mandir}/man1/hirte.*
-%{_mandir}/man1/hirtectl.*
 %{_mandir}/man5/hirte.conf.*
 %{_sysconfdir}/dbus-1/system.d/org.containers.hirte.conf
 %{_unitdir}/hirte.service
@@ -80,6 +78,22 @@ This package contains the node agent.
 %{_unitdir}/hirte-agent.service
 %{_userunitdir}/hirte-agent.service
 
+
+%package ctl
+Summary:	Hirte service controller command line tool
+Requires:	%{name} = %{version}-%{release}
+
+%description ctl
+Hirte is a systemd service controller for multi-nodes environements with a
+predefined number of nodes and with a focus on highly regulated environment
+such as those requiring functional safety (for example in cars).
+This package contains the service controller command line tool.
+
+%files ctl
+%doc README.md
+%license LICENSE
+%{_bindir}/hirtectl
+%{_mandir}/man1/hirtectl.*
 
 %prep
 %setup -c -q

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -2,7 +2,7 @@ Name:    hirte
 Version: @VERSION@
 Release: @RELEASE@%{?dist}
 Summary: A systemd service controller for multi-nodes environments
-License: GPLv2
+License: GPLv2+
 URL:     https://github.com/containers/hirte
 Source0: %{url}/archive/%{name}-%{version}.tar.gz
 

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -4,7 +4,7 @@ Release:	@RELEASE@%{?dist}
 Summary:	A service orchestrator tool for multi-node devices (e.g.: edge devices)
 License:	GPLv2
 URL:		https://github.com/containers/hirte
-Source0:	%{name}-%{version}.tar.gz
+Source0:	https://github.com/containers/hirte/archive/refs/tags/%{name}-%{version}.tar.gz
 
 BuildRequires:	gcc
 BuildRequires:	meson

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -4,7 +4,7 @@ Release:	@RELEASE@%{?dist}
 Summary:	A systemd service controller for multi-nodes environments
 License:	GPLv2
 URL:		https://github.com/containers/hirte
-Source0:	https://github.com/containers/hirte/archive/refs/tags/%{name}-%{version}.tar.gz
+Source0:	%{url}/archive/%{name}-%{version}.tar.gz
 
 BuildRequires:	gcc
 BuildRequires:	meson
@@ -96,7 +96,7 @@ This package contains the service controller command line tool.
 %{_mandir}/man1/hirtectl.*
 
 %prep
-%setup -c -q
+%autosetup
 
 
 %build

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -70,7 +70,7 @@ This package contains the node agent.
 
 
 %files
-%config %{_sysconfdir}/hirte/hirte.conf
+%config(noreplace) %{_sysconfdir}/hirte/hirte.conf
 %doc README.md
 %doc README.developer.md
 %license LICENSE
@@ -89,7 +89,7 @@ This package contains the node agent.
 %{_unitdir}/hirte.socket
 
 %files agent
-%config %{_sysconfdir}/hirte/agent.conf
+%config(noreplace) %{_sysconfdir}/hirte/agent.conf
 %doc README.md
 %license LICENSE
 %{_bindir}/hirte-agent

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -1,18 +1,18 @@
-Name:		hirte
-Version:	@VERSION@
-Release:	@RELEASE@%{?dist}
-Summary:	A systemd service controller for multi-nodes environments
-License:	GPLv2
-URL:		https://github.com/containers/hirte
-Source0:	%{url}/archive/%{name}-%{version}.tar.gz
+Name:    hirte
+Version: @VERSION@
+Release: @RELEASE@%{?dist}
+Summary: A systemd service controller for multi-nodes environments
+License: GPLv2
+URL:     https://github.com/containers/hirte
+Source0: %{url}/archive/%{name}-%{version}.tar.gz
 
-BuildRequires:	gcc
-BuildRequires:	meson
-BuildRequires:	systemd-devel
-BuildRequires:	systemd-rpm-macros
-BuildRequires:	golang-github-cpuguy83-md2man
+BuildRequires: gcc
+BuildRequires: meson
+BuildRequires: systemd-devel
+BuildRequires: systemd-rpm-macros
+BuildRequires: golang-github-cpuguy83-md2man
 
-Requires:	systemd
+Requires: systemd
 
 %description
 Hirte is a systemd service controller for multi-nodes environements with a
@@ -48,8 +48,8 @@ This package contains the controller and command line tool.
 
 
 %package agent
-Summary:	Hirte service controller agent
-Requires:	systemd
+Summary:  Hirte service controller agent
+Requires: systemd
 
 %description agent
 Hirte is a systemd service controller for multi-nodes environements with a
@@ -80,8 +80,8 @@ This package contains the node agent.
 
 
 %package ctl
-Summary:	Hirte service controller command line tool
-Requires:	%{name} = %{version}-%{release}
+Summary:  Hirte service controller command line tool
+Requires: %{name} = %{version}-%{release}
 
 %description ctl
 Hirte is a systemd service controller for multi-nodes environements with a

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -14,6 +14,13 @@ BuildRequires:	golang-github-cpuguy83-md2man
 
 Requires:	systemd
 
+%description
+Hirte is a service orchestrator tool intended for multi-node devices (e.g.:
+edge devices) clusters with a predefined number of nodes and with a focus on
+highly regulated environment such as those requiring functional safety (for
+example in cars).
+This package contains the orchestrator and command line tool.
+
 %post
 %systemd_post hirte.service
 
@@ -22,52 +29,6 @@ Requires:	systemd
 
 %postun
 %systemd_postun_with_restart hirte.service
-
-%description
-Hirte is a service orchestrator tool intended for multi-node devices (e.g.:
-edge devices) clusters with a predefined number of nodes and with a focus on
-highly regulated environment such as those requiring functional safety (for
-example in cars).
-This package contains the orchestrator and command line tool.
-
-
-%package agent
-Summary:	Hirte service orchestrator agent
-Requires:	systemd
-
-%post agent
-%systemd_post hirte-agent.service
-
-%preun agent
-%systemd_preun hirte-agent.service
-
-%postun agent
-%systemd_postun_with_restart hirte-agent.service
-
-%description agent
-Hirte is a service orchestrator tool intended for multi-node devices (e.g.:
-edge devices) clusters with a predefined number of nodes and with a focus on
-highly regulated environment such as those requiring functional safety (for
-example in cars).
-This package contains the node agent.
-
-
-%prep
-%setup -c -q
-
-
-%build
-%meson -Dapi_bus=system
-%meson_build
-
-
-%install
-%meson_install
-
-
-%check
-%meson_test
-
 
 %files
 %config(noreplace) %{_sysconfdir}/hirte/hirte.conf
@@ -88,6 +49,27 @@ This package contains the node agent.
 %{_unitdir}/hirte.service
 %{_unitdir}/hirte.socket
 
+
+%package agent
+Summary:	Hirte service orchestrator agent
+Requires:	systemd
+
+%description agent
+Hirte is a service orchestrator tool intended for multi-node devices (e.g.:
+edge devices) clusters with a predefined number of nodes and with a focus on
+highly regulated environment such as those requiring functional safety (for
+example in cars).
+This package contains the node agent.
+
+%post agent
+%systemd_post hirte-agent.service
+
+%preun agent
+%systemd_preun hirte-agent.service
+
+%postun agent
+%systemd_postun_with_restart hirte-agent.service
+
 %files agent
 %config(noreplace) %{_sysconfdir}/hirte/agent.conf
 %doc README.md
@@ -99,6 +81,24 @@ This package contains the node agent.
 %{_sysconfdir}/dbus-1/system.d/org.containers.hirte.Agent.conf
 %{_unitdir}/hirte-agent.service
 %{_userunitdir}/hirte-agent.service
+
+
+%prep
+%setup -c -q
+
+
+%build
+%meson -Dapi_bus=system
+%meson_build
+
+
+%install
+%meson_install
+
+
+%check
+%meson_test
+
 
 %changelog
 * Tue Mar 21 2023 Martin Perina <mperina@redhat.com> - 0.1.0-1

--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -1,7 +1,7 @@
 Name:		hirte
 Version:	@VERSION@
 Release:	@RELEASE@%{?dist}
-Summary:	A service orchestrator tool for multi-node devices (e.g.: edge devices)
+Summary:	A systemd service controller for multi-nodes environments
 License:	GPLv2
 URL:		https://github.com/containers/hirte
 Source0:	https://github.com/containers/hirte/archive/refs/tags/%{name}-%{version}.tar.gz
@@ -15,11 +15,10 @@ BuildRequires:	golang-github-cpuguy83-md2man
 Requires:	systemd
 
 %description
-Hirte is a service orchestrator tool intended for multi-node devices (e.g.:
-edge devices) clusters with a predefined number of nodes and with a focus on
-highly regulated environment such as those requiring functional safety (for
-example in cars).
-This package contains the orchestrator and command line tool.
+Hirte is a systemd service controller for multi-nodes environements with a
+predefined number of nodes and with a focus on highly regulated environment
+such as those requiring functional safety (for example in cars).
+This package contains the controller and command line tool.
 
 %post
 %systemd_post hirte.service
@@ -51,14 +50,13 @@ This package contains the orchestrator and command line tool.
 
 
 %package agent
-Summary:	Hirte service orchestrator agent
+Summary:	Hirte service controller agent
 Requires:	systemd
 
 %description agent
-Hirte is a service orchestrator tool intended for multi-node devices (e.g.:
-edge devices) clusters with a predefined number of nodes and with a focus on
-highly regulated environment such as those requiring functional safety (for
-example in cars).
+Hirte is a systemd service controller for multi-nodes environements with a
+predefined number of nodes and with a focus on highly regulated environment
+such as those requiring functional safety (for example in cars).
 This package contains the node agent.
 
 %post agent

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -1584,7 +1584,7 @@ bool agent_stop(Agent *agent) {
 static bool agent_connect(Agent *agent) {
         peer_bus_close(agent->peer_dbus);
 
-        agent->peer_dbus = peer_bus_open(agent->event, "peer-bus-to-orchestrator", agent->orch_addr);
+        agent->peer_dbus = peer_bus_open(agent->event, "peer-bus-to-controller", agent->orch_addr);
         if (agent->peer_dbus == NULL) {
                 hirte_log_error("Failed to open peer dbus");
                 return false;

--- a/src/libhirte/bus/bus.c
+++ b/src/libhirte/bus/bus.c
@@ -43,10 +43,10 @@ static sd_bus *peer_bus_new(sd_event *event, const char *dbus_description) {
         }
         (void) sd_bus_set_description(dbus, dbus_description);
 
-        // trust everything to/from the orchestrator
+        // trust everything to/from the controller
         r = sd_bus_set_trusted(dbus, true);
         if (r < 0) {
-                hirte_log_errorf("Failed to trust orchestrator: %s", strerror(-r));
+                hirte_log_errorf("Failed to trust controller: %s", strerror(-r));
                 return NULL;
         }
 

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -38,7 +38,7 @@ static int node_property_get_status(
                 void *userdata,
                 sd_bus_error *ret_error);
 
-static const sd_bus_vtable internal_manager_orchestrator_vtable[] = {
+static const sd_bus_vtable internal_manager_controller_vtable[] = {
         SD_BUS_VTABLE_START(0), SD_BUS_METHOD("Register", "s", "", node_method_register, 0), SD_BUS_VTABLE_END
 };
 
@@ -396,7 +396,7 @@ bool node_set_agent_bus(Node *node, sd_bus *bus) {
                                 &node->internal_manager_slot,
                                 INTERNAL_MANAGER_OBJECT_PATH,
                                 INTERNAL_MANAGER_INTERFACE,
-                                internal_manager_orchestrator_vtable,
+                                internal_manager_controller_vtable,
                                 node);
                 if (r < 0) {
                         node_unset_agent_bus(node);

--- a/systemd-units/hirte-agent-user.service
+++ b/systemd-units/hirte-agent-user.service
@@ -3,7 +3,7 @@
 #  This file is part of hirte-agent.
 #
 [Unit]
-Description=Hirte service orchestrator agent daemon
+Description=Hirte systemd service controller agent daemon
 Documentation=man:hirte-agent(1) man:hirte-agent.conf(5)
 After=network.target
 

--- a/systemd-units/hirte-agent.service
+++ b/systemd-units/hirte-agent.service
@@ -3,7 +3,7 @@
 #  This file is part of hirte-agent.
 #
 [Unit]
-Description=Hirte service orchestrator agent daemon
+Description=Hirte systemd service controller agent daemon
 Documentation=man:hirte-agent(1) man:hirte-agent.conf(5)
 After=network.target
 

--- a/systemd-units/hirte.service
+++ b/systemd-units/hirte.service
@@ -3,7 +3,7 @@
 #  This file is part of hirte.
 #
 [Unit]
-Description=Hirte service orchestrator manager daemon
+Description=Hirte systemd service controller manager daemon
 Documentation=man:hirte(1) man:hirte.conf(5)
 After=network.target
 

--- a/tests/Containerfile
+++ b/tests/Containerfile
@@ -3,7 +3,7 @@ RUN mkdir -p /tmp/rpms
 COPY ./exported-artifacts/ /tmp/rpms/
 RUN dnf install -y --repo local-hirte-snapshot \
     --repofrompath local-hirte-snapshot,file:///tmp/rpms \
-    --nogpgcheck hirte hirte-agent
+    --nogpgcheck hirte hirte-agent hirte-ctl
 CMD [ "/sbin/init" ]
 
 WORKDIR /hirte


### PR DESCRIPTION
- Fix rpm-lint summary issues
- Fix rpm-lint description-line-too-long issue
- Fix rpm-lint conffile-without-noreplace-flag issue
- Fix rpm-lint complains about relative path in Source
- Keep package sections together in the spec file
- Adjust the description of the project (#218)
- Move hirtectl into separate package
- Align source archive content with the one generated on GitHub
- Replace tabs with spaces in the spec file
- Align source code license with RPM license
- Move DBus configuration from /etc to /usr/share
