### PR TITLE
Cleanup conf and man pages

### DIFF
--- a/config/agent/agent.conf
+++ b/config/agent/agent.conf
@@ -12,31 +12,29 @@ NodeName=
 
 #
 # The IP address that hirte-agent can use to connect to hirte manager. It must be a valid IPv4 or IPv6 address.
-# It's mandatory to set either ManagerHost or ManagerAddress option for each hirte-agent.
+# One of the ManagerHost or ManagerAddress options must be set for each hirte-agent.
 ManagerHost=
 
 #
-# The port the manager listens on to establish connections with the hirte
-# agents.
+# The port the manager listens on to establish connections with the hirte agents.
 #ManagerPort=842
 
 #
 # SD Bus address used by hirte-agent to connect to hirte. See `man sd_bus_set_address` for its format.
-# Overrides any setting of ManagerHost or ManagerPort defined in the configuration file as well as the respective
-# CLI options.
+# The ManagerAddress overrides any setting of ManagerHost or ManagerPort defined in the configuration file as well as
+# the respective CLI options.
 #ManagerAddress=
 
 #
-# Defines the interval between two heartbeat signals sent to hirte in milliseconds. 
-#HeartbeatInterval=
+# Defines the interval between two heartbeat signals sent to hirte in milliseconds.
+#HeartbeatInterval=2000
 
 #
 # The level used for logging. Supported values are: DEBUG, INFO, WARN and ERROR.
 #LogLevel=INFO
 
 #
-# The target where logs are written to. Supported values are: journald and
-# stderr.
+# The target where logs are written to. Supported values are: journald and stderr.
 #LogTarget=journald
 
 #

--- a/config/hirte/hirte.conf
+++ b/config/hirte/hirte.conf
@@ -7,14 +7,13 @@
 [hirte]
 
 #
-# A comma separated list of unique hirte-agent names. Only nodes with names mentioned in the list can connect to
-# hirte manager. These names are defined in the agent's configuration file under `NodeName` option
+# A comma separated list of unique hirte-agent names. Only nodes with names mentioned in the list can connect to hirte
+# manager. These names are defined in the agent's configuration file under the `NodeName` option.
 # (see `hirte-agent.conf(5)`).
 AllowedNodeNames=
 
 #
-# The port the manager listens on to establish connections with the hirte
-# agents.
+# The port the manager listens on to establish connections with the hirte agents.
 #ManagerPort=842
 
 #
@@ -22,8 +21,7 @@ AllowedNodeNames=
 #LogLevel=INFO
 
 #
-# The target where logs are written to. Supported values are: journald and
-# stderr.
+# The target where logs are written to. Supported values are: journald and stderr.
 #LogTarget=journald
 
 #

--- a/doc/man/hirte-agent.1.md
+++ b/doc/man/hirte-agent.1.md
@@ -28,7 +28,7 @@ The host used by `hirte-agent` to connect to `hirte`. Must be a valid IPv4 or IP
 
 #### **--port**, **-p**
 
-The port on which `hirte` is listening for connection request and the `hirte-agent` is connecting to. This option will overwrite the port defined in the configuration file.
+The port on which `hirte` is listening for connection request and the `hirte-agent` is connecting to. This option will overwrite the port defined in the configuration file. (default: 842)
 
 #### **--address**, **-a**
 
@@ -45,7 +45,7 @@ The interval between two heartbeat signals sent to hirte in milliseconds. This o
 
 #### **--config**, **-c**
 
-Path to the configuration file, see `hirte-agent.conf(5)`.
+Path to the configuration file, see `hirte-agent.conf(5)`. (default: /etc/hirte/agent.conf)
 
 #### **--user**
 

--- a/doc/man/hirte-agent.conf.5.md
+++ b/doc/man/hirte-agent.conf.5.md
@@ -92,6 +92,9 @@ LogLevel=DEBUG
 LogTarget=journald
 LogIsQuiet=false
 ```
+## FILES
+
+Distributions provide the __/usr/share/hirte-agent/config/hirte-default.conf__ file which defines hirte-agent configuration defaults. Administrators can copy this file to __/etc/hirte/agent.conf__ and specify their own configuration.
 
 ## SEE ALSO
 


### PR DESCRIPTION
Identify in the hire-agent man page where the /etc/hirte/agent.conf file is supposed to be installed.

Also don't go over 120 characters in the conf files, to make them easier to view in terminals as well as editors.

Add builtin default settings to conf files so users have better idea of what is set when not commented out.