### PR TITLE
Add agent heartbeat timestamps to client node monitoring.

### DIFF
--- a/data/org.containers.hirte.internal.Agent.xml
+++ b/data/org.containers.hirte.internal.Agent.xml
@@ -110,7 +110,8 @@
       <arg name="unitName" type="s" />
     </signal>
     <signal name="Heartbeat">
-      <arg name="agent_name" type="s" />
+      <arg name="nodeName" type="s" />
+      <arg name="timestamp" type="s" />
     </signal>
   </interface>
 </node>

--- a/src/libhirte/common/protocol.h
+++ b/src/libhirte/common/protocol.h
@@ -93,11 +93,8 @@ UnitActiveState active_state_from_string(const char *s);
 
 char *get_hostname();
 
-/* Agent to Hirte heartbeat signals */
-
-// Application-level heartbeat set at 2 seconds.
 #define AGENT_HEARTBEAT_INTERVAL_MSEC (2000)
-#define AGENT_HEARTBEAT_SIGNAL_NAME "Heartbeat"
+#define AGENT_HEARTBEAT_TIMESTAMP_SIZE 16
 
 /* Constants */
 #define SYMBOL_WILDCARD "*"

--- a/src/manager/manager.h
+++ b/src/manager/manager.h
@@ -57,7 +57,8 @@ bool manager_add_job(Manager *manager, Job *job);
 void manager_remove_job(Manager *manager, Job *job, const char *result);
 void manager_finish_job(Manager *manager, uint32_t job_id, const char *result);
 void manager_job_state_changed(Manager *manager, uint32_t job_id, const char *state);
-void manager_node_connection_state_changed(Manager *manager, const char *node_name, const char *state);
+void manager_node_connection_state_update(
+                Manager *manager, const char *node_name, const char *state, const char *heartbeat_timestamp);
 
 void manager_remove_monitor(Manager *manager, Monitor *monitor);
 

--- a/src/manager/node.h
+++ b/src/manager/node.h
@@ -52,6 +52,8 @@ struct Node {
         LIST_HEAD(ProxyDependency, proxy_dependencies);
 
         struct hashmap *unit_subscriptions;
+
+        char heartbeat_timestamp[AGENT_HEARTBEAT_TIMESTAMP_SIZE];
 };
 
 Node *node_new(Manager *manager, const char *name);


### PR DESCRIPTION
This addresses issue #337, adding the last heartbeat timestamp in client node monitoring.

```
NODE                          |     STATE|      LAST HEARTBEAT|
===============================================================
agent-001                     |    online|     Jun 04 12:28:03|
agent-002                     |   offline|                    |
```

If the node goes offline, you can determine from the last heartbeat timestamp when it went down.