### PR TITLE
Use the same URL structure as systemd

### DIFF
--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -4,7 +4,7 @@ Release: @RELEASE@%{?dist}
 Summary: A systemd service controller for multi-nodes environments
 License: GPLv2+
 URL:     https://github.com/containers/hirte
-Source0: %{url}/archive/%{name}-%{version}.tar.gz
+Source0: %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires: gcc
 BuildRequires: meson


### PR DESCRIPTION
Use the same URL structure for source archive in RPM spec file as
systemd uses. This should be OK as we are now using the same structure
of the release tag `v<VERSION>`.

Signed-off-by: Martin Perina <mperina@redhat.com>
