### PR TITLE
test: remove get_address_test from meson.build

### DIFF
--- a/src/libhirte/test/common/network/meson.build
+++ b/src/libhirte/test/common/network/meson.build
@@ -3,7 +3,6 @@
 network_src = [
   'is_ipv4_test',
   'is_ipv6_test',
-  'get_address_test',
   'assemble_tcp_address',
 ]
 


### PR DESCRIPTION
Depending of the build system it might not be able to access outside network.

Fixes: https://github.com/containers/hirte/issues/398