### PR TITLE
Use correct architecture within container builds

### DIFF
--- a/tests/containers/integration-test-snapshot
+++ b/tests/containers/integration-test-snapshot
@@ -1,7 +1,7 @@
 FROM quay.io/hirte/integration-test-base:latest
 
 RUN dnf install -y --repo hirte-snapshot \
-    --repofrompath hirte-snapshot,https://download.copr.fedorainfracloud.org/results/mperina/hirte-snapshot/centos-stream-9-x86_64/ \
+    --repofrompath hirte-snapshot,https://download.copr.fedorainfracloud.org/results/mperina/hirte-snapshot/centos-stream-9-$ARCH/ \
     --nogpgcheck hirte hirte-debuginfo hirte-agent hirte-agent-debuginfo hirte-ctl hirte-ctl-debuginfo hirte-selinux
 
 CMD [ "/sbin/init" ]


### PR DESCRIPTION
Use correct architecture when building containers on non-x86_64
platforms.

Fixes: https://github.com/containers/hirte/issues/437
Signed-off-by: Martin Perina <mperina@redhat.com>
