### PR TITLE
info: show hirte version in the start

### DIFF
--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -1890,6 +1890,8 @@ bool agent_start(Agent *agent) {
         int r = 0;
         sd_bus_error error = SD_BUS_ERROR_NULL;
 
+        hirte_log_infof("Starting hirte-agent %s", CONFIG_H_HIRTE_VERSION);
+
         if (agent == NULL) {
                 return false;
         }

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -914,6 +914,7 @@ static int manager_name_owner_changed(sd_bus_message *m, void *userdata, UNUSED 
 }
 
 bool manager_start(Manager *manager) {
+        hirte_log_infof("Starting hirte %s", CONFIG_H_HIRTE_VERSION);
         if (manager == NULL) {
                 return false;
         }


### PR DESCRIPTION
Today reading the logs is not possible to identify which hirte version is loaded. Helps support/debug and development.

Fixes: https://github.com/containers/hirte/issues/406