### PR TITLE
config: provide D-Bus info via hirte config

### DIFF
--- a/config/hirte/hirte.conf
+++ b/config/hirte/hirte.conf
@@ -26,3 +26,8 @@ AllowedNodeNames=
 #
 # If this flag is set to true, no logs are written by hirte.
 #LogIsQuiet=false
+
+#
+# Dbus information
+DbusName="org.containers.hirte"
+DbusObjectPath="/org/containers/hirte"

--- a/doc/man/hirte.conf.5.md
+++ b/doc/man/hirte.conf.5.md
@@ -53,6 +53,12 @@ By default `journald` is used as the target.
 
 If this flag is set to `true`, no logs are written by hirte. By default the flag is set to `false`.
 
+#### **DbusName** (string)
+D-Bus name for hirte.
+
+#### **DbusObjectPath** (string)
+D-Bus object path for hirte.
+
 ## Example
 
 ```


### PR DESCRIPTION
Tools, libs and scripts can look to hirte.conf to identify D-bus data for hirte easily.

See-Also: https://github.com/containers/hirte/pull/339