### PR TITLE
added typecast to uintptr_t for subscription pointer

### DIFF
--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -239,7 +239,7 @@ bool node_is_online(Node *node) {
 
 static uint64_t subscription_hashmap_hash(const void *item, UNUSED uint64_t seed0, UNUSED uint64_t seed1) {
         const Subscription * const *subscriptionp = item;
-        return (uint64_t) *subscriptionp;
+        return (uint64_t) ((uintptr_t) *subscriptionp);
 }
 
 static int subscription_hashmap_compare(const void *a, const void *b, UNUSED void *udata) {


### PR DESCRIPTION
This PR attempts to fix a pointer to int cast error due to different size on 32-bit platforms. Occurred in:
https://koji.fedoraproject.org/koji/taskinfo?taskID=101972333

It uses the [uintptr_t](https://manpages.debian.org/unstable/manpages/uintptr_t.3.en.html#uintptr_t) data type to first "safely" cast the pointer address to an int and then casts it to an `uint64_t` (as required by the hashmap library). 