### PR TITLE
build: do not include debug symbols by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,8 @@ srpm:
 
 distclean: clean
 	rm -rf $(BUILDDIR)
+
+debug:
+	$(MAKE) clean
+	@sed -i 's/debug=false/debug=true/g' meson.build
+	$(MAKE) build

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project(
   default_options: [
     'c_std=gnu17',     # Adds "-std=gnu17".  Includes GNU 17 extensions.
     'warning_level=2', # Adds "-Wextra".  Enables additional warnings.
-    'debug=true',      # Adds "-g".  Object files include debugging symbols.
+    'debug=false',      # Adds "-g".  Object files include debugging symbols.
     'werror=true'      # Adds "-Werror".  Treat warnings as errors.
   ]
 )


### PR DESCRIPTION
By default debug symbols are included into the hirte binaries. It should included only for development and tests.

GitHub-Issue: https://github.com/containers/hirte/issues/409

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>