### PR TITLE
tests: README.md update tmt instructions

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -13,7 +13,7 @@ First, enable required repositories on CentOS Stream 9:
 
 ```shell
 sudo dnf install -y dnf-plugin-config-manager
-sudo dnf install -y --set-enabled crb
+sudo dnf config-manager -y --set-enabled crb
 sudo dnf install -y epel-release
 ```
 


### PR DESCRIPTION
The command: dnf install -y --set-enabled crb is incorrect. This patch fix it.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>

Resolves: #457 