### PR TITLE
log: improve timestamps on stderr log output

### DIFF
--- a/src/libhirte/common/time-util.c
+++ b/src/libhirte/common/time-util.c
@@ -1,6 +1,9 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
+#include <errno.h>
+#include <stdio.h>
 #include <time.h>
 
+#include "libhirte/common/common.h"
 #include "time-util.h"
 
 uint64_t get_time_micros() {
@@ -19,4 +22,32 @@ uint64_t finalize_time_interval_micros(int64_t start_time_micros) {
 
 double micros_to_millis(uint64_t time_micros) {
         return (double) time_micros * microsec_to_millisec_multiplier;
+}
+
+char *get_formatted_log_timestamp() {
+        struct timespec now;
+        int r = 0;
+        r = clock_gettime(CLOCK_REALTIME, &now);
+        if (r < 0) {
+                return NULL;
+        }
+        return get_formatted_log_timestamp_for_timespec(now);
+}
+
+char *get_formatted_log_timestamp_for_timespec(struct timespec time) {
+        const size_t timestamp_size = 20;
+        const size_t timestamp_with_millis_size = timestamp_size + 4;
+        const size_t timestamp_offset_size = 7;
+        const size_t timestamp_full_size = timestamp_with_millis_size + timestamp_offset_size;
+        char timebuf[timestamp_size];
+        char offsetbuf[timestamp_offset_size];
+        char *timebuf_full = malloc0(timestamp_full_size);
+        struct tm *time_tm = localtime(&time.tv_sec);
+
+        strftime(timebuf, timestamp_size, "%Y-%m-%d %H:%M:%S", time_tm);
+        uint64_t millis = (uint64_t) ((double) time.tv_nsec * nanosec_to_millisec_multiplier);
+        strftime(offsetbuf, timestamp_offset_size, "%z", time_tm);
+        snprintf(timebuf_full, timestamp_full_size, "%s,%ld%s", timebuf, millis % millis_in_second, offsetbuf);
+
+        return timebuf_full;
 }

--- a/src/libhirte/common/time-util.c
+++ b/src/libhirte/common/time-util.c
@@ -31,10 +31,10 @@ char *get_formatted_log_timestamp() {
         if (r < 0) {
                 return NULL;
         }
-        return get_formatted_log_timestamp_for_timespec(now);
+        return get_formatted_log_timestamp_for_timespec(now, false);
 }
 
-char *get_formatted_log_timestamp_for_timespec(struct timespec time) {
+char *get_formatted_log_timestamp_for_timespec(struct timespec time, bool is_gmt) {
         const size_t timestamp_size = 20;
         const size_t timestamp_with_millis_size = timestamp_size + 4;
         const size_t timestamp_offset_size = 7;
@@ -42,12 +42,12 @@ char *get_formatted_log_timestamp_for_timespec(struct timespec time) {
         char timebuf[timestamp_size];
         char offsetbuf[timestamp_offset_size];
         char *timebuf_full = malloc0(timestamp_full_size);
-        struct tm *time_tm = localtime(&time.tv_sec);
+        struct tm *time_tm = is_gmt ? gmtime(&time.tv_sec) : localtime(&time.tv_sec);
 
         strftime(timebuf, timestamp_size, "%Y-%m-%d %H:%M:%S", time_tm);
         uint64_t millis = (uint64_t) ((double) time.tv_nsec * nanosec_to_millisec_multiplier);
         strftime(offsetbuf, timestamp_offset_size, "%z", time_tm);
-        snprintf(timebuf_full, timestamp_full_size, "%s,%ld%s", timebuf, millis % millis_in_second, offsetbuf);
+        snprintf(timebuf_full, timestamp_full_size, "%s,%03ld%s", timebuf, millis % millis_in_second, offsetbuf);
 
         return timebuf_full;
 }

--- a/src/libhirte/common/time-util.h
+++ b/src/libhirte/common/time-util.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 
 static const uint64_t sec_to_microsec_multiplier = 1000000;
@@ -14,4 +15,4 @@ uint64_t get_time_micros();
 uint64_t finalize_time_interval_micros(int64_t start_time_micros);
 double micros_to_millis(uint64_t time_micros);
 char *get_formatted_log_timestamp();
-char *get_formatted_log_timestamp_for_timespec(struct timespec time);
+char *get_formatted_log_timestamp_for_timespec(struct timespec time, bool is_gmt);

--- a/src/libhirte/common/time-util.h
+++ b/src/libhirte/common/time-util.h
@@ -2,11 +2,16 @@
 #pragma once
 
 #include <inttypes.h>
+#include <stdlib.h>
 
 static const uint64_t sec_to_microsec_multiplier = 1000000;
 static const double microsec_to_millisec_multiplier = 1e-3;
 static const double nanosec_to_microsec_multiplier = 1e-3;
+static const double nanosec_to_millisec_multiplier = 1e-6;
+static const uint64_t millis_in_second = 1000;
 
 uint64_t get_time_micros();
 uint64_t finalize_time_interval_micros(int64_t start_time_micros);
 double micros_to_millis(uint64_t time_micros);
+char *get_formatted_log_timestamp();
+char *get_formatted_log_timestamp_for_timespec(struct timespec time);

--- a/src/libhirte/log/log.c
+++ b/src/libhirte/log/log.c
@@ -2,6 +2,7 @@
 #include <errno.h>
 
 #include "libhirte/common/common.h"
+#include "libhirte/common/time-util.h"
 
 #include "log.h"
 
@@ -90,21 +91,17 @@ int hirte_log_to_stderr_full_with_location(
                 const char *func,
                 const char *msg,
                 const char *data) {
-
-        time_t t = time(NULL);
-        const size_t timestamp_size = 9;
-        char timebuf[timestamp_size];
-        timebuf[strftime(timebuf, sizeof(timebuf), "%H:%M:%S", localtime(&t))] = '\0';
+        _cleanup_free_ char *timestamp = get_formatted_log_timestamp();
 
         // clang-format off
         if (data && *data) {
                 fprintf(stderr, "%s %s\t%s:%s %s\tmsg=\"%s\", data=\"%s\"\n",
-                        timebuf, log_level_to_string(lvl),
+                        timestamp, log_level_to_string(lvl),
                         file, line, func,
                         msg, data);
         } else {
                 fprintf(stderr, "%s %s\t%s:%s %s\tmsg=\"%s\"\n",
-                        timebuf, log_level_to_string(lvl),
+                        timestamp, log_level_to_string(lvl),
                         file, line, func,
                         msg);
         }
@@ -119,7 +116,8 @@ int hirte_log_to_stderr_with_location(
                 UNUSED const char *func,
                 const char *msg,
                 UNUSED const char *data) {
-        fprintf(stderr, "%s\t: %s\n", log_level_to_string(lvl), msg);
+        _cleanup_free_ char *timestamp = get_formatted_log_timestamp();
+        fprintf(stderr, "%s %s\t: %s\n", timestamp, log_level_to_string(lvl), msg);
         return 0;
 }
 

--- a/src/libhirte/test/common/meson.build
+++ b/src/libhirte/test/common/meson.build
@@ -4,7 +4,8 @@ common_src = [
   'cfg_test',
   'list_test',
   'parse-util_test',
-  'string-util_test'
+  'string-util_test',
+  'time-util_test'
 ]
 
 foreach src : common_src

--- a/src/libhirte/test/common/time-util_test.c
+++ b/src/libhirte/test/common/time-util_test.c
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "libhirte/common/common.h"
+#include "libhirte/common/string-util.h"
+#include "libhirte/common/time-util.h"
+
+bool test_get_log_timestamp(__time_t tv_sec, __time_t tv_nsec, char *expected_timestamp) {
+        struct timespec time;
+        time.tv_sec = tv_sec;
+        time.tv_nsec = tv_nsec;
+        _cleanup_free_ char *timestamp = get_formatted_log_timestamp_for_timespec(time, true);
+
+        if (streq(timestamp, expected_timestamp)) {
+                return true;
+        }
+
+        fprintf(stdout,
+                "FAILED: for time (%ldsec, %ldnsec) - Expected %s, but got %s\n",
+                tv_sec,
+                tv_nsec,
+                expected_timestamp,
+                timestamp);
+        return false;
+}
+
+int main() {
+        bool result = true;
+
+        result = result && test_get_log_timestamp(0, 0, "1970-01-01 00:00:00,000+0000");
+        result = result && test_get_log_timestamp(1687075200, 0, "2023-06-18 08:00:00,000+0000");
+        result = result && test_get_log_timestamp(1687075200, 999999999, "2023-06-18 08:00:00,999+0000");
+        result = result && test_get_log_timestamp(1687075200, 999000000, "2023-06-18 08:00:00,999+0000");
+        result = result && test_get_log_timestamp(1687075200, 998900000, "2023-06-18 08:00:00,998+0000");
+        result = result && test_get_log_timestamp(1687046399, 999000000, "2023-06-17 23:59:59,999+0000");
+
+        if (result) {
+                return EXIT_SUCCESS;
+        }
+        return EXIT_FAILURE;
+}


### PR DESCRIPTION
This adds date and milliseconds to the timestamp output to stderr-full, and also adds timestamp to stderr log output

```
[mkemel@lptp systemd]$ sudo hirte-agent -c ~/hirte-conf/agent.conf
2023-06-12 08:56:46,331+0300 DEBUG	: Final configuration used
2023-06-12 08:56:46,332+0300 DEBUG	: Connected to system bus
2023-06-12 08:56:46,332+0300 DEBUG	: Connected to systemd bus
2023-06-12 08:56:46,336+0300 INFO	: Connecting to manager on tcp:host=127.0.0.1,port=842
2023-06-12 08:56:46,337+0300 INFO	: Connected to manager as 'laptop'
```