### PR TITLE
Fix detecting architecture within container builds

### DIFF
--- a/tests/containers/integration-test-snapshot
+++ b/tests/containers/integration-test-snapshot
@@ -1,7 +1,7 @@
 FROM quay.io/hirte/integration-test-base:latest
 
 RUN dnf install -y --repo hirte-snapshot \
-    --repofrompath hirte-snapshot,https://download.copr.fedorainfracloud.org/results/mperina/hirte-snapshot/centos-stream-9-$ARCH/ \
+    --repofrompath hirte-snapshot,https://download.copr.fedorainfracloud.org/results/mperina/hirte-snapshot/centos-stream-9-$(uname -m)/ \
     --nogpgcheck \
     --nodocs \
         hirte \


### PR DESCRIPTION
We need to detect the architecture to provide the correct DNF repository
with BlueChi RPMs.

Fixes: https://github.com/containers/hirte/issues/437
Signed-off-by: Martin Perina <mperina@redhat.com>
