### PR TITLE
Fix SELinux build on centos stream 9

### DIFF
--- a/selinux/hirte.te
+++ b/selinux/hirte.te
@@ -46,7 +46,6 @@ kernel_dgram_send(hirte_t)
 
 logging_send_syslog_msg(hirte_t)
 logging_read_syslog_pid(hirte_t)
-logging_write_syslog_pid_socket(hirte_t)
 
 ########################################
 #
@@ -66,7 +65,6 @@ miscfiles_read_localization(hirte_agent_t)
 
 logging_send_syslog_msg(hirte_agent_t)
 logging_read_syslog_pid(hirte_agent_t)
-logging_write_syslog_pid_socket(hirte_agent_t)
 
 allow hirte_agent_t self:tcp_socket create_stream_socket_perms;
 allow hirte_agent_t hirte_port_t:tcp_socket name_connect;


### PR DESCRIPTION
logging_write_syslog_pid_socket method does not exists, and I don't think it is necessary, so just removing it.