### PR TITLE
Add support for unit file enable and disable and daemon-reload

### DIFF
--- a/data/org.containers.hirte.Node.xml
+++ b/data/org.containers.hirte.Node.xml
@@ -43,9 +43,22 @@
       <arg name="runtime" type="b" direction="in" />
       <arg name="keyvalues" type="a(sv)" direction="in" />
     </method>
+    <method name="EnableUnitFiles">
+      <arg name="files" type="as" direction="in" />
+      <arg name="runtime" type="b" direction="in" />
+      <arg name="force" type="b" direction="in" />
+      <arg name="carries_install_info" type="b" direction="out" />
+      <arg name="changes" type="a{sss}" direction="out" />
+    </method>
+    <method name="DisableUnitFiles">
+      <arg name="files" type="as" direction="in" />
+      <arg name="runtime" type="b" direction="in" />
+      <arg name="changes" type="a{sss}" direction="out" />
+    </method>
     <method name="ListUnits">
       <arg name="units" type="a(ssssssouso)" direction="out" />
     </method>
+    <method name="Reload" />
 
     <property name="Name" type="s" access="read" />
     <property name="Status" type="s" access="read" />

--- a/data/org.containers.hirte.internal.Agent.xml
+++ b/data/org.containers.hirte.internal.Agent.xml
@@ -43,6 +43,18 @@
       <arg name="runtime" type="b" direction="in" />
       <arg name="keyvalues" type="a(sv)" direction="in" />
     </method>
+    <method name="EnableUnitFiles">
+      <arg name="files" type="as" direction="in" />
+      <arg name="runtime" type="b" direction="in" />
+      <arg name="force" type="b" direction="in" />
+      <arg name="carries_install_info" type="b" direction="out" />
+      <arg name="changes" type="a{sss}" direction="out" />
+    </method>
+    <method name="DisableUnitFiles">
+      <arg name="files" type="as" direction="in" />
+      <arg name="runtime" type="b" direction="in" />
+      <arg name="changes" type="a{sss}" direction="out" />
+    </method>
     <method name="ListUnits">
       <arg name="units" type="a(ssssssouso)" direction="out" />
     </method>
@@ -60,6 +72,7 @@
     <method name="StopDep">
       <arg name="unit" type="s" direction="in" />
     </method>
+    <method name="Reload" />
 
     <signal name="JobDone">
       <arg name="id" type="u" />

--- a/doc/api-examples/enable-unit.py
+++ b/doc/api-examples/enable-unit.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+
+import sys
+from collections import namedtuple
+import dasbus.connection
+bus = dasbus.connection.SystemMessageBus()
+
+EnabledServiceInfo = namedtuple("EnabledServicesInfo", ["op_type", "symlink_file", "symlink_dest"])
+EnableResponse = namedtuple("EnableResponse", ["carries_install_info", "enabled_services_info"])
+
+if len(sys.argv) < 2:
+    print(f"Usage: {sys.argv[0]} node_name unit_name...")
+    sys.exit(1)
+
+node_name = sys.argv[1]
+
+manager = bus.get_proxy("org.containers.hirte",  "/org/containers/hirte")
+node_path = manager.GetNode(node_name)
+node = bus.get_proxy("org.containers.hirte",  node_path)
+
+response = node.EnableUnitFiles(sys.argv[2:], False, False)
+enable_response = EnableResponse(*response)
+if enable_response.carries_install_info:
+    print("The unit files included enablement information")
+else:
+    print("The unit files did not include any enablement information")
+
+for e in enable_response.enabled_services_info:
+    enabled_service_info = EnabledServiceInfo(*e)
+    if enabled_service_info.op_type == "symlink":
+        print(f"Created symlink {enabled_service_info.symlink_file} -> {enabled_service_info.symlink_dest}")
+    elif enabled_service_info.op_type == "unlink":
+        print(f"Removed \"{enabled_service_info.symlink_file}\".")

