### PR TITLE
SELinux RPM - set selinuxtype to targeted

### DIFF
--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -103,6 +103,8 @@ Requires: selinux-policy >= %{_selinux_policy_version}
 
 Requires(post): policycoreutils
 
+%global selinuxtype	targeted
+
 %description selinux
 SELinux policy associated with the hirte and hirte-agent daemons
 


### PR DESCRIPTION
The policy installation command in the `post` step uses this global without setting it. As a result, the policy does not get installed