### PR TITLE
removed meson from rpm build scripts

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -4,5 +4,6 @@ installdeps:
 	dnf -y install gcc git jq meson systemd-devel rpm-build
 
 srpm: installdeps
-	./build-scripts/build-srpm.sh
+	meson setup builddir
+	ninja -C builddir srpm
 	cp rpmbuild/SRPMS/*.src.rpm $(outdir)

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,7 +49,8 @@ jobs:
 
       - name: Perform build
         run: |
-          ./build-scripts/build-rpm.sh $ARTIFACTS_DIR
+          meson setup builddir
+          make rpm
 
       - name: Create DNF repository
         run: |

--- a/Makefile
+++ b/Makefile
@@ -48,12 +48,11 @@ clean:
 	find . -name \*# -delete
 	meson setup --wipe $(BUILDDIR)
 
-rpm: srpm
-	@build-scripts/build-rpm.sh
+rpm:
+	ninja -C $(BUILDDIR) rpm
 
 srpm: 
-	@rpmbuild || (echo "For building RPM package, rpmbuild command is required. To install use: dnf install rpm-build"; exit 1)
-	@build-scripts/build-srpm.sh
+	ninja -C $(BUILDDIR) srpm
 
 distclean: clean
 	rm -rf $(BUILDDIR)

--- a/build-scripts/build-srpm.sh
+++ b/build-scripts/build-srpm.sh
@@ -1,9 +1,15 @@
 #!/bin/bash -xe
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# Parse package version from the project
-meson setup builddir
-VERSION="$(meson introspect --projectinfo builddir | jq -r '.version')"
+if [ -z "$1" ]; then
+    echo "Missing first argument: version"
+fi
+VERSION=$1
+
+if [ -z "$2" ]; then
+    echo "Missing second argument: source directory"
+fi
+cd $2
 
 # Mark current directory as safe for git to be able to parse git hash
 git config --global --add safe.directory $(pwd)

--- a/meson.build
+++ b/meson.build
@@ -76,3 +76,12 @@ if clangtidy.found()
   run_target('clang-tidy', command : ['build-scripts/clang-tidy-all.sh'])
   run_target('clang-tidy-fix', command : ['build-scripts/clang-tidy-all.sh', '--fix'])
 endif
+
+# add custom rpmbuild targets
+rpmbuild = find_program('rpmbuild', required : false)
+if rpmbuild.found()
+  run_target('srpm', command : ['build-scripts/build-srpm.sh', meson.project_version(), meson.source_root()])
+  run_target('rpm', command : ['build-scripts/build-rpm.sh', meson.project_version(), meson.source_root()])
+else
+  message('For building RPM package, rpmbuild command is required.')
+endif


### PR DESCRIPTION
This PR changes the rpm build scripts to receive the current hirte version as parameter. This way the custom meson targets `srpm` and `rpm` can pass the `meson.project_version()` - which removes the dependency of the scripts on meson. 