### PR TITLE
fixed get_address unit test

### DIFF
--- a/src/libhirte/test/common/network/get_address_test.c
+++ b/src/libhirte/test/common/network/get_address_test.c
@@ -35,7 +35,7 @@ int main() {
         result = result && test_get_address(NULL, ip, false);
         result = result && test_get_address(".", ip, false);
         result = result && test_get_address("redhat", ip, false);
-        result = result && test_get_address("redhat.com", ip, true);
+        result = result && test_get_address("localhost", ip, true);
         result = result && test_get_address("8.8.8.8", ip, false);
         result = result && test_get_address("fe80::78b3:75ff:fe1b:6803", ip, false);
         result = result && test_get_address("?10.10.10.3", ip, false);


### PR DESCRIPTION
Unit tests on COPR are failing since https://github.com/containers/hirte/pull/340 has been merged (see [this build, for example](https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/build/6027988/)). 

The unit test of get_address used `redhat.com` as a test case to resolve a domain name. This, however, requires an internet connection to work. This PR changed it to use `localhost` instead so the unit test doesn't have a network dependency.
