### PR TITLE
added empty pytest.ini

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -45,7 +45,7 @@ the following snippet uses the built-in [venv](https://docs.python.org/3/library
 ```bash
 python -m venv env
 source env/bin/activate
-pip install -r requirements.txt
+pip install -r -U requirements.txt
 # ...
 
 # exit the virtual env


### PR DESCRIPTION
In release 7.4.0 of pytest (https://github.com/pytest-dev/pytest/releases/tag/7.4.0) a fallback to rootdir was implemented by pytest if no inipath is set, see:
https://github.com/pytest-dev/pytest/pull/11043
Therefore, add an empty pytest.ini in the tests directory to enforce pytest to set the rootdir to it