### PR TITLE
Node last seen timestamp

### DIFF
--- a/data/org.containers.hirte.Node.xml
+++ b/data/org.containers.hirte.Node.xml
@@ -60,5 +60,6 @@
 
     <property name="Name" type="s" access="read" />
     <property name="Status" type="s" access="read" />
+    <property name="LastSeenTimestamp" type="t" access="read" />
   </interface>
 </node>

--- a/data/org.containers.hirte.internal.Agent.xml
+++ b/data/org.containers.hirte.internal.Agent.xml
@@ -107,8 +107,6 @@
       <arg name="nodeName" type="s" />
       <arg name="unitName" type="s" />
     </signal>
-    <signal name="Heartbeat">
-      <arg name="agent_name" type="s" />
-    </signal>
+    <signal name="Heartbeat" />
   </interface>
 </node>

--- a/doc/docs/api/description.md
+++ b/doc/docs/api/description.md
@@ -203,6 +203,10 @@ Object path: `/org/containers/hirte/node/$name`
   * `Status` - `s`
 
     Status of the node, currently one of: `online`, `offline`. Emits changed when this changes.
+  
+  * `LastSeenTimestamp` - `t`
+
+    Timestamp of the last successfully received heartbeat of the node.
 
 ### interface org.containers.hirte.Job
 

--- a/doc/docs/api/description.md
+++ b/doc/docs/api/description.md
@@ -379,7 +379,7 @@ This is the main interface that the node implements and that is used by the mana
     This is emitted when a proxy is not needed anymore because the service requiring the proxy
     service is stopped.
 
-  * `Heartbeat(s nodeName)`
+  * `Heartbeat()`
 
     This is a periodic signal from the node to the manager.
 

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -124,8 +124,7 @@ static int agent_heartbeat_timer_callback(sd_event_source *event_source, UNUSED 
                                 INTERNAL_AGENT_OBJECT_PATH,
                                 INTERNAL_AGENT_INTERFACE,
                                 "Heartbeat",
-                                "s",
-                                agent->name);
+                                "");
                 if (r < 0) {
                         hirte_log_errorf("Failed to emit heartbeat signal: %s", strerror(-r));
                 }
@@ -1389,7 +1388,7 @@ static const sd_bus_vtable internal_agent_vtable[] = {
                                         SD_BUS_PARAM(reason),
                         0),
         SD_BUS_SIGNAL_WITH_NAMES("UnitRemoved", "s", SD_BUS_PARAM(unit), 0),
-        SD_BUS_SIGNAL_WITH_NAMES("Heartbeat", "s", SD_BUS_PARAM(agent_name), 0),
+        SD_BUS_SIGNAL("Heartbeat", "", 0),
         SD_BUS_METHOD("StartDep", "s", "", agent_method_start_dep, 0),
         SD_BUS_METHOD("StopDep", "s", "", agent_method_stop_dep, 0),
         SD_BUS_METHOD("EnableUnitFiles", "asbb", "ba(sss)", agent_method_passthrough_to_systemd, 0),

--- a/src/libhirte/common/time-util.c
+++ b/src/libhirte/common/time-util.c
@@ -16,6 +16,20 @@ uint64_t get_time_micros() {
         return now_micros;
 }
 
+int get_time_seconds(time_t *ret_time_seconds) {
+        if (ret_time_seconds == NULL) {
+                return -EINVAL;
+        }
+
+        struct timespec now;
+        int r = clock_gettime(CLOCK_REALTIME, &now);
+        if (r < 0) {
+                return r;
+        }
+        *ret_time_seconds = now.tv_sec;
+        return 0;
+}
+
 uint64_t finalize_time_interval_micros(int64_t start_time_micros) {
         return get_time_micros() - start_time_micros;
 }

--- a/src/libhirte/common/time-util.h
+++ b/src/libhirte/common/time-util.h
@@ -12,6 +12,7 @@ static const double nanosec_to_millisec_multiplier = 1e-6;
 static const uint64_t millis_in_second = 1000;
 
 uint64_t get_time_micros();
+int get_time_seconds(time_t *ret_time_seconds);
 uint64_t finalize_time_interval_micros(int64_t start_time_micros);
 double micros_to_millis(uint64_t time_micros);
 char *get_formatted_log_timestamp();

--- a/src/libhirte/test/common/meson.build
+++ b/src/libhirte/test/common/meson.build
@@ -19,3 +19,4 @@ foreach src : common_src
 endforeach
 
 subdir('network')
+subdir('time-util')

--- a/src/libhirte/test/common/time-util/get_log_timestamp.c
+++ b/src/libhirte/test/common/time-util/get_log_timestamp.c
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "libhirte/common/common.h"
+#include "libhirte/common/string-util.h"
+#include "libhirte/common/time-util.h"
+
+bool test_get_log_timestamp(__time_t tv_sec, __time_t tv_nsec, char *expected_timestamp) {
+        struct timespec time;
+        time.tv_sec = tv_sec;
+        time.tv_nsec = tv_nsec;
+        _cleanup_free_ char *timestamp = get_formatted_log_timestamp_for_timespec(time, true);
+
+        if (streq(timestamp, expected_timestamp)) {
+                return true;
+        }
+
+        fprintf(stdout,
+                "FAILED: for time (%ldsec, %ldnsec) - Expected %s, but got %s\n",
+                tv_sec,
+                tv_nsec,
+                expected_timestamp,
+                timestamp);
+        return false;
+}
+
+int main() {
+        bool result = true;
+
+        result = result && test_get_log_timestamp(0, 0, "1970-01-01 00:00:00,000+0000");
+        result = result && test_get_log_timestamp(1687075200, 0, "2023-06-18 08:00:00,000+0000");
+        result = result && test_get_log_timestamp(1687075200, 999999999, "2023-06-18 08:00:00,999+0000");
+        result = result && test_get_log_timestamp(1687075200, 999000000, "2023-06-18 08:00:00,999+0000");
+        result = result && test_get_log_timestamp(1687075200, 998900000, "2023-06-18 08:00:00,998+0000");
+        result = result && test_get_log_timestamp(1687046399, 999000000, "2023-06-17 23:59:59,999+0000");
+
+        if (result) {
+                return EXIT_SUCCESS;
+        }
+        return EXIT_FAILURE;
+}

