### PR TITLE
Install gcc-c++ as a depedency for SRPM creation for COPR build

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,7 +1,7 @@
 .PHONY: installdeps srpm
 
 installdeps:
-	dnf -y install gcc git jq meson systemd-devel rpm-build
+	dnf -y install gcc gcc-c++ git jq meson systemd-devel rpm-build
 
 srpm: installdeps
 	./build-scripts/build-srpm.sh


### PR DESCRIPTION
Adds gcc-c++ to the installed dependencies during SRPM creation when
building package from COPR. inih library contains C++ code, but even
though we use only C part of the library, meson needs to detect C++
compiler to pass successfully.

Signed-off-by: Martin Perina <mperina@redhat.com>
