### PR TITLE
Signal on agent online offline

### DIFF
--- a/data/org.containers.hirte.Manager.xml
+++ b/data/org.containers.hirte.Manager.xml
@@ -31,6 +31,10 @@
       <arg name="unit" type="s" />
       <arg name="result" type="s" />
     </signal>
+    <signal name="NodeConnectionStateChanged">
+      <arg name="node" type="s" />
+      <arg name="connection_state" type="s" />
+    </signal>
 
     <property name="Nodes" type="as" access="read" />
   </interface>

--- a/doc/docs/api/description.md
+++ b/doc/docs/api/description.md
@@ -45,6 +45,10 @@ Note that all properties also come with change events, so you can easily track w
     `failed`, `cancelled`, `timeout`, `dependency`, `skipped`. This is either the result from systemd on the node, or
     `cancelled` if the job was cancelled in Hirte before any systemd job was started for it.
 
+  * `NodeConnectionStateChanged(s node, s state)`
+
+    Emitted each time a listed node in Hirte changes its connection state from offline to online and vice versa. A node is considered online only when its registration at Hirte succeeds.
+
 #### Properties
 
   * `Nodes` - `as`

--- a/doc/docs/api/description.md
+++ b/doc/docs/api/description.md
@@ -33,6 +33,14 @@ Note that all properties also come with change events, so you can easily track w
 
     Returns the object path of a node given its name.
 
+  * `EnableMetrics()`
+
+    Enables the collection of metrics on all connected agents.
+
+  * `DisableMetrics()`
+
+    Disables the collection of metrics on all agents.
+
 #### Signals
 
   * `JobNew(u id, o job, s nodeName, s unit)`
@@ -256,6 +264,20 @@ interface.
 
     When a proxy is not needed anymore it is being removed on the node and a `ProxyRemoved` is emitted to notify the manager.
 
+### interface org.containers.hirte.Metrics
+
+This interface is provides signals for collecting metrics. It is created by calling `EnableMetrics` on the `org.containers.hirte.Manager` interface and removed by calling `DisableMetrics`.
+
+#### Signals
+
+  * `StartUnitJobMetrics(s node_name, s job_id, s unit, t job_measured_time_micros, t unit_start_prop_time_micros)`
+
+    `StartUnitJobMetrics` will be emitted when a `Start` operation processed by Hirte finishes and the collection of metrics has been enabled previously.
+
+  * `AgentJobMetrics(s node_name, s unit, s method, t systemd_job_time_micros)`
+
+    `AgentJobMetrics` will be emitted for all unit lifecycle operations (e.g. `Start`, `Stop`, `Reload`, etc.) processed by Hirte when these finish and the collection of metrics has been enabled previously.
+
 ## Internal D-Bus APIs
 
 The above APIs are the public facing ones that users of Hirte would use. Additionally there are additional APIs that are
@@ -311,6 +333,26 @@ This is the main interface that the node implements and that is used by the mana
   * `Unsubscribe(in unit s)`
 
     Remove a subscription added via `Subscribe()`. If there are none left, call `Unsubscribe()` in the systemd API.
+  
+  * `EnableMetrics()`
+
+    Enables the collection of metrics on this agent.
+
+  * `DisableMetrics()`
+
+    Disables the collection of metrics on this agent.
+
+  * `StartDep(in unit s)`
+
+    Starts a dependency systemd service on the specified unit. This is used by the proxy service to ensure that required systemd services on other nodes are running.
+
+  * `StopDep(in unit s)`
+
+    Stops a dependency systemd service on the specified unit.
+
+  * `Reload()`
+
+    `Reload` causes systemd on the agent to reload all unit files.
 
 #### Signals
 
@@ -355,3 +397,13 @@ with the proxy.
     Called by the manager when the corresponding service is active (either was running already, or was started), or when
     it failed. result is `done` if it was already running, otherwise it is the same value as the remote node returned in
     result from its start job.
+
+### interface org.containers.hirte.internal.Agent.Metrics
+
+This is the interface that provides signals sent from the agent to the manager to collect metrics, e.g. time measurements.
+
+#### Signals
+
+  * `AgentJobMetrics(in s unit, in s method, in t systemd_job_time_micros)`
+
+    This is emitted for each completed job when the collection of metrics has been enabled via `EnableMetrics`.

--- a/doc/man/hirtectl.1.md
+++ b/doc/man/hirtectl.1.md
@@ -38,6 +38,11 @@ Fetches information about all systemd units on the hirte-agents. If [hirte-agent
 
 Creates a monitor on the given agent to observe changes in the specified units. Wildcards **\*** to match all agents and/or units are also supported.
 
+### **hirtectl** *monitor* *node-connection*
+
+Creates a monitor to observe connection state changes for all nodes. 
+
+
 **Example:**
 
 hirtectl monitor

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -549,6 +549,12 @@ int client_call_manager(Client *client) {
                 }
                 r = method_lifecycle_action_on(client, client->opargv[0], client->opargv[1], "ReloadUnit");
         } else if (streq(client->op, "monitor")) {
+                /* monitor node connection status changes */
+                if (client->opargc == 1 && streq(client->opargv[0], "node-connection")) {
+                        return method_monitor_node_connection_state(client->api_bus);
+                }
+
+                /* monitor systemd units on the specified nodes */
                 char *arg0 = SYMBOL_WILDCARD;
                 char *arg1 = SYMBOL_WILDCARD;
                 switch (client->opargc) {
@@ -641,6 +647,8 @@ int print_client_usage(char *argv) {
         printf("    usage: metrics listen\n");
         printf("  - monitor: creates a monitor on the given node to observe changes in the specified units\n");
         printf("    usage: monitor [node] [unit1,unit2,...]\n");
+        printf("  - monitor node-connection: creates a monitor to observe changes in state of all nodes\n");
+        printf("    usage: monitor node-connection\n");
         printf("  - daemon-reload: reload systemd daemon on a specific node\n");
         printf("    usage: disable nodename\n");
         return 0;

--- a/src/client/method_monitor.h
+++ b/src/client/method_monitor.h
@@ -2,3 +2,4 @@
 #include <systemd/sd-bus.h>
 
 int method_monitor_units_on_nodes(sd_bus *api_bus, char *nodes, char *units);
+int method_monitor_node_connection_state(sd_bus *api_bus);

--- a/src/manager/manager.h
+++ b/src/manager/manager.h
@@ -57,6 +57,7 @@ bool manager_add_job(Manager *manager, Job *job);
 void manager_remove_job(Manager *manager, Job *job, const char *result);
 void manager_finish_job(Manager *manager, uint32_t job_id, const char *result);
 void manager_job_state_changed(Manager *manager, uint32_t job_id, const char *state);
+void manager_node_connection_state_changed(Manager *manager, const char *node_name, const char *state);
 
 void manager_remove_monitor(Manager *manager, Monitor *monitor);
 


### PR DESCRIPTION
This PR attempts to fix #186 by extending the public D-Bus API for the `org.containers.hirte.Manager` interface with the `NodeConnectionStateChanged` signal. 