### PR TITLE
Allow snapshot builds in hirte-0.3.z branch

### DIFF
--- a/build-scripts/build-srpm.sh
+++ b/build-scripts/build-srpm.sh
@@ -11,9 +11,9 @@ git config --global --add safe.directory $(pwd)
 # Package release
 #
 # Use following for official releases
-RELEASE="1"
+#RELEASE="1"
 # Use following for nightly builds
-#RELEASE="0.$(date +%04Y%02m%02d%02H%02M).git$(git rev-parse --short ${GITHUB_SHA:-HEAD})"
+RELEASE="0.$(date +%04Y%02m%02d%02H%02M).git$(git rev-parse --short ${GITHUB_SHA:-HEAD})"
 
 
 # Set version and release

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@
 project(
   'hirte',
   'c',
-  version: '0.3.0',
+  version: '0.3.1',
   license: 'GPL-2.0-or-later',
   default_options: [
     'c_std=gnu17',     # Adds "-std=gnu17".  Includes GNU 17 extensions.


### PR DESCRIPTION
Allow snapshot builds in hirte-0.3.z branch, so each PR merged into the
branch will produce RPMs, which can upgrade RPMs from any previous
commit.

Signed-off-by: Martin Perina <mperina@redhat.com>
