### PR TITLE
portable print for uint64_t timestamps milliseconds

### DIFF
--- a/src/libhirte/common/time-util.c
+++ b/src/libhirte/common/time-util.c
@@ -47,7 +47,12 @@ char *get_formatted_log_timestamp_for_timespec(struct timespec time, bool is_gmt
         strftime(timebuf, timestamp_size, "%Y-%m-%d %H:%M:%S", time_tm);
         uint64_t millis = (uint64_t) ((double) time.tv_nsec * nanosec_to_millisec_multiplier);
         strftime(offsetbuf, timestamp_offset_size, "%z", time_tm);
-        snprintf(timebuf_full, timestamp_full_size, "%s,%03ld%s", timebuf, millis % millis_in_second, offsetbuf);
+        snprintf(timebuf_full,
+                 timestamp_full_size,
+                 "%s,%03" PRIu64 "%s",
+                 timebuf,
+                 millis % millis_in_second,
+                 offsetbuf);
 
         return timebuf_full;
 }


### PR DESCRIPTION
This PR fixes build on 686:
```bash
./src/libhirte/common/time-util.c: In function â€˜get_formatted_log_timestamp_for_timespecâ€™:
../src/libhirte/common/time-util.c:50:61: error: format â€˜%ldâ€™ expects argument of type â€˜long intâ€™, but argument 5 has type â€˜uint64_tâ€™ {aka â€˜long long unsigned intâ€™} [-Werror=format=]
   50 |         snprintf(timebuf_full, timestamp_full_size, "%s,%03ld%s", timebuf, millis % millis_in_second, offsetbuf);
      |                                                         ~~~~^              ~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                             |                     |
      |                                                             long int              uint64_t {aka long long unsigned int}
      |                                                         %03lld
```
