### PR TITLE
test: add getaddress mock

### DIFF
--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -1840,7 +1840,7 @@ static bool ensure_orch_address(Agent *agent) {
 
         _cleanup_free_ char *resolved_ip_address = NULL;
         if (!host_is_ipv4 && !host_is_ipv6) {
-                int r = get_address(ip_address, &resolved_ip_address);
+                int r = get_address(ip_address, &resolved_ip_address, getaddrinfo);
                 if (r < 0) {
                         hirte_log_errorf(
                                         "Failed to get IP address from host '%s': %s",

--- a/src/libhirte/common/network.c
+++ b/src/libhirte/common/network.c
@@ -17,7 +17,7 @@ bool is_ipv6(const char *domain) {
         return (inet_pton(AF_INET6, domain, &(sa.sin6_addr)) == 1);
 }
 
-int get_address(const char *domain, char **ip_address) {
+int get_address(const char *domain, char **ip_address, getaddrinfo_func resolve_addr) {
         if (domain == NULL) {
                 return -EINVAL;
         }
@@ -31,7 +31,7 @@ int get_address(const char *domain, char **ip_address) {
         hints.ai_family = AF_UNSPEC;
         hints.ai_socktype = SOCK_STREAM;
 
-        int status = getaddrinfo(domain, NULL, &hints, &res);
+        int status = resolve_addr(domain, NULL, &hints, &res);
         if (status != 0) {
                 hirte_log_errorf("getaddrinfo failed: %s\n", gai_strerror(status));
                 return status;

--- a/src/libhirte/common/network.h
+++ b/src/libhirte/common/network.h
@@ -16,10 +16,16 @@ bool is_ipv4(const char *domain);
 bool is_ipv6(const char *domain);
 
 char *get_hostname();
-int get_address(const char *domain, char **ip_address);
 
 char *typesafe_inet_ntop4(const struct sockaddr_in *addr);
 char *typesafe_inet_ntop6(const struct sockaddr_in6 *addr);
 
 char *assemble_tcp_address(const struct sockaddr_in *addr);
 char *assemble_tcp_address_v6(const struct sockaddr_in6 *addr);
+
+typedef int (*getaddrinfo_func)(
+                const char * restrict node,
+                const char * restrict service,
+                const struct addrinfo * restrict hints,
+                struct addrinfo ** restrict res);
+int get_address(const char *domain, char **ip_address, getaddrinfo_func resolve_addr);

--- a/src/libhirte/test/common/network/get_address_test.c
+++ b/src/libhirte/test/common/network/get_address_test.c
@@ -7,88 +7,101 @@
 #include "libhirte/common/network.h"
 #include "libhirte/common/string-util.h"
 
-/* test cases with invalid or unresolvable domains */
-bool test_get_address_failure(const char *domain) {
-        _cleanup_free_ char *ip = NULL;
-        int result = get_address(domain, &ip);
-        if (result >= 0) {
-                fprintf(stdout,
-                        "FAILED: get_address('%s') - Expected a failure (result < 0), but got %d\n",
-                        domain,
-                        result);
-                return false;
+typedef struct get_address_test_params {
+        char *hostname;
+        bool use_ipv4;
+        char *expected_resolved_addresses;
+        int expected_result;
+} get_address_test_params;
+
+
+long unsigned int test_data_index = 0;
+struct get_address_test_params test_data[] = {
+        { NULL, true, NULL, -EINVAL },
+        { ".", true, NULL, -1 },
+        { "redhat", true, NULL, -1 },
+        { "?10.10.10.3", true, NULL, -1 },
+        { "192.168.1.", true, NULL, -1 },
+        { "8.8.8.8", true, NULL, 0 },
+        { "localhost.localdomain", true, "127.0.0.1", 0 },
+};
+
+int getaddrinfo_mock(
+                UNUSED const char *name,
+                UNUSED const char *service,
+                UNUSED const struct addrinfo *req,
+                struct addrinfo **pai) {
+
+        void *offset;
+
+        get_address_test_params current_test_case = test_data[test_data_index];
+        if (current_test_case.expected_result < 0) {
+                *pai = NULL;
+                return current_test_case.expected_result;
         }
-        if (ip != NULL) {
-                fprintf(stdout, "FAILED: get_address('%s') - Expected null, but got non-null (%s)\n", domain, ip);
-                return false;
+
+        /*
+         * To emulate what getaddrinfo does, allocate both sockaddr_in and
+         * addrinfo together so freeaddrinfo() will free the entire thing.
+         */
+        *pai = malloc0(sizeof(struct addrinfo) + sizeof(struct sockaddr_in6));
+        offset = (void *) ((long) *pai + sizeof(struct addrinfo));
+
+        if (current_test_case.use_ipv4) {
+                struct sockaddr_in *addr = (struct sockaddr_in *) offset;
+                (*pai)->ai_family = AF_INET;
+                if (!inet_pton(AF_INET, current_test_case.expected_resolved_addresses, addr)) {
+                        fprintf(stderr, "sockaddr_in AF_INET failed");
+                        exit(1);
+                }
+                (*pai)->ai_addr = (struct sockaddr *) addr;
+                (*pai)->ai_addrlen = sizeof(*addr);
+        } else {
+                struct sockaddr_in6 *addr = (struct sockaddr_in6 *) offset;
+                if (!addr) {
+                        fprintf(stderr, "sockaddr_in6 AF_INET6 failed");
+                        exit(1);
+                }
+
+                (*pai)->ai_family = AF_INET6;
+                inet_pton(AF_INET6, current_test_case.expected_resolved_addresses, &addr);
+                if (!inet_pton(AF_INET6, current_test_case.expected_resolved_addresses, &addr)) {
+                        fprintf(stderr, "inet_pton AF_INET6 failed");
+                        exit(1);
+                }
+                (*pai)->ai_addr = (struct sockaddr *) addr;
+                (*pai)->ai_addrlen = sizeof(*addr);
         }
-        return true;
+
+        return current_test_case.expected_result;
 }
 
-/* test cases where domain already contains an IPv4 or IPv6 */
-bool test_get_address_success(const char *domain) {
+bool test_get_address(get_address_test_params params) {
         _cleanup_free_ char *ip = NULL;
-        int result = get_address(domain, &ip);
-        if (result != 0) {
+        int result = get_address(params.hostname, &ip, getaddrinfo_mock);
+        if ((result != params.expected_result) ||
+            ((params.expected_resolved_addresses == NULL && ip != NULL) ||
+             (params.expected_resolved_addresses != NULL && ip == NULL))) {
                 fprintf(stdout,
-                        "FAILED: get_address('%s') - Expected a success (result == 0), but got %d (%s)\n",
-                        domain,
+                        "FAILED: get_address('%s') - "
+                        "Expected return value %d with resolved address '%s', but got return value %d with '%s'\n",
+                        params.hostname,
+                        params.expected_result,
+                        params.expected_resolved_addresses,
                         result,
-                        strerror(-result));
-                return false;
-        }
-        if (ip != NULL) {
-                fprintf(stdout, "FAILED: get_address('%s') - Expected null, but got non-null (%s)\n", domain, ip);
-                return false;
-        }
-        return true;
-}
-
-/* test case for actually resolving a domain to an IP */
-bool test_get_address_localhost() {
-        const char *domain = "localhost";
-        int expected_ret = 0;
-        const char *expected_addressv4 = "127.0.0.1";
-        const char *expected_addressv6 = "::1";
-
-        _cleanup_free_ char *ip = NULL;
-        int result = get_address("localhost", &ip);
-        if (result != expected_ret) {
-                fprintf(stdout,
-                        "FAILED: get_address('%s') - Expected return code %d, but got %d (%s)\n",
-                        domain,
-                        expected_ret,
-                        result,
-                        strerror(-result));
-                return false;
-        }
-        if (ip == NULL) {
-                fprintf(stdout, "FAILED: get_address('%s') - Expected non-null, but got null\n", domain);
-                return false;
-        }
-        if (!streq(ip, expected_addressv4) && !streq(ip, expected_addressv6)) {
-                fprintf(stdout,
-                        "FAILED: get_address('%s') - Expected either %s or %s, but got %s\n",
-                        domain,
-                        expected_addressv4,
-                        expected_addressv6,
                         ip);
                 return false;
         }
         return true;
 }
 
-
 int main() {
         bool result = true;
-        result = result && test_get_address_failure(NULL);
-        result = result && test_get_address_failure(".");
-        result = result && test_get_address_failure("redhat");
-        result = result && test_get_address_failure("?10.10.10.3");
-        result = result && test_get_address_failure("192.168.1.");
-        result = result && test_get_address_success("8.8.8.8");
-        result = result && test_get_address_success("fe80::78b3:75ff:fe1b:6803");
-        result = result && test_get_address_localhost();
+        for (test_data_index = 0; test_data_index < sizeof(test_data) / sizeof(get_address_test_params);
+             test_data_index++) {
+                result = result && test_get_address(test_data[test_data_index]);
+        }
+
         if (result) {
                 return EXIT_SUCCESS;
         }


### PR DESCRIPTION
There are test pipelines environments that cannot use external network due security restrictions. This patch ensure the code can be still tested.

Fixes: https://github.com/containers/bluechi/issues/398

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>
Signed-off-by: Michael Engel <mengel@redhat.com>