### PR TITLE
Auto restart hirte and hirte-agent

### DIFF
--- a/systemd-units/hirte-agent.service
+++ b/systemd-units/hirte-agent.service
@@ -10,6 +10,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/hirte-agent
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd-units/hirte.service
+++ b/systemd-units/hirte.service
@@ -10,6 +10,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/hirte
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Added configuration for hirte and hirte-agent services to be automatically restarted by systemd after they crashed (using Restart=on-failure)