### PR TITLE
RPM: requires policycoreutils-python-utils

### DIFF
--- a/hirte.spec.in
+++ b/hirte.spec.in
@@ -102,6 +102,8 @@ Requires: selinux-policy >= %{_selinux_policy_version}
 %endif
 
 Requires(post): policycoreutils
+Requires(post): policycoreutils-python-utils
+Requires(postun): policycoreutils-python-utils
 
 %global selinuxtype	targeted
 


### PR DESCRIPTION
policycoreutils-python-utils provides /usr/sbin/semanage

Resolves: #262

@rhatdan @mwperina @pypingou PTAL