### PR TITLE
Don't run linters on merge

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,6 @@
 name: Lint
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
When PR is merged, the whole repo needs to be checked out for the
paths-filter to be able to read changed files. It would be possible to
add checkout to the workflow, but it's enough to run linter on the PR,
because it should be used for owner/reviewers to fix linter issues
before PR is merged.

Signed-off-by: Martin Perina <mperina@redhat.com>
