### PR TITLE
Use proper string size in get_address_test.c

### DIFF
--- a/src/libhirte/test/common/network/get_address_test.c
+++ b/src/libhirte/test/common/network/get_address_test.c
@@ -30,7 +30,7 @@ bool test_get_address(const char *domain, char *ip, bool expected) {
 
 int main() {
         bool result = true;
-        char ip[INET_ADDRSTRLEN];
+        char ip[INET6_ADDRSTRLEN];
 
         result = result && test_get_address(NULL, ip, false);
         result = result && test_get_address(".", ip, false);


### PR DESCRIPTION
We are testing hostname to address resolution, so we need to expect that
IPv6 address might be returned.

Signed-off-by: Martin Perina <mperina@redhat.com>
