### PR TITLE
Default Hirte Agent NodeName to hostname

### DIFF
--- a/config/agent/agent.conf
+++ b/config/agent/agent.conf
@@ -7,7 +7,7 @@
 [hirte-agent]
 #
 # The unique name of this agent.
-# It's mandatory to set this option for each hirte-agent.
+# NodeName defaults the system's hostname.
 NodeName=
 
 #

--- a/config/agent/hirte-default.conf
+++ b/config/agent/hirte-default.conf
@@ -3,7 +3,7 @@
 [hirte-agent]
 #
 # The unique name of this agent.
-# It's mandatory to set this option for each hirte-agent.
+# NodeName defaults the system's hostname.
 NodeName=
 
 #

--- a/doc/man/hirte-agent.conf.5.md
+++ b/doc/man/hirte-agent.conf.5.md
@@ -20,8 +20,7 @@ by `hirte-agent`.
 
 #### **NodeName** (string)
 
-The unique name of this agent. The option doesn't have a default value, it's mandatory to set this option for each
-`hirte-agent`.
+The unique name of this agent. The option defaults to the system's hostname.
 
 #### **ManagerAddress** (string)
 

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -335,6 +335,7 @@ Agent *agent_new(void) {
         agent->connection_state = AGENT_CONNECTION_STATE_DISCONNECTED;
         agent->connection_retry_count = 0;
 
+        agent->name = get_hostname();
         return steal_pointer(&agent);
 }
 

--- a/src/libhirte/common/protocol.c
+++ b/src/libhirte/common/protocol.c
@@ -43,3 +43,13 @@ UnitActiveState active_state_from_string(const char *s) {
         }
         return _UNIT_ACTIVE_STATE_INVALID;
 }
+
+char *get_hostname() {
+        char hostname[BUFSIZ];
+        memset((char *) hostname, 0, sizeof(hostname));
+        if (gethostname(hostname, sizeof(hostname)) < 0) {
+                fprintf(stderr, "Warning failed to gethostname, error code '%s'.\n", strerror(-errno));
+                return "";
+        }
+        return strdup(hostname);
+}

--- a/src/libhirte/common/protocol.h
+++ b/src/libhirte/common/protocol.h
@@ -86,6 +86,8 @@ typedef enum UnitActiveState {
 const char *active_state_to_string(UnitActiveState s);
 UnitActiveState active_state_from_string(const char *s);
 
+char *get_hostname();
+
 /* Agent to Hirte heartbeat signals */
 
 // Application-level heartbeat set at 2 seconds.


### PR DESCRIPTION
If the user does not specify a NodeName in the
agent config, then hirte-agent should default to
the system's hostname.