### PR TITLE
Allow CI to run on stable branches

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,9 +2,9 @@ name: Integration tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, hirte-*]
   pull_request:
-    branches: [main]
+    branches: [main, hirte-*]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, hirte-*]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,9 +2,9 @@ name: Unit tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, hirte-*]
   pull_request:
-    branches: [main]
+    branches: [main, hirte-*]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Allow CI to run on stable branches such as hirte-0.3.z. This patch needs
to be backported to hirte-0.3.z, but merging to main will main it
working for all future stable branches.

Signed-off-by: Martin Perina <mperina@redhat.com>
