### PR TITLE
build: add gcovr / lcov requirement

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,11 @@ project(
   ]
 )
 
+gcovr = find_program('gcovr', required: false)
+if not gcovr.found()
+   find_program('lcov', required: true)
+endif
+
 test_cflags = [ '-Wno-cast-function-type' ]
 
 cc = meson.get_compiler('c')


### PR DESCRIPTION
During build the system must have a utility to generate reports to avoid generic errors.

For Fedora users there is gcovr. CentOS 9 Stream contain lcov via epel-release.

Fixes: https://github.com/containers/bluechi/issues/461

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>