### PR TITLE
Allow hirte to communicate with unconfined user

### DIFF
--- a/selinux/hirte.te
+++ b/selinux/hirte.te
@@ -87,3 +87,5 @@ stream_connect_pattern(hirte_agent_t, haproxy_var_lib_t, haproxy_var_lib_t, hapr
 
 manage_sock_files_pattern(init_t, haproxy_var_lib_t, haproxy_var_lib_t)
 manage_sock_files_pattern(init_t, haproxy_var_run_t, haproxy_var_run_t)
+
+unconfined_dbus_chat(hirte_t)


### PR DESCRIPTION
When running hirtectl by an unconfined user, the
unconfined_t domain is dbus communicationg with the hirte_t domain.