### PR TITLE
Allow building the RPM locally without root privileges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 
 builddir
 tags
+
+hirte.spec
+rpmbuild/

--- a/README.developer.md
+++ b/README.developer.md
@@ -149,3 +149,27 @@ sudo dnf install golang-github-cpuguy83-md2man
 ```
 
 After executing a `meson install` the MAN pages are located in the `man/man*` directories.
+
+## Packaging
+
+Hirte is packaged as an RPM. The scripts used to create the SRPM and RPM may be found in [.build-scripts](./build-scripts).
+
+The RPM creation [script](./build-scripts/build-rpm.sh) requires one environment variable:
+
+- `ARTIFACTS_DIR` - full path to a directory where the RPMs will be saved.
+  The script will create the directory if it does not exist
+
+Please note that the RPM creation script also installs all build dependencies and therefore requires running with root privileges
+
+In order to build an RPM locally use the following command:
+
+```bash
+sudo ARTIFACTS_DIR=${PWD}/output ./build-scripts/build-rpm.sh
+```
+
+Alternatively, by setting the environment variable `SKIP_BUILDDEP=yes`,
+the installation process is skipped, allowing regular user permissions
+
+```bash
+SKIP_BUILDDEP=yes ARTIFACTS_DIR=${PWD}/output ./build-scripts/build-rpm.sh
+```

--- a/build-scripts/build-rpm.sh
+++ b/build-scripts/build-rpm.sh
@@ -4,7 +4,9 @@
 source $(dirname "$(readlink -f "$0")")/build-srpm.sh
 
 # Install build dependencies
-dnf builddep -y rpmbuild/SRPMS/*src.rpm
+if [ "${SKIP_BUILDDEP}" != "yes" ]; then
+    dnf builddep -y rpmbuild/SRPMS/*src.rpm
+fi
 
 # Build binary package
 rpmbuild \


### PR DESCRIPTION
Add a packaging section to the developer doc
Add rpm build products to .gitignore