### PR TITLE
Pytest - explicitly set confcutdir

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -36,7 +36,7 @@ dnf install \
 All required python packages are listed in the [requirements.txt](./requirements.txt) and can be installed using `pip`:
 
 ```bash
-pip install -r requirements.txt
+pip install -U -r requirements.txt
 ```
 
 Instead of installing the required packages directly, it is recommended to create a virtual environment. For example,
@@ -45,7 +45,7 @@ the following snippet uses the built-in [venv](https://docs.python.org/3/library
 ```bash
 python -m venv env
 source env/bin/activate
-pip install -r requirements.txt
+pip install -U -r requirements.txt
 # ...
 
 # exit the virtual env

--- a/tests/tests/main.fmf
+++ b/tests/tests/main.fmf
@@ -1,1 +1,1 @@
-test: pytest -svv
+test: pytest -svv --confcutdir=../../../


### PR DESCRIPTION
The new Pytest did not find the hirte_test module
Also update the README to updating the pip installation