### PR TITLE
hirtectl monitor is documented to handle no options

### DIFF
--- a/doc/man/hirtectl.1.md
+++ b/doc/man/hirtectl.1.md
@@ -40,8 +40,12 @@ Creates a monitor on the given agent to observe changes in the specified units. 
 
 **Example:**
 
+hirtectl monitor
+
+hirtectl monitor node1
+
 hirtectl monitor \\\* dbus.service,apache2.service
 
-### **hirtectl** [*daemon-reload*] [*agent*]
+### **hirtectl** *daemon-reload* [*agent*]
 
 Performs `daemon-reload` for the `hirte-agent`.

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -549,10 +549,22 @@ int client_call_manager(Client *client) {
                 }
                 r = method_lifecycle_action_on(client, client->opargv[0], client->opargv[1], "ReloadUnit");
         } else if (streq(client->op, "monitor")) {
-                if (client->opargc != 2) {
+                char *arg0 = SYMBOL_WILDCARD;
+                char *arg1 = SYMBOL_WILDCARD;
+                switch (client->opargc) {
+                case 0:
+                        break;
+                case 1:
+                        arg0 = client->opargv[0];
+                        break;
+                case 2:
+                        arg0 = client->opargv[0];
+                        arg1 = client->opargv[1];
+                        break;
+                default:
                         return -EINVAL;
                 }
-                r = method_monitor_units_on_nodes(client->api_bus, client->opargv[0], client->opargv[1]);
+                r = method_monitor_units_on_nodes(client->api_bus, arg0, arg1);
         } else if (streq(client->op, "metrics")) {
                 if (client->opargc != 1) {
                         return -EINVAL;


### PR DESCRIPTION
This PR defaults to '\*' for nodes and '\*' for services if they are not specified on the command line.