### PR TITLE
Prevent continuous heartbeats

### DIFF
--- a/doc/man/hirte-agent.1.md
+++ b/doc/man/hirte-agent.1.md
@@ -41,7 +41,7 @@ The unique name of this `hirte-agent` used for registering at `hirte`. This opti
 
 #### **--interval**, **-i**
 
-The interval between two heartbeat signals sent to hirte in milliseconds. This option will overwrite the heartbeat interval defined in the configuration file. 
+The interval between two heartbeat signals sent to hirte in milliseconds. If an agent is not connected, it will retry to connect on each heartbeat. Setting this options to values smaller or equal to 0 disables it. This option will overwrite the heartbeat interval defined in the configuration file. 
 
 #### **--config**, **-c**
 

--- a/doc/man/hirte-agent.conf.5.md
+++ b/doc/man/hirte-agent.conf.5.md
@@ -39,7 +39,7 @@ The port on which `hirte` is listening for connection request and the `hirte-age
 
 #### **HeartbeatInterval** (long)
 
-The interval between two heartbeat signals sent to hirte in milliseconds. This option will overwrite the heartbeat interval defined in the configuration file. 
+The interval between two heartbeat signals sent to hirte in milliseconds. If an agent is not connected, it will retry to connect on each heartbeat. Setting this options to values smaller or equal to 0 disables it. This option will overwrite the heartbeat interval defined in the configuration file. 
 
 #### **LogLevel** (string)
 

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -164,6 +164,11 @@ static int agent_setup_heartbeat_timer(Agent *agent) {
 
         assert(agent);
 
+        if (agent->heartbeat_interval_msec <= 0) {
+                hirte_log_warnf("Heartbeat disabled since interval is '%d', ", agent->heartbeat_interval_msec);
+                return 0;
+        }
+
         r = agent_reset_heartbeat_timer(agent, &event_source);
         if (r < 0) {
                 hirte_log_errorf("Failed to reset agent heartbeat timer: %s", strerror(-r));

--- a/src/libhirte/socket.c
+++ b/src/libhirte/socket.c
@@ -25,6 +25,8 @@ int create_tcp_socket(uint16_t port) {
         servaddr.sin6_family = AF_INET6;
         servaddr.sin6_addr = in6addr_any;
         servaddr.sin6_port = htons(port);
+        servaddr.sin6_flowinfo = 0;
+        servaddr.sin6_scope_id = 0;
 
         if (bind(fd, &servaddr, sizeof(servaddr)) < 0) {
                 int errsv = errno;


### PR DESCRIPTION
This PR

#### disables heartbeat for intervals smaller or equal to 0
If the heartbeat interval is set to 0, this event gets fired continuously, consuming a lot of CPU (on my machine ~80% for hirte-agent and ~60% for hirte). To prevent this don't register any heartbeat for interval values smaller than or equal to 0. Smaller values also disable the heartbeat, so not registering at all has the same result. 

#### fully initializes the serveraddr struct
Running hirte with valgrind, it complains about `servaddr.sin6_flowinfo` and `sin6_scope_id` not to be initialized. Setting these values to 0 should keep the current behavior and still initialize it. 