### PR TITLE
hirte-agent crashes if config files are not present

### DIFF
--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -481,6 +481,7 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
                         CFG_ETC_AGENT_CONF_DIR);
         if (result != 0) {
                 cfg_dispose(agent->config);
+                agent->config = NULL;
                 return false;
         }
 


### PR DESCRIPTION
If you call cgd_dispose then you need to null the value.