### PR TITLE
added dnf upgrade when building the integration-test-base image

### DIFF
--- a/tests/containers/integration-test-base
+++ b/tests/containers/integration-test-base
@@ -2,6 +2,8 @@ FROM quay.io/centos/centos:stream9
 
 RUN dnf install -y dnf-plugin-config-manager
 
+RUN dnf upgrade --refresh -y
+
 RUN dnf install \
         policycoreutils-python-utils \
         selinux-policy \


### PR DESCRIPTION
This PR adds a `dnf upgrade` previous to installing the necessary packages. This way we avoid conflicts in packages, e.g. 
```bash
12:51:09             err:  Problem: conflicting requests
12:51:09             err:   - nothing provides selinux-policy >= 38.1.14-1.el9 needed by hirte-selinux-0.3.0-1.el9.x86_64 from hirte-rpms
```

Note: the updated `integration-test-base` image was already pushed manually (otherwise the integration test in this PR would fail as well). 
