### PR TITLE
improved logging for loading configuration files

### DIFF
--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -480,7 +480,6 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
                         CFG_ETC_HIRTE_AGENT_CONF,
                         CFG_ETC_AGENT_CONF_DIR);
         if (result != 0) {
-                fprintf(stderr, "Error loading configuration: '%s'.", strerror(-result));
                 cfg_dispose(agent->config);
                 return false;
         }
@@ -543,6 +542,9 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
                         return false;
                 }
         }
+
+        _cleanup_free_ const char *dumped_cfg = cfg_dump(agent->config);
+        hirte_log_debug_with_data("Final configuration used", "\n%s", dumped_cfg);
 
         return true;
 }

--- a/src/libhirte/common/cfg.h
+++ b/src/libhirte/common/cfg.h
@@ -176,15 +176,9 @@ bool cfg_get_bool_value(struct config *config, const char *option_name);
 bool cfg_s_get_bool_value(struct config *config, const char *section, const char *option_name);
 
 /*
- * Iterate over configuration and for each item execute the iter function.
- * For example using following iterator method would print the whole configuration:
+ * Dump all key-value pairs in the config to a string.
  *
- *     bool config_option_iterator(const void *item, void *udata) {
- *         const struct config_option *option = item;
- *         printf("%s = %s\n", option->name, option->value);
- *         return true;
- *     }
- *
- * WARNING: configuration items are accessed directly, DO NOT modify them during iteration!!!
+ * Returns a string containing all key-value pairs in the configuration separated by new lines.
+ * The caller is responsible for freeing the returned string.
  */
-void cfg_iterate(struct config *config, bool (*iter)(const void *item, void *udata), void *udata);
+const char *cfg_dump(struct config *config);

--- a/src/libhirte/test/common/cfg_test.c
+++ b/src/libhirte/test/common/cfg_test.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 #include "libhirte/common/cfg.h"
+#include "libhirte/common/common.h"
 
 void _config_set_and_get(
                 struct config *config,
@@ -325,6 +326,21 @@ void test_env_override_config() {
         dispose_env();
 }
 
+void test_config_dump() {
+        struct config *config = NULL;
+        cfg_initialize(&config);
+
+        _config_set_and_get(config, "key1", "value1", "value1", false);
+        _config_set_and_get(config, "key2", "value4", "value4", false);
+
+        const char *expected_cfg_dump = "key1=value1\nkey2=value4\n";
+
+        _cleanup_free_ const char *cfg = cfg_dump(config);
+        assert(streq(cfg, expected_cfg_dump));
+
+        cfg_dispose(config);
+}
+
 int main() {
         test_config_set_get();
         test_config_set_get_bool();
@@ -335,5 +351,7 @@ int main() {
         test_default_section();
         test_parse_config_from_env();
         test_env_override_config();
+        test_config_dump();
+
         return EXIT_SUCCESS;
 }

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -282,7 +282,6 @@ bool manager_parse_config(Manager *manager, const char *configfile) {
         result = cfg_load_complete_configuration(
                         manager->config, CFG_HIRTE_DEFAULT_CONFIG, CFG_ETC_HIRTE_CONF, CFG_ETC_HIRTE_CONF_DIR);
         if (result != 0) {
-                fprintf(stderr, "Error loading configuration '%s'.", strerror(result));
                 cfg_dispose(manager->config);
                 return false;
         }
@@ -330,6 +329,9 @@ bool manager_parse_config(Manager *manager, const char *configfile) {
                         name = strtok_r(NULL, ",", &saveptr);
                 }
         }
+
+        _cleanup_free_ const char *dumped_cfg = cfg_dump(manager->config);
+        hirte_log_debug_with_data("Final configuration used", "\n%s", dumped_cfg);
 
         /* TODO: Handle per-node-name option section */
 
@@ -837,7 +839,7 @@ bool manager_start(Manager *manager) {
         int r = sd_bus_request_name(
                         manager->api_bus, manager->api_bus_service_name, SD_BUS_NAME_REPLACE_EXISTING);
         if (r < 0) {
-                hirte_log_errorf("Failed to acquire service name on user dbus: %s", strerror(-r));
+                hirte_log_errorf("Failed to acquire service name on api dbus: %s", strerror(-r));
                 return false;
         }
 


### PR DESCRIPTION
This PR 
- introduces a `cfg_dump` to log the final configuration being used (on debug level)
- adds more concise logging when loading the configuration
- removes any return when failing to load a configuration file (except for OOM errors) as a following configuration might be valid as well