### PR TITLE
dbus policy: Fix typo in previous commit

### DIFF
--- a/data/org.containers.hirte.Agent.conf.in
+++ b/data/org.containers.hirte.Agent.conf.in
@@ -9,7 +9,7 @@
   </policy>
 
   <policy context="default">
-    <deny send_destination="org.freedesktop.systemd1"/>
+    <deny send_destination="org.containers.hirte.Agent"/>
 
     <!-- Completely open to anyone: org.freedesktop.DBus.* introspaction  -->
     <allow send_destination="org.containers.hirte.Agent"

--- a/data/org.containers.hirte.conf.in
+++ b/data/org.containers.hirte.conf.in
@@ -9,7 +9,7 @@
   </policy>
 
   <policy context="default">
-    <deny send_destination="org.freedesktop.systemd1"/>
+    <deny send_destination="org.containers.hirte"/>
 
     <!-- Completely open to anyone: org.freedesktop.DBus.* introspaction  -->
     <allow send_destination="org.containers.hirte"


### PR DESCRIPTION
We're supposed to deny hirte access, not systemd access.