### PR TITLE
network: add dual stack

### DIFF
--- a/src/libhirte/common/network.h
+++ b/src/libhirte/common/network.h
@@ -19,6 +19,7 @@ bool isIPv6Addr(const char *domain);
 int get_address(const char *domain, char **ip_address);
 
 char *typesafe_inet_ntop4(const struct sockaddr_in *addr);
-char *typesafe_inet_ntop6(const struct sockaddr_in *addr);
+char *typesafe_inet_ntop6(const struct sockaddr_in6 *addr);
 
 char *assemble_tcp_address(const struct sockaddr_in *addr);
+char *assemble_tcp_address_v6(const struct sockaddr_in6 *addr);

--- a/src/libhirte/socket.c
+++ b/src/libhirte/socket.c
@@ -8,9 +8,9 @@
 #include "socket.h"
 
 int create_tcp_socket(uint16_t port) {
-        struct sockaddr_in servaddr;
+        struct sockaddr_in6 servaddr;
 
-        int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
+        int fd = socket(AF_INET6, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
         if (fd < 0) {
                 int errsv = errno;
                 return -errsv;
@@ -22,11 +22,11 @@ int create_tcp_socket(uint16_t port) {
                 return -errsv;
         }
 
-        servaddr.sin_family = AF_INET;
-        servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
-        servaddr.sin_port = htons(port);
+        servaddr.sin6_family = AF_INET6;
+        servaddr.sin6_addr = in6addr_any;
+        servaddr.sin6_port = htons(port);
 
-        if (bind(fd, (struct sockaddr *) &servaddr, sizeof(servaddr)) < 0) {
+        if (bind(fd, &servaddr, sizeof(servaddr)) < 0) {
                 int errsv = errno;
                 return -errsv;
         }

--- a/src/libhirte/test/common/network/assemble_tcp_address.c
+++ b/src/libhirte/test/common/network/assemble_tcp_address.c
@@ -13,6 +13,22 @@
 #        define __FUNCTION_NAME__ __func__
 #endif
 
+int build_sockaddr_in6(const char *host_in, uint16_t port_in, struct sockaddr_in6 *ret) {
+        int r = 0;
+
+        memset(ret, 0, sizeof(*ret));
+        ret->sin6_family = AF_INET6;
+        ret->sin6_port = htons(port_in);
+
+        r = inet_pton(AF_INET6, host_in, &ret->sin6_addr);
+        if (r < 1) {
+                fprintf(stdout, "Invalid host option '%s'\n", host_in);
+                return r;
+        }
+
+        return 0;
+}
+
 int build_sockaddr_in(const char *host_in, uint16_t port_in, struct sockaddr_in *ret) {
         int r = 0;
 
@@ -29,6 +45,27 @@ int build_sockaddr_in(const char *host_in, uint16_t port_in, struct sockaddr_in 
         return 0;
 }
 
+bool test_assemble_tcp_address_v6(const struct sockaddr_in6 *input, const char *expectedResult) {
+        _cleanup_free_ char *result = assemble_tcp_address_v6(input);
+        if ((result == NULL && expectedResult != NULL) || (result != NULL && !streq(result, expectedResult))) {
+                _cleanup_free_ char *msg = NULL;
+                int r = asprintf(
+                                &msg,
+                                "FAILED: %s\n\tExpected: %s\n\tGot: %s\n",
+                                __FUNCTION_NAME__,
+                                expectedResult,
+                                result);
+                if (r < 0) {
+                        fprintf(stderr, "OOM: %s failed", __FUNCTION_NAME__);
+                        return false;
+                }
+                if (msg != NULL) {
+                        fprintf(stderr, "%s", msg);
+                        return false;
+                }
+        }
+        return true;
+}
 
 bool test_assemble_tcp_address(const struct sockaddr_in *input, const char *expectedResult) {
         _cleanup_free_ char *result = assemble_tcp_address(input);
@@ -55,11 +92,15 @@ bool test_assemble_tcp_address(const struct sockaddr_in *input, const char *expe
 int main() {
         bool result = true;
         struct sockaddr_in host;
+        struct sockaddr_in6 host6;
 
         result = result && test_assemble_tcp_address(NULL, NULL);
 
         build_sockaddr_in("127.0.0.1", 808, &host);
         result = result && test_assemble_tcp_address(&host, "tcp:host=127.0.0.1,port=808");
+
+        build_sockaddr_in6("::1", 808, &host6);
+        result = result && test_assemble_tcp_address_v6(&host6, "tcp:host=::1,port=808");
 
         build_sockaddr_in("192.168.178.1", 808, &host);
         result = result && test_assemble_tcp_address(&host, "tcp:host=192.168.178.1,port=808");


### PR DESCRIPTION
# Test scenario 1
Description: Manager listening. Agents are IPv4 and IPV6.

**Manager listening**
```
# ./builddir/src/manager/hirte -c /etc/hirte/hirte.conf
```
**Manager agent connecting via IPV6**
```
./builddir/src/agent/hirte-agent -c /etc/hirte/agent.conf
INFO	: Connecting to manager on tcp:host=fd00::1:8:5,port=842
INFO	: Connected to manager as 'control'
```
**Node1 connected via IPV4**
```
 ./builddir/src/agent/hirte-agent -c /etc/hirte/agent.conf
INFO	: Connecting to manager on tcp:host=10.90.0.5,port=842
INFO	: Connected to manager as 'node1'
```

# Test scenario 2:
Description: Both agents are IPV6

**Manager listening**
```
# ./builddir/src/manager/hirte -c /etc/hirte/hirte.conf
```
**Manager agent connecting via IPV6**
```
./builddir/src/agent/hirte-agent -c /etc/hirte/agent.conf
INFO	: Connecting to manager on tcp:host=fd00::1:8:5,port=842
INFO	: Connected to manager as 'control'
```
**Node1 connected via IPV6**
```
# ./builddir/src/agent/hirte-agent -c /etc/hirte/agent.conf
INFO	: Connecting to manager on tcp:host=fd00::1:8:5,port=842
INFO	: Connected to manager as 'node1'
```

# Test scenario 3:
Both agents are IPv4

**Manager listening**
```
# ./builddir/src/manager/hirte -c /etc/hirte/hirte.conf
```

**Manager agent connecting via IPV4**
```
[root@control hirte]# ./builddir/src/agent/hirte-agent -c /etc/hirte/agent.conf
INFO	: Connecting to manager on tcp:host=10.90.0.5,port=842
INFO	: Connected to manager as 'control'
```

**Node 1 connected via IPv4**
```
[root@node1 hirte]# ./builddir/src/agent/hirte-agent -c /etc/hirte/agent.conf
INFO	: Connecting to manager on tcp:host=10.90.0.5,port=842
INFO	: Connected to manager as 'node1'
```

Resolves:  https://github.com/containers/hirte/issues/342 and https://github.com/containers/hirte/issues/334

