### PR TITLE
Better default dbus policy

### DIFF
--- a/data/org.containers.hirte.Agent.conf.in
+++ b/data/org.containers.hirte.Agent.conf.in
@@ -9,7 +9,15 @@
   </policy>
 
   <policy context="default">
-    <allow send_destination="org.containers.hirte.Agent"/>
+    <deny send_destination="org.freedesktop.systemd1"/>
+
+    <!-- Completely open to anyone: org.freedesktop.DBus.* introspaction  -->
+    <allow send_destination="org.containers.hirte.Agent"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+
+    <allow send_destination="org.containers.hirte.Agent"
+           send_interface="org.freedesktop.DBus.Peer"/>
+
     <allow receive_sender="org.containers.hirte.Agent"/>
   </policy>
 

--- a/data/org.containers.hirte.conf.in
+++ b/data/org.containers.hirte.conf.in
@@ -9,7 +9,15 @@
   </policy>
 
   <policy context="default">
-    <allow send_destination="org.containers.hirte"/>
+    <deny send_destination="org.freedesktop.systemd1"/>
+
+    <!-- Completely open to anyone: org.freedesktop.DBus.* introspaction  -->
+    <allow send_destination="org.containers.hirte"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+
+    <allow send_destination="org.containers.hirte"
+           send_interface="org.freedesktop.DBus.Peer"/>
+
     <allow receive_sender="org.containers.hirte"/>
   </policy>
 


### PR DESCRIPTION
The existing policy allowed anyone to send messages to hirte, which isn't ideal. It also isn't a huge issue as the default policy disallows sending any method calls even if you are allowed to send messages in general.

However, it seems better to disallow messages in general, and just open up a few specific methods. This change allows the basic introspection but nothing more.

This is a bit more limited than what the systemd configuration uses, as that allows anyone to use a lot of read-only APIs. However, readonly access to hirte would be give read access to other machines too, so it makes sense to be more limited.