### PR TITLE
config: remove dup code for setting port

### DIFF
--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -373,7 +373,6 @@ Agent *agent_new(void) {
         agent->ref_count = 1;
         agent->event = steal_pointer(&event);
         agent->api_bus_service_name = steal_pointer(&service_name);
-        agent->port = HIRTE_DEFAULT_PORT;
         agent->host = strdup(HIRTE_DEFAULT_HOST);
         agent->heartbeat_interval_msec = AGENT_HEARTBEAT_INTERVAL_MSEC;
         LIST_HEAD_INIT(agent->outstanding_requests);
@@ -488,17 +487,6 @@ void agent_unref(Agent *agent) {
         free(agent);
 }
 
-bool agent_set_port(Agent *agent, const char *port_s) {
-        uint16_t port = 0;
-
-        if (!parse_port(port_s, &port)) {
-                hirte_log_errorf("Invalid port format '%s'", port_s);
-                return false;
-        }
-        agent->port = port;
-        return true;
-}
-
 bool agent_set_orch_address(Agent *agent, const char *address) {
         return copy_str(&agent->orch_addr, address);
 }
@@ -584,10 +572,8 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
         }
 
         value = cfg_get_value(agent->config, CFG_MANAGER_PORT);
-        if (value) {
-                if (!agent_set_port(agent, value)) {
-                        return false;
-                }
+        if (!cfg_set_port(NODE_AGENT, agent, value)) {
+                return false;
         }
 
         value = cfg_get_value(agent->config, CFG_MANAGER_ADDRESS);

--- a/src/agent/agent.h
+++ b/src/agent/agent.h
@@ -94,7 +94,6 @@ Agent *agent_new(void);
 Agent *agent_ref(Agent *agent);
 void agent_unref(Agent *agent);
 
-bool agent_set_port(Agent *agent, const char *port);
 bool agent_set_host(Agent *agent, const char *host);
 bool agent_set_orch_address(Agent *agent, const char *address);
 bool agent_set_name(Agent *agent, const char *name);

--- a/src/agent/main.c
+++ b/src/agent/main.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "libhirte/common/cfg.h"
 #include "libhirte/common/opt.h"
 #include "libhirte/log/log.h"
 
@@ -131,7 +132,7 @@ int main(int argc, char *argv[]) {
         /* Then override individual options */
         agent_set_systemd_user(agent, opt_user);
 
-        if (opt_port && !agent_set_port(agent, opt_port)) {
+        if (opt_port && !cfg_set_port(NODE_AGENT, agent, opt_port)) {
                 return EXIT_FAILURE;
         }
 

--- a/src/libhirte/common/cfg.h
+++ b/src/libhirte/common/cfg.h
@@ -182,3 +182,14 @@ bool cfg_s_get_bool_value(struct config *config, const char *section, const char
  * The caller is responsible for freeing the returned string.
  */
 const char *cfg_dump(struct config *config);
+
+/*
+ * Define the types of node that can help writing single functions managing different behaviours
+ * for nodes.
+ */
+typedef enum NodeType { NODE_MANAGER, NODE_AGENT } NodeType;
+
+/*
+ * Set port in the instance->port, returns bool
+ */
+bool cfg_set_port(enum NodeType node, void *instance, const char *port_s);

--- a/src/manager/main.c
+++ b/src/manager/main.c
@@ -3,6 +3,7 @@
 #include <getopt.h>
 #include <stdlib.h>
 
+#include "libhirte/common/cfg.h"
 #include "libhirte/common/opt.h"
 #include "libhirte/common/parse-util.h"
 #include "libhirte/service/shutdown.h"
@@ -83,7 +84,7 @@ int main(int argc, char *argv[]) {
 
         /* Then override individual options */
 
-        if (opt_port && !manager_set_port(manager, opt_port)) {
+        if (opt_port && !cfg_set_port(NODE_MANAGER, manager, opt_port)) {
                 return EXIT_FAILURE;
         }
 

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -38,7 +38,6 @@ Manager *manager_new(void) {
         Manager *manager = malloc0(sizeof(Manager));
         if (manager != NULL) {
                 manager->ref_count = 1;
-                manager->port = HIRTE_DEFAULT_PORT;
                 manager->api_bus_service_name = steal_pointer(&service_name);
                 manager->event = steal_pointer(&event);
                 manager->metrics_enabled = false;
@@ -293,17 +292,6 @@ Node *manager_add_node(Manager *manager, const char *name) {
         return steal_pointer(&node);
 }
 
-bool manager_set_port(Manager *manager, const char *port_s) {
-        uint16_t port = 0;
-
-        if (!parse_port(port_s, &port)) {
-                hirte_log_errorf("Invalid port format '%s'", port_s);
-                return false;
-        }
-        manager->port = port;
-        return true;
-}
-
 bool manager_parse_config(Manager *manager, const char *configfile) {
         int result = 0;
 
@@ -345,7 +333,7 @@ bool manager_parse_config(Manager *manager, const char *configfile) {
         const char *port = NULL;
         port = cfg_get_value(manager->config, CFG_MANAGER_PORT);
         if (port) {
-                if (!manager_set_port(manager, port)) {
+                if (!cfg_set_port(NODE_MANAGER, manager, port)) {
                         return false;
                 }
         }

--- a/src/manager/manager.h
+++ b/src/manager/manager.h
@@ -41,7 +41,6 @@ Manager *manager_new(void);
 Manager *manager_ref(Manager *manager);
 void manager_unref(Manager *manager);
 
-bool manager_set_port(Manager *manager, const char *port);
 bool manager_parse_config(Manager *manager, const char *configfile);
 
 bool manager_start(Manager *manager);


### PR DESCRIPTION
This is initial patch to simplify and unify the
configuration management.

GitHub-Issue: https://github.com/containers/hirte/issues/301