### PR TITLE
fix loading confd files and related memory leaks

### DIFF
--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -423,6 +423,7 @@ void agent_unref(Agent *agent) {
 
         if (agent->config) {
                 cfg_dispose(agent->config);
+                agent->config = NULL;
         }
         free(agent);
 }
@@ -481,8 +482,6 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
                         CFG_ETC_HIRTE_AGENT_CONF,
                         CFG_ETC_AGENT_CONF_DIR);
         if (result != 0) {
-                cfg_dispose(agent->config);
-                agent->config = NULL;
                 return false;
         }
 

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -283,8 +283,6 @@ bool manager_parse_config(Manager *manager, const char *configfile) {
         result = cfg_load_complete_configuration(
                         manager->config, CFG_HIRTE_DEFAULT_CONFIG, CFG_ETC_HIRTE_CONF, CFG_ETC_HIRTE_CONF_DIR);
         if (result != 0) {
-                cfg_dispose(manager->config);
-                manager->config = NULL;
                 return false;
         }
 


### PR DESCRIPTION
This PR fixes #251 by passing the assembled file path (not only the file name) to `cfg_load_from_file()`, properly freeing memory in `cfg_load_from_dir()` and only freeing `cfg` once. 