### PR TITLE
Maintain Python 3.9 compatibility for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.9'
 
       - name: Install dependencies
         run: |

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,8 @@ dnf install \
     -y
 ```
 
+**_NOTE:_** Integration tests code should be compatible with Python 3.9, please don't use features from newer versions.
+
 ### Installing packages using pip
 
 All required python packages are listed in the [requirements.txt](./requirements.txt) and can be installed using `pip`:
@@ -43,8 +45,8 @@ Instead of installing the required packages directly, it is recommended to creat
 the following snippet uses the built-in [venv](https://docs.python.org/3/library/venv.html):
 
 ```bash
-python -m venv env
-source env/bin/activate
+python -m venv ~/bluechi-env
+source ~/bluechi-env/bin/activate
 pip install -U -r requirements.txt
 # ...
 

--- a/tests/hirte_test/container.py
+++ b/tests/hirte_test/container.py
@@ -63,7 +63,7 @@ class HirteContainer():
             self.container.stop()
         self.container.remove()
 
-    def exec_run(self, command: (str | list[str]), raw_output: bool = False) -> \
+    def exec_run(self, command: (Union[str, list[str]]), raw_output: bool = False) -> \
             Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
 
         result, output = self.container.exec_run(command)

--- a/tests/hirte_test/fixtures.py
+++ b/tests/hirte_test/fixtures.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 from podman import PodmanClient
+from typing import Union
 
 from hirte_test.test import HirteTest
 from hirte_test.config import HirteControllerConfig, HirteNodeConfig
@@ -59,7 +60,7 @@ def podman_client() -> PodmanClient:
 
 
 @pytest.fixture(scope='session')
-def hirte_image_id(podman_client: PodmanClient, hirte_image_name: str) -> (str | None):
+def hirte_image_id(podman_client: PodmanClient, hirte_image_name: str) -> (Union[str, None]):
     """Returns the image ID of hirte testing containers"""
     image = next(
         iter(

--- a/tests/hirte_test/util.py
+++ b/tests/hirte_test/util.py
@@ -2,8 +2,10 @@
 
 import socket
 
+from typing import Union
 
-def read_file(local_file: str) -> (str | None):
+
+def read_file(local_file: str) -> (Union[str, None]):
     content = None
     with open(local_file, 'r') as fh:
         content = fh.read()


### PR DESCRIPTION
- Make tests compatible with Python 3.9
- Run integration tests in CI with Python 3.9

Fixes: https://github.com/containers/bluechi/issues/456