--- a/src/libhirte/test/common/time-util/get_time_seconds.c
+++ b/src/libhirte/test/common/time-util/get_time_seconds.c
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "libhirte/common/common.h"
+#include "libhirte/common/string-util.h"
+#include "libhirte/common/time-util.h"
+
+bool test_get_time_seconds(time_t *input, int expected_return) {
+        int r = get_time_seconds(input);
+
+        if (r == expected_return) {
+                return true;
+        }
+
+        fprintf(stdout,
+                "FAILED: get_time_seconds() - Expected return value %d (%s), but got %d (%s)\n",
+                expected_return,
+                strerror(-expected_return),
+                r,
+                strerror(-r));
+        return false;
+}
+
+int main() {
+        bool result = true;
+
+        result = result && test_get_time_seconds(NULL, -EINVAL);
+
+        time_t ret = 0;
+        result = result && test_get_time_seconds(&ret, 0);
+
+        if (result) {
+                return EXIT_SUCCESS;
+        }
+        return EXIT_FAILURE;
+}

--- a/src/libhirte/test/common/time-util/meson.build
+++ b/src/libhirte/test/common/time-util/meson.build
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+network_src = [
+  'get_log_timestamp',
+  'get_time_seconds',
+]
+
+foreach src : network_src
+  exec_test = executable(src, src + '.c',
+    link_with: [
+      hirte_lib,
+    ],
+    include_directories: include_directories('../../../..'),
+  )
+  test(src, exec_test)
+endforeach

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -314,8 +314,7 @@ static struct hashmap *node_compute_unique_monitor_subscriptions(Node *node, con
 }
 
 
-static int node_match_job_state_changed(
-                UNUSED sd_bus_message *m, UNUSED void *userdata, UNUSED sd_bus_error *error) {
+static int node_match_job_state_changed(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *error) {
         Node *node = userdata;
         Manager *manager = node->manager;
         uint32_t hirte_job_id = 0;
@@ -491,7 +490,7 @@ static int node_match_job_done(UNUSED sd_bus_message *m, UNUSED void *userdata, 
         return 1;
 }
 
-static int node_match_heartbeat(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *error) {
+static int node_match_heartbeat(UNUSED sd_bus_message *m, void *userdata, UNUSED sd_bus_error *error) {
         Node *node = userdata;
 
         struct timespec now;
@@ -501,13 +500,6 @@ static int node_match_heartbeat(sd_bus_message *m, void *userdata, UNUSED sd_bus
                 return 0;
         }
         node->last_seen = now.tv_sec;
-
-        char *node_name = NULL;
-        r = sd_bus_message_read(m, "s", &node_name);
-        if (r < 0) {
-                hirte_log_errorf("Error reading heartbeat: %s", strerror(-r));
-                return 0;
-        }
 
         return 1;
 }

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -493,14 +493,11 @@ static int node_match_job_done(UNUSED sd_bus_message *m, UNUSED void *userdata, 
 static int node_match_heartbeat(UNUSED sd_bus_message *m, void *userdata, UNUSED sd_bus_error *error) {
         Node *node = userdata;
 
-        struct timespec now;
-        int r = clock_gettime(CLOCK_REALTIME, &now);
+        int r = get_time_seconds(&node->last_seen);
         if (r < 0) {
                 hirte_log_errorf("Failed to get current time on heartbeat: %s", strerror(-r));
                 return 0;
         }
-        node->last_seen = now.tv_sec;
-
         return 1;
 }
 

--- a/src/manager/node.h
+++ b/src/manager/node.h
@@ -52,6 +52,7 @@ struct Node {
         LIST_HEAD(ProxyDependency, proxy_dependencies);
 
         struct hashmap *unit_subscriptions;
+        time_t last_seen;
 };
 
 Node *node_new(Manager *manager, const char *name);


### PR DESCRIPTION
This PR is a continuation of #338 (therefore solving #337) and
- adds a last seen timestamp for the node. It is set each time a successful heartbeat signal (emitted from `hirte-agent`) is received by `hirte`. This value is exposed on the API via a D-Bus property that needs to be queried explicitly to get its value (which reduces traffic)
- extends the `hirtectl monitor node-connection` command so that a `LAST SEEN` field is displayed. If the node is connected, it shows "now". If it has never been connected, it shows "never". If the node is offline, but has been connected till time x, then time x is displayed. 
- removes the `node_name` from the heartbeat signal. Since the signal is emitted on the peer-to-peer dbus between hirte and the respective node, hirte already knows which node the heartbeat is from.  

Example output using `hirtectl monitor node-connection`:
![image](https://github.com/containers/hirte/assets/26504678/b2e0c090-bb33-48bd-af9a-d9cb301f0268)
