### PR TITLE
Fix importing the python examples in the doc

### DIFF
--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -22,4 +22,5 @@ markdown_extensions:
   - sane_lists
   - smarty
   - admonition
-  - pymdownx.snippets
+  - pymdownx.snippets:
+     base_path: ["doc"]


### PR DESCRIPTION
Basically, our example files were not being found when the doc was built on read-the-docs. This was due to the fact that rtd wasn't finding the file. By specifying a base_path in the mkdocs.yml config file, all the paths to the files we want to include can be made relative to this base_path. Using this mechanism, rtd is able to find the snippets to include in the doc and it is also working locally for developpers.