### PR TITLE
Add debug monitor to Manager.

### DIFF
--- a/README.developer.md
+++ b/README.developer.md
@@ -94,6 +94,37 @@ After building, three binaries are available:
 - `hirte-agent`: the node agent unit which connects with the controller and executes commands on the node machine
 - `hirtectl`: a helper (CLI) program to send an commands to the controller
 
+### Debugging
+
+Debug prints can be written to the systemd journal or stderr.
+
+Periodic debug prints for `hirte` can be added in `hirte/src/manager/manager.c`, in function
+`manager_debug_monitor_timer_callback()`.  The interval in milliseconds for these prints can be
+set with the `hirte` config option, `DebugMonitorInterval`.  The default is zero milliseconds,
+which prevents the periodic function from getting invoked.
+
+Periodic debug prints for `hirte-agent` can be added in `hirte/src/agent/agent.c`, in function
+`agent_heartbeat_timer_callback()`.  The interval in milliseconds for these prints can set with
+the `hirte-agent` config option, `HeartbeatInterval`.
+
+Suppose you would like `hirte` to output the connected nodes to stderr every 2 seconds.
+`/etc/hirte/hirte.conf` could be set as follows:
+```bash
+[hirte]
+ManagerPort=1999
+AllowedNodeNames=agent-001,agent-002
+LogLevel=DEBUG
+LogTarget=stderr-full
+LogIsQuiet=false
+DebugMonitorInterval=2000
+```
+
+If `agent-001` and `agent-002` are connected, `hirte` outputs the following prints every 2 seconds:
+```bash
+15:04:26 DEBUG  ../src/manager/manager.c:845 manager_debug_monitor_timer_callback   msg="../src/manager/manager.c:845: manager_debug_monitor_timer_callback(): connected node name = agent-001"
+15:04:26 DEBUG  ../src/manager/manager.c:845 manager_debug_monitor_timer_callback   msg="../src/manager/manager.c:845: manager_debug_monitor_timer_callback(): connected node name = agent-002"
+```
+
 ### Unit tests
 
 Unit tests can be executed using following commands

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -464,7 +464,6 @@ bool agent_set_heartbeat_interval(Agent *agent, const char *interval_msec) {
         return true;
 }
 
-
 void agent_set_systemd_user(Agent *agent, bool systemd_user) {
         agent->systemd_user = systemd_user;
 }

--- a/src/libhirte/common/cfg.h
+++ b/src/libhirte/common/cfg.h
@@ -17,6 +17,7 @@
 #define CFG_NODE_NAME "NodeName"
 #define CFG_ALLOWED_NODE_NAMES "AllowedNodeNames"
 #define CFG_HEARTBEAT_INTERVAL "HeartbeatInterval"
+#define CFG_DEBUG_MONITOR_INTERVAL "DebugMonitorInterval"
 
 /*
  * Global section - this is used, when configuration options are specified in the configuration file

--- a/src/libhirte/common/opt.h
+++ b/src/libhirte/common/opt.h
@@ -13,9 +13,13 @@
 #define ARG_ADDRESS_SHORT 'a'
 #define ARG_ADDRESS_SHORT_S "a:"
 
-#define ARG_HEARTBEAT_INTERVAL "interval"
+#define ARG_HEARTBEAT_INTERVAL "heartbeat-interval"
 #define ARG_HEARTBEAT_INTERVAL_SHORT 'i'
 #define ARG_HEARTBEAT_INTERVAL_SHORT_S "i:"
+
+#define ARG_DEBUG_MONITOR_INTERVAL "debug-monitor-interval"
+#define ARG_DEBUG_MONITOR_INTERVAL_SHORT 'd'
+#define ARG_DEBUG_MONITOR_INTERVAL_SHORT_S "d:"
 
 #define ARG_CONFIG "config"
 #define ARG_CONFIG_SHORT 'c'

--- a/src/manager/manager.h
+++ b/src/manager/manager.h
@@ -32,6 +32,8 @@ struct Manager {
         LIST_HEAD(Subscription, all_subscriptions);
 
         struct config *config;
+
+        long debug_monitor_interval_msec;
 };
 
 Manager *manager_new(void);

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -931,8 +931,7 @@ static int node_disconnected(UNUSED sd_bus_message *message, void *userdata, UNU
         if (node->name == NULL) {
                 manager_remove_node(manager, node);
         } else {
-                /* Remove all jobs associated with the registered node that got
-                   disconnected. */
+                /* Remove all jobs for the disconnected node. */
                 if (!LIST_IS_EMPTY(manager->jobs)) {
                         Job *job = NULL;
                         Job *next_job = NULL;


### PR DESCRIPTION
This PR addresses issue #312.

To use debug monitor for development debugging, add "DebugMonitorInterval" to the hirte config.  For example:

[hirte]
ManagerPort=1999
AllowedNodeNames=agent-001,agent-002
LogLevel=DEBUG
LogTarget=stderr-full
LogIsQuiet=false
DebugMonitorInterval=2000

The debug monitor has an interval of zero by default, which prevents its use in production. 