### PR TITLE
build-base: add tools for coverage reports

### DIFF
--- a/tests/containers/build-base
+++ b/tests/containers/build-base
@@ -3,7 +3,7 @@ FROM quay.io/centos/centos:stream9
 RUN dnf install -y dnf-plugin-config-manager
 # CRB is required for meson
 RUN dnf config-manager -y --set-enabled crb
-# EPEL is required for python3-flake8 and codespell
+# EPEL is required for lcov, python3-flake8, python3-html2text and codespell
 RUN dnf install -y epel-release
 
 RUN dnf install \
@@ -17,9 +17,11 @@ RUN dnf install \
         golang-github-cpuguy83-md2man \
         gzip \
         jq \
+        lcov \
         make \
         meson \
         python3-flake8 \
+        python3-html2text \
         rpm-build \
         sed \
         selinux-policy-devel \


### PR DESCRIPTION
- adding lcov as gcov is not available on el9
- adding html2text to generate summary for github action step