--- a/doc/docs/api/description.md
+++ b/doc/docs/api/description.md
@@ -146,6 +146,23 @@ Object path: `/org/containers/hirte/node/$name`
 
     Kill a unit on the node. Arguments and semantics are equivalent to the systemd `KillUnit()` method.
 
+  * `EnableUnitFiles(in  as files, in  b runtime, in  b force, out b carries_install_info, out a(sss) changes);`
+
+    `EnableUnitFiles()` may be used to enable one or more units in the system (by creating symlinks to them in /etc/ or /run/).
+    It takes a list of unit files to enable
+    (either just file names or full absolute paths if the unit files are residing outside the usual unit search paths)
+    and two booleans: the first controls whether the unit shall be enabled for runtime only (true, /run/), or persistently (false, /etc/).
+    The second one controls whether symlinks pointing to other units shall be replaced if necessary.
+    This method returns one boolean and an array of the changes made.
+    The boolean signals whether the unit files contained any enablement information (i.e. an [Install] section).
+    The changes array consists of structures with three strings: the type of the change (one of "symlink" or "unlink"),
+    the file name of the symlink and the destination of the symlink.
+
+  * `DisableUnitFiles(in  as files, in  b runtime, out a(sss) changes);`
+
+    `DisableUnitFiles()` is similar to `EnableUnitFiles()` but
+    disables the specified units by removing all symlinks to them in /etc/ and /run/
+
   * `GetUnitProperties(in s name, in s interface, out a{sv} props)`
 
     Returns the current properties for a named unit on the node. The returned properties are the same as you would
@@ -164,6 +181,10 @@ Object path: `/org/containers/hirte/node/$name`
 
     Returns all the currently loaded systemd units on this node. The returned structure is the same as the one returned
     by the systemd `ListUnits()` call.
+
+  * `Reload()`
+
+    `Reload()` may be invoked to reload all unit files.
 
 #### Properties
 

--- a/doc/docs/api/examples.md
+++ b/doc/docs/api/examples.md
@@ -66,3 +66,11 @@ pip3 install dasbus
 ```
 
 ---
+
+### Enable unit files
+
+```python
+--8<-- "api-examples/enable-unit.py"
+```
+
+---

--- a/doc/man/hirtectl.1.md
+++ b/doc/man/hirtectl.1.md
@@ -26,14 +26,22 @@ Print usage statement and exit.
 
 Performs one of the listed lifecycle operations on the given systemd unit for the `hirte-agent`.
 
+### **hirtectl** [*enable|disable*] [*agent*] [*unit1*,*...*]
+
+Enable/Disable the list of systemd unit files for the `hirte-agent`.
+
 ### **hirtectl** *list-units* [*agent*]
 
 Fetches information about all systemd units on the hirte-agents. If [hirte-agent] is not specified, all agents are queried.
 
 ### **hirtectl** *monitor* [*agent*] [*unit1*,*unit2*,*...*]
 
-Creates a monitor on the given agent to observe changes in the specified units. Wildcards **\*** to match all agents and/or units are also supported. 
+Creates a monitor on the given agent to observe changes in the specified units. Wildcards **\*** to match all agents and/or units are also supported.
 
 **Example:**
 
 hirtectl monitor \\\* dbus.service,apache2.service
+
+### **hirtectl** [*daemon-reload*] [*agent*]
+
+Performs `daemon-reload` for the `hirte-agent`.


### PR DESCRIPTION
## Implementation

Implement EnableUnitFiles, DisableUnitFiles and Reload in the Node and Internal Agent interfaces.
Since the signature and behavior is the same throughout the flow (Manager->Agent->Systemd), passthrough function functions were added and used for all three commands.

Implement support in hirectl for enable, disable and daemon-reload

## Incomplete 
Options processing in hirtectl is very cumbersome. So, for now, enable and disable do not support their flags:
- Enable:  force, runtime and no-reload
- Disable: runtime and no-reload

Resolves: #275