### PR TITLE
manager: remove stop()

### DIFF
--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -1003,11 +1003,3 @@ bool manager_start(Manager *manager) {
 
         return true;
 }
-
-bool manager_stop(Manager *manager) {
-        if (manager == NULL) {
-                return false;
-        }
-
-        return true;
-}

--- a/src/manager/manager.h
+++ b/src/manager/manager.h
@@ -45,7 +45,6 @@ bool manager_set_port(Manager *manager, const char *port);
 bool manager_parse_config(Manager *manager, const char *configfile);
 
 bool manager_start(Manager *manager);
-bool manager_stop(Manager *manager);
 
 Node *manager_find_node(Manager *manager, const char *name);
 Node *manager_find_node_by_path(Manager *manager, const char *path);


### PR DESCRIPTION
No function is calling manager_stop() and in fact, there is no action to stop the manager at all. It seems the same validation manager_start() uses.