### PR TITLE
fixed cfg_dump unit test

### DIFF
--- a/src/libhirte/test/common/cfg_test.c
+++ b/src/libhirte/test/common/cfg_test.c
@@ -333,10 +333,9 @@ void test_config_dump() {
         _config_set_and_get(config, "key1", "value1", "value1", false);
         _config_set_and_get(config, "key2", "value4", "value4", false);
 
-        const char *expected_cfg_dump = "key1=value1\nkey2=value4\n";
-
         _cleanup_free_ const char *cfg = cfg_dump(config);
-        assert(streq(cfg, expected_cfg_dump));
+        assert(strstr(cfg, "key1=value1\n") != NULL);
+        assert(strstr(cfg, "key2=value4\n") != NULL);
 
         cfg_dispose(config);
 }


### PR DESCRIPTION
This PR fixes the unit test for `cfg_dump` by checking if the individual key-value pair is in the dump instead of validating the full output. Since the items in a hashmap are not sorted, this can cause test failures (which already happend on x390s, for example - see [this copr build](https://download.copr.fedorainfracloud.org/results/mperina/hirte-snapshot/fedora-rawhide-s390x/05869114-hirte/builder-live.log.gz)). 