### PR TITLE
Get hirte version through CLI

### DIFF
--- a/doc/man/hirte-agent.1.md
+++ b/doc/man/hirte-agent.1.md
@@ -47,6 +47,10 @@ The interval between two heartbeat signals sent to hirte in milliseconds. If an 
 
 Path to the configuration file, see `hirte-agent.conf(5)`. (default: /etc/hirte/agent.conf)
 
+#### **--version**,  **-v**
+
+Print current hirte-agent version
+
 #### **--user**
 
 Connect to the user systemd instance instead of the system one.

--- a/doc/man/hirte-proxy.1.md
+++ b/doc/man/hirte-proxy.1.md
@@ -27,6 +27,10 @@ or stopped on a remote node managed by another `hirte-agent`.
 
 Print usage statement and exit.
 
+#### **--version**,  **-v**
+
+Print current hirte-proxy version
+
 
 ## Commands
 

--- a/doc/man/hirte.1.md
+++ b/doc/man/hirte.1.md
@@ -30,6 +30,10 @@ The port on which hirte is listening for and setting up connections with `hirte-
 
 Path to the configuration file, see `hirte.conf(5)`.
 
+#### **--version**,  **-v**
+
+Print current hirte version
+
 ## Environment Variables
 
 `hirte` understands the following environment variables that can be used to override the settings from the configuration file (see `hirte.conf(5)`).

--- a/doc/man/hirtectl.1.md
+++ b/doc/man/hirtectl.1.md
@@ -20,6 +20,10 @@ A simple command line tool that uses the public D-Bus API provided by `hirte` to
 
 Print usage statement and exit.
 
+#### **--version**,  **-v**
+
+Print current hirtectl version
+
 ## Commands
 
 ### **hirtectl** [*start|stop|restart|reload*] [*agent*] [*unit*]

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,7 @@ prefixdir = get_option('prefix')
 
 conf.set_quoted('CONFIG_H_SYSCONFDIR', join_paths(prefixdir, get_option('sysconfdir')))
 conf.set_quoted('CONFIG_H_DATADIR', join_paths(prefixdir, get_option('datadir')))
+conf.set_quoted('CONFIG_H_HIRTE_VERSION', meson.project_version())
 
 config_h = configure_file(
         output : 'config.h',

--- a/src/agent/main.c
+++ b/src/agent/main.c
@@ -18,11 +18,12 @@ const struct option options[] = { { ARG_HOST, required_argument, 0, ARG_HOST_SHO
                                   { ARG_CONFIG, required_argument, 0, ARG_CONFIG_SHORT },
                                   { ARG_USER, no_argument, 0, ARG_USER_SHORT },
                                   { ARG_HELP, no_argument, 0, ARG_HELP_SHORT },
+                                  { ARG_VERSION, no_argument, 0, ARG_VERSION_SHORT },
                                   { NULL, 0, 0, '\0' } };
 
 #define OPTIONS_STR                                                                               \
         ARG_PORT_SHORT_S ARG_HOST_SHORT_S ARG_ADDRESS_SHORT_S ARG_HELP_SHORT_S ARG_CONFIG_SHORT_S \
-                        ARG_NAME_SHORT_S ARG_USER_SHORT_S ARG_HEARTBEAT_INTERVAL_SHORT_S
+                        ARG_NAME_SHORT_S ARG_USER_SHORT_S ARG_HEARTBEAT_INTERVAL_SHORT_S ARG_VERSION_SHORT_S
 
 static const char *opt_port = 0;
 static const char *opt_host = NULL;
@@ -43,7 +44,8 @@ static void usage(char *argv[]) {
                "\t-%c %s\t\t The unique name of this hirte-agent used to register at hirte.\n"
                "\t-%c %s\t The interval between two heartbeat signals in milliseconds.\n"
                "\t-%c %s\t A path to a config file used to bootstrap hirte-agent.\n"
-               "\t-%c %s\t\t Connect to the user systemd instance instead of the system one.\n",
+               "\t-%c %s\t\t Connect to the user systemd instance instead of the system one.\n"
+               "\t-%c %s\t\t Print current version of hirte-agent.\n",
                argv[0],
                ARG_HELP_SHORT,
                ARG_HELP,
@@ -60,7 +62,9 @@ static void usage(char *argv[]) {
                ARG_CONFIG_SHORT,
                ARG_CONFIG,
                ARG_USER_SHORT,
-               ARG_USER);
+               ARG_USER,
+               ARG_VERSION_SHORT,
+               ARG_VERSION);
 }
 
 static int get_opts(int argc, char *argv[]) {
@@ -70,6 +74,10 @@ static int get_opts(int argc, char *argv[]) {
                 switch (opt) {
                 case ARG_HELP_SHORT:
                         usage(argv);
+                        return 1;
+
+                case ARG_VERSION_SHORT:
+                        printf("%s\n", CONFIG_H_HIRTE_VERSION);
                         return 1;
 
                 case ARG_NAME_SHORT:

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -679,6 +679,8 @@ int client_call_manager(Client *client) {
                 } else {
                         return -EINVAL;
                 }
+        } else if (streq(client->op, "version")) {
+                printf("%s\n", CONFIG_H_HIRTE_VERSION);
         } else {
                 return -EINVAL;
         }

--- a/src/libhirte/common/opt.h
+++ b/src/libhirte/common/opt.h
@@ -36,3 +36,7 @@
 #define ARG_HELP "help"
 #define ARG_HELP_SHORT 'h'
 #define ARG_HELP_SHORT_S "h"
+
+#define ARG_VERSION "version"
+#define ARG_VERSION_SHORT 'v'
+#define ARG_VERSION_SHORT_S "v"

--- a/src/manager/main.c
+++ b/src/manager/main.c
@@ -12,9 +12,10 @@
 const struct option options[] = { { ARG_PORT, required_argument, 0, ARG_PORT_SHORT },
                                   { ARG_CONFIG, required_argument, 0, ARG_CONFIG_SHORT },
                                   { ARG_HELP, no_argument, 0, ARG_HELP_SHORT },
+                                  { ARG_VERSION, no_argument, 0, ARG_VERSION_SHORT },
                                   { NULL, 0, 0, '\0' } };
 
-#define OPTIONS_STR ARG_PORT_SHORT_S ARG_HELP_SHORT_S ARG_CONFIG_SHORT_S
+#define OPTIONS_STR ARG_PORT_SHORT_S ARG_HELP_SHORT_S ARG_CONFIG_SHORT_S ARG_VERSION_SHORT_S
 
 static const char *opt_port = 0;
 static const char *opt_config = NULL;
@@ -25,14 +26,17 @@ static void usage(char *argv[]) {
                "Available options are:\n"
                "\t-%c %s\t\t Print this help message.\n"
                "\t-%c %s\t\t The port of hirte to connect to.\n"
-               "\t-%c %s\t A path to a config file used to bootstrap hirte-agent.\n",
+               "\t-%c %s\t A path to a config file used to bootstrap hirte-agent.\n"
+               "\t-%c %s\t Print current hirte version.\n",
                argv[0],
                ARG_HELP_SHORT,
                ARG_HELP,
                ARG_PORT_SHORT,
                ARG_PORT,
                ARG_CONFIG_SHORT,
-               ARG_CONFIG);
+               ARG_CONFIG,
+               ARG_VERSION_SHORT,
+               ARG_VERSION);
 }
 
 static int get_opts(int argc, char *argv[]) {
@@ -42,6 +46,10 @@ static int get_opts(int argc, char *argv[]) {
                 switch (opt) {
                 case ARG_HELP_SHORT:
                         usage(argv);
+                        return 1;
+
+                case ARG_VERSION_SHORT:
+                        printf("%s\n", CONFIG_H_HIRTE_VERSION);
                         return 1;
 
                 case ARG_PORT_SHORT:

--- a/src/proxy/main.c
+++ b/src/proxy/main.c
@@ -12,9 +12,10 @@
 
 const struct option options[] = { { ARG_USER, no_argument, 0, ARG_USER_SHORT },
                                   { ARG_HELP, no_argument, 0, ARG_HELP_SHORT },
+                                  { ARG_VERSION, no_argument, 0, ARG_VERSION_SHORT },
                                   { NULL, 0, 0, '\0' } };
 
-#define OPTIONS_STR ARG_HELP_SHORT_S ARG_USER_SHORT_S
+#define OPTIONS_STR ARG_HELP_SHORT_S ARG_USER_SHORT_S ARG_VERSION_SHORT_S
 
 static const char *opt_node_unit = NULL;
 static const char *opt_operation = NULL;
@@ -33,7 +34,8 @@ static void usage(char *argv[]) {
         printf("Usage: %s \n"
                "\t[-h help]\t\t Print this help message.\n"
                "\t<operation>\t\t Required. Operation to perform. Must be one of [%s,%s].\n"
-               "\t<node>_<service>\t Required. Input the name of the node the required service is supposed to run on.\n",
+               "\t<node>_<service>\t Required. Input the name of the node the required service is supposed to run on.\n"
+               "\t<[-v version]\t Print current version of hirte-proxy\n",
                argv[0],
                OPT_OPERATION_CREATE,
                OPT_OPERATION_REMOVE);
@@ -72,6 +74,11 @@ static int get_opts(int argc, char *argv[]) {
                 case ARG_HELP_SHORT:
                         usage(argv);
                         return 1;
+
+                case ARG_VERSION_SHORT:
+                        printf("%s\n", CONFIG_H_HIRTE_VERSION);
+                        return 1;
+
                 case ARG_USER_SHORT:
                         opt_user = true;
                         break;


### PR DESCRIPTION
Added CLI parameter for hirte, hirte-agent, hirtectl and hirte-proxy that prints thier current version.

Fixes: https://github.com/containers/hirte/issues/384