### PR TITLE
Add gcc-c++ to the spec build requirements

### DIFF
--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -7,6 +7,8 @@ URL:     https://github.com/containers/bluechi
 Source0: %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires: gcc
+# Meson needs to detect C++, because part of inih library (which we don't use) provides C++ functionality
+BuildRequires: gcc-c++
 BuildRequires: meson
 BuildRequires: systemd-devel
 BuildRequires: systemd-rpm-macros


### PR DESCRIPTION
Part of inih libraryr provides C++ interface, which is not used in
BlueChi. But meson detects this C++ code, so it needs to detect also C++
compiler.

Signed-off-by: Martin Perina <mperina@redhat.com>
