### PR TITLE
removed not implemented KillUnit from api description

### DIFF
--- a/data/org.containers.hirte.Node.xml
+++ b/data/org.containers.hirte.Node.xml
@@ -22,11 +22,6 @@
       <arg name="mode" type="s" direction="in" />
       <arg name="job" type="o" direction="out" />
     </method>
-    <method name="KillUnit">
-      <arg name="name" type="s" direction="in" />
-      <arg name="who" type="s" direction="in" />
-      <arg name="signal" type="i" direction="in" />
-    </method>
     <method name="GetUnitProperties">
       <arg name="name" type="s" direction="in" />
       <arg name="interface" type="s" direction="in" />

--- a/data/org.containers.hirte.internal.Agent.xml
+++ b/data/org.containers.hirte.internal.Agent.xml
@@ -22,11 +22,6 @@
       <arg name="mode" type="s" direction="in" />
       <arg name="jobid" type="u" direction="in" />
     </method>
-    <method name="KillUnit">
-      <arg name="name" type="s" direction="in" />
-      <arg name="who" type="s" direction="in" />
-      <arg name="signal" type="i" direction="in" />
-    </method>
     <method name="GetUnitProperties">
       <arg name="name" type="s" direction="in" />
       <arg name="interface" type="s" direction="in" />

--- a/doc/docs/api/description.md
+++ b/doc/docs/api/description.md
@@ -154,10 +154,6 @@ Object path: `/org/containers/hirte/node/$name`
     `ReloadUnit()`/`RestartUnit()` is similar to `StartUnit()` but can be used to reload/restart a unit instead. See
     equivalent systemd methods for details.
 
-  * `KillUnit(in  s name, in  s who, in  i signal)`
-
-    Kill a unit on the node. Arguments and semantics are equivalent to the systemd `KillUnit()` method.
-
   * `EnableUnitFiles(in  as files, in  b runtime, in  b force, out b carries_install_info, out a(sss) changes);`
 
     `EnableUnitFiles()` may be used to enable one or more units in the system (by creating symlinks to them in /etc/ or /run/).
@@ -311,8 +307,6 @@ This is the main interface that the node implements and that is used by the mana
   * `ReloadUnit(in s name, in s mode, in u id)`
 
   * `RestartUnit(in s name, in s mode, in u id)`
-
-  * `KillUnit(in s name, in s who, in i signal)`
 
   * `GetUnitProperties(in name, out a{sv} props)`
 


### PR DESCRIPTION
The `KillUnit` method is not implemented, so this PR removes it from the API description. 