### PR TITLE
split get address test into success and failure cases

### DIFF
--- a/src/libhirte/test/common/network/get_address_test.c
+++ b/src/libhirte/test/common/network/get_address_test.c
@@ -7,7 +7,7 @@
 #include "libhirte/common/network.h"
 #include "libhirte/common/string-util.h"
 
-bool test_get_address(const char *domain, const char *expected_address, int expected_ret) {
+bool test_get_address_failure(const char *domain, int expected_ret) {
         _cleanup_free_ char *ip = NULL;
         int result = get_address(domain, &ip);
         if (result != expected_ret) {
@@ -19,19 +19,40 @@ bool test_get_address(const char *domain, const char *expected_address, int expe
                         strerror(-result));
                 return false;
         }
-        if (expected_address == NULL && ip != NULL) {
+        if (ip != NULL) {
                 fprintf(stdout, "FAILED: get_address('%s') - Expected null, but got non-null (%s)", domain, ip);
                 return false;
         }
-        if (expected_address != NULL && ip == NULL) {
+        return true;
+}
+
+bool test_get_address_localhost() {
+        const char *domain = "localhost";
+        int expected_ret = 0;
+        const char *expected_addressv4 = "127.0.0.1";
+        const char *expected_addressv6 = "::1";
+
+        _cleanup_free_ char *ip = NULL;
+        int result = get_address("localhost", &ip);
+        if (result != expected_ret) {
+                fprintf(stdout,
+                        "FAILED: get_address('%s') - Expected return code %d, but got %d (%s)\n",
+                        domain,
+                        expected_ret,
+                        result,
+                        strerror(-result));
+                return false;
+        }
+        if (ip == NULL) {
                 fprintf(stdout, "FAILED: get_address('%s') - Expected non-null, but got null", domain);
                 return false;
         }
-        if (expected_address != NULL && ip != NULL && !streq(ip, expected_address)) {
+        if (!streq(ip, expected_addressv4) && !streq(ip, expected_addressv6)) {
                 fprintf(stdout,
-                        "FAILED: get_address('%s') - Expected %s, but got %s\n",
+                        "FAILED: get_address('%s') - Expected either %s or %s, but got %s\n",
                         domain,
-                        expected_address,
+                        expected_addressv4,
+                        expected_addressv6,
                         ip);
                 return false;
         }
@@ -41,14 +62,14 @@ bool test_get_address(const char *domain, const char *expected_address, int expe
 
 int main() {
         bool result = true;
-        result = result && test_get_address(NULL, NULL, -EINVAL);
-        result = result && test_get_address(".", NULL, -ENOENT);
-        result = result && test_get_address("redhat", NULL, -ENOENT);
-        result = result && test_get_address("localhost", "127.0.0.1", 0);
-        result = result && test_get_address("8.8.8.8", NULL, 0);
-        result = result && test_get_address("fe80::78b3:75ff:fe1b:6803", NULL, 0);
-        result = result && test_get_address("?10.10.10.3", NULL, -ENOENT);
-        result = result && test_get_address("192.168.1.", NULL, -ENOENT);
+        result = result && test_get_address_failure(NULL, -EINVAL);
+        result = result && test_get_address_failure(".", -ENOENT);
+        result = result && test_get_address_failure("redhat", -ENOENT);
+        result = result && test_get_address_failure("8.8.8.8", 0);
+        result = result && test_get_address_failure("fe80::78b3:75ff:fe1b:6803", 0);
+        result = result && test_get_address_failure("?10.10.10.3", -ENOENT);
+        result = result && test_get_address_failure("192.168.1.", -ENOENT);
+        result = result && test_get_address_localhost();
         if (result) {
                 return EXIT_SUCCESS;
         }


### PR DESCRIPTION
Resolving a domain may result in either an ipv4 or ipv6 address in the current implementation. Therefore, split the localhost (success) and others (failure) test cases and check for the localhost test to resolve either to `127.0.0.1` or `::1`. This will fix the current failure when building on COPR: https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/build/6105555/