### PR TITLE
Add coverage report generation for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,23 @@ build:
 	meson setup $(BUILDDIR)
 	meson compile -C $(BUILDDIR)
 
+build-coverage:
+	meson setup -Db_coverage=true $(BUILDDIR)
+	meson compile -C $(BUILDDIR)
+
 test: build
 	meson test -C $(BUILDDIR)
 
+test-coverage: build-coverage
+	meson test -C $(BUILDDIR)
+	ninja coverage-html -C $(BUILDDIR)
+
 test-with-valgrind: build
 	meson test --wrap='valgrind --leak-check=full --error-exitcode=1 --track-origins=yes' -C $(BUILDDIR)
+
+test-with-valgrind-coverage: build-coverage
+	meson test --wrap='valgrind --leak-check=full --error-exitcode=1 --track-origins=yes' -C $(BUILDDIR)
+	ninja coverage-html -C $(BUILDDIR)
 
 install: build
 	meson install -C $(BUILDDIR) --destdir "$(DESTDIR)"

--- a/Makefile
+++ b/Makefile
@@ -11,23 +11,15 @@ build:
 	meson setup $(BUILDDIR)
 	meson compile -C $(BUILDDIR)
 
-build-coverage:
-	meson setup -Db_coverage=true $(BUILDDIR)
+test:
+	meson setup $(BUILDDIR)
+	meson configure -Db_coverage=true $(BUILDDIR)
 	meson compile -C $(BUILDDIR)
-
-test: build
-	meson test -C $(BUILDDIR)
-
-test-coverage: build-coverage
 	meson test -C $(BUILDDIR)
 	ninja coverage-html -C $(BUILDDIR)
 
 test-with-valgrind: build
 	meson test --wrap='valgrind --leak-check=full --error-exitcode=1 --track-origins=yes' -C $(BUILDDIR)
-
-test-with-valgrind-coverage: build-coverage
-	meson test --wrap='valgrind --leak-check=full --error-exitcode=1 --track-origins=yes' -C $(BUILDDIR)
-	ninja coverage-html -C $(BUILDDIR)
 
 install: build
 	meson install -C $(BUILDDIR) --destdir "$(DESTDIR)"

--- a/README.developer.md
+++ b/README.developer.md
@@ -153,6 +153,26 @@ meson compile -C builddir
 meson test -C builddir
 ```
 
+or simply:
+
+```bash
+# unit tests
+make test
+# unit tests with valgrind
+make test-with-valgrind
+```
+
+If you want to get coverage data you'll need `lcov` package installed:
+
+```bash
+# unit tests with coverage report
+make test-coverage
+# unit tests with valgrind and coverage report
+make test-with-valgrind-coverage
+```
+
+will produce a coverage report in `builddir/meson-logs/coveragereport/index.html`
+
 ### Integration tests
 
 All files related to the integration tests are located in [tests](./tests/) and are organized via

--- a/README.developer.md
+++ b/README.developer.md
@@ -149,26 +149,10 @@ Unit tests can be executed using following commands:
 
 ```bash
 meson setup builddir
+meson configure -Db_coverage=true builddir  # if you want to collect coverage data
 meson compile -C builddir
 meson test -C builddir
-```
-
-or simply:
-
-```bash
-# unit tests
-make test
-# unit tests with valgrind
-make test-with-valgrind
-```
-
-If you want to get coverage data you'll need `lcov` package installed:
-
-```bash
-# unit tests with coverage report
-make test-coverage
-# unit tests with valgrind and coverage report
-make test-with-valgrind-coverage
+ninja coverage-html -C builddir  # if you want to generate coverage report
 ```
 
 will produce a coverage report in `builddir/meson-logs/coveragereport/index.html`


### PR DESCRIPTION
Added targets to Makefile for getting a coverage report from the unit tests.

Example report:
![image](https://github.com/containers/hirte/assets/937860/9f3a6327-6c83-46a2-82bb-25c646102c09)
