### PR TITLE
manager: check if AllowedNodeNames contain value

### DIFF
--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -351,16 +351,19 @@ bool manager_parse_config(Manager *manager, const char *configfile) {
         }
 
         const char *expected_nodes = cfg_get_value(manager->config, CFG_ALLOWED_NODE_NAMES);
-        if (expected_nodes) {
-                char *saveptr = NULL;
-                char *name = strtok_r((char *) expected_nodes, ",", &saveptr);
-                while (name != NULL) {
-                        if (manager_find_node(manager, name) == NULL) {
-                                manager_add_node(manager, name);
-                        }
+        if (!expected_nodes) {
+                hirte_log_error("AllowedNodeNames must container at least one node in configuration file");
+                return false;
+        }
 
-                        name = strtok_r(NULL, ",", &saveptr);
+        char *saveptr = NULL;
+        char *name = strtok_r((char *) expected_nodes, ",", &saveptr);
+        while (name != NULL) {
+                if (manager_find_node(manager, name) == NULL) {
+                        manager_add_node(manager, name);
                 }
+
+                name = strtok_r(NULL, ",", &saveptr);
         }
 
         _cleanup_free_ const char *dumped_cfg = cfg_dump(manager->config);

--- a/tests/tests/tier0/hirte-service-startup/test_service_startup.py
+++ b/tests/tests/tier0/hirte-service-startup/test_service_startup.py
@@ -5,7 +5,9 @@ from typing import Dict
 
 from hirte_test.test import HirteTest
 from hirte_test.container import HirteControllerContainer, HirteNodeContainer
-from hirte_test.config import HirteControllerConfig
+from hirte_test.config import HirteControllerConfig, HirteNodeConfig
+
+node_foo_name = "node-foobar"
 
 
 def startup_verify(ctrl: HirteControllerContainer, _: Dict[str, HirteNodeContainer]):
@@ -16,7 +18,16 @@ def startup_verify(ctrl: HirteControllerContainer, _: Dict[str, HirteNodeContain
 
 
 @pytest.mark.timeout(5)
-def test_controller_startup(hirte_test: HirteTest, hirte_ctrl_default_config: HirteControllerConfig):
+def test_controller_startup(
+        hirte_test: HirteTest,
+        hirte_ctrl_default_config: HirteControllerConfig,
+        hirte_node_default_config: HirteNodeConfig):
+
+    node_foo_cfg = hirte_node_default_config.deep_copy()
+    node_foo_cfg.node_name = node_foo_name
+    hirte_ctrl_default_config.allowed_node_names = [node_foo_name]
+
     hirte_test.set_hirte_controller_config(hirte_ctrl_default_config)
+    hirte_test.add_hirte_node_config(node_foo_cfg)
 
     hirte_test.run(startup_verify)


### PR DESCRIPTION
Before starting the daemon, make sure the AllowedNodeNames is set. If users don't set the AllowedNodeNames the hirte won't communicate with other nodes.