### PR TITLE
Run lint and rpmbuild+e2e-tests in parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,6 @@ jobs:
           path: ./builddir/meson-logs/testlog-valgrind.txt
 
   rpmbuild:
-    needs: lint
     runs-on: ubuntu-latest
     container:
       image: quay.io/centos/centos:stream9


### PR DESCRIPTION
Originally we wanted lint to be executed before rpmbuild to catch simple
style error, but unfortunately markdown lint takes a lot of time and
also to peform C code linting we need to build the project due to
internal meson dependencies.
Current average times of job executions are:

 * lint:       2min 10sec
 * rpmbuild:   1min 13sec
 * e2e tests:  3min 20sec

So we can save some time in CI processing by running lint and rpmbuild
in parallel.

Signed-off-by: Martin Perina <mperina@redhat.com>
