### PR TITLE
Always attach unit test logs to artifacts

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,6 +26,7 @@ jobs:
           make test-with-valgrind
 
       - name: Upload unit test logs
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: unit-test-logs


### PR DESCRIPTION
Attach unit test logs to GH CI artifacts always (even in case of
failure).

Signed-off-by: Martin Perina <mperina@redhat.com>
