### PR TITLE
increase maximum line length of inih

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,10 +21,16 @@ common_cflags = cc.get_supported_arguments(test_cflags)
 # Link with systemd shared library.
 systemd_dep = dependency('libsystemd')
 
+# Set option to use either the session or system D-Bus
 api_bus = get_option('api_bus')
 if api_bus == 'user'
    common_cflags += '-DUSE_USER_API_BUS'
 endif
+
+# Set option of inih libraries maximum line length
+# 500 characters for actual value
+# 20 characters as buffer (key, library internal usage, etc.)
+common_cflags += '-DINI_MAX_LINE=520'
 
 # Build time configuration header file
 conf = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -27,10 +27,13 @@ if api_bus == 'user'
    common_cflags += '-DUSE_USER_API_BUS'
 endif
 
-# Set option of inih libraries maximum line length
+# inih library options
+# Set option of maximum line length
 # 500 characters for actual value
 # 20 characters as buffer (key, library internal usage, etc.)
 common_cflags += '-DINI_MAX_LINE=520'
+# Set option to abort parsing on first error
+common_cflags += '-DINI_STOP_ON_FIRST_ERROR=1'
 
 # Build time configuration header file
 conf = configuration_data()

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -551,11 +551,14 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
 
         if (configfile != NULL) {
                 result = cfg_load_from_file(agent->config, configfile);
-                if (result != 0) {
+                if (result < 0) {
                         fprintf(stderr,
                                 "Error loading configuration file '%s', error code '%s'.\n",
                                 configfile,
                                 strerror(-result));
+                        return false;
+                } else if (result > 0) {
+                        fprintf(stderr, "Error parsing configuration file '%s' on line %d\n", configfile, result);
                         return false;
                 }
         }

--- a/src/libhirte/common/cfg.h
+++ b/src/libhirte/common/cfg.h
@@ -100,7 +100,8 @@ int cfg_load_complete_configuration(
 /*
  * Load the application configuration from the specified file and override any existing options values.
  *
- * Returns 0 if successful, otherwise standard error code.
+ * Returns 0 if successful. If a parsing error occurred, a positive integer indicating the line of error is
+ * returned. On all other errors a standard error code will be returned.
  */
 int cfg_load_from_file(struct config *config, const char *config_file);
 

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -326,11 +326,14 @@ bool manager_parse_config(Manager *manager, const char *configfile) {
 
         if (configfile != NULL) {
                 result = cfg_load_from_file(manager->config, configfile);
-                if (result != 0) {
+                if (result < 0) {
                         fprintf(stderr,
                                 "Error loading configuration file '%s': '%s'.\n",
                                 configfile,
                                 strerror(-result));
+                        return false;
+                } else if (result > 0) {
+                        fprintf(stderr, "Error parsing configuration file '%s' on line %d\n", configfile, result);
                         return false;
                 }
         }


### PR DESCRIPTION
This PR fixes #431 by
- increasing the maximum line length used by the `inih` library (should've been added in #428, but missed it)
- providing an error message with the line number where the error occurred 
