### PR TITLE
Update quay organization for images and support multiplatform container base

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
   rpmbuild:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/hirte/build-base:latest
+      image: quay.io/bluechi/build-base:latest
     env:
       ARTIFACTS_DIR: exported-artifacts
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
     name: Common
     runs-on: ubuntu-latest
     container:
-      image: quay.io/hirte/build-base:latest
+      image: quay.io/bluechi/build-base:latest
 
     steps:
       - name: Checkout sources
@@ -63,7 +63,7 @@ jobs:
     name: C
     runs-on: ubuntu-latest
     container:
-      image: quay.io/hirte/build-base:latest
+      image: quay.io/bluechi/build-base:latest
 
     steps:
       - name: Checkout sources
@@ -108,7 +108,7 @@ jobs:
     name: Python
     runs-on: ubuntu-latest
     container:
-      image: quay.io/hirte/build-base:latest
+      image: quay.io/bluechi/build-base:latest
 
     steps:
       - name: Checkout sources
@@ -129,7 +129,7 @@ jobs:
     name: 
     runs-on: ubuntu-latest
     container:
-      image: quay.io/hirte/build-base:latest
+      image: quay.io/bluechi/build-base:latest
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     name: Publish bluechi on PyPi
     runs-on: ubuntu-latest
     container:
-      image: quay.io/hirte/build-base:latest
+      image: quay.io/bluechi/build-base:latest
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/hirte/build-base:latest
+      image: quay.io/bluechi/build-base:latest
 
     steps:
       - name: Checkout sources

--- a/build-scripts/build-containers.sh
+++ b/build-scripts/build-containers.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -xe
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+SCRIPT_DIR=$( realpath "$0"  )
+SCRIPT_DIR=$(dirname "$SCRIPT_DIR")/
+CONTAINER_FILE_DIR=$SCRIPT_DIR"../tests/containers/"
+
+PLATFORMS=linux/amd64,linux/arm64
+
+function build_base(){
+    podman build --no-cache \
+        --platform ${PLATFORMS} \
+        -f ${CONTAINER_FILE_DIR}build-base \
+        --manifest quay.io/bluechi/build-base .
+}
+
+function integration_test_base(){
+    podman build --no-cache \
+        --platform ${PLATFORMS} \
+        -f ${CONTAINER_FILE_DIR}integration-test-base \
+        --manifest quay.io/bluechi/integration-test-base .
+}
+
+echo "Building containers and manifest for $1"
+echo ""
+$1

--- a/tests/README.md
+++ b/tests/README.md
@@ -132,4 +132,17 @@ The `integration-test-base` file describes the builder base image that is publis
 
 Both, `integration-test-local` as well as `integration-test-snapshot`, are based on the builder base image for the integration tests and contain compiled products and configurations for integration testing.
 
-**_NOTE:_** Currently, the images are pushed manually to the quay.io container repository. If any updates are required, please reach out to the [code owners](../.github/CODEOWNERS).
+### Updating container images in registry
+
+Currently, the base images are pushed manually to the [bluechi on quay.io](https://quay.io/organization/bluechi) organization and its repositories. If any updates are required, please reach out to the [code owners](../.github/CODEOWNERS).
+
+**Note to codeowners:**
+
+The base images [build-base](./containers/build-base) and [integration-test-base](./containers/integration-test-base) can be built for multiple platforms (arm64 and amd64) using the [build-containers.sh](../build-scripts/build-containers.sh) script. It'll build images for the given platforms as well as a manifest with the same name, which can then be pushed to the registry. From the root directory of the project run the following commands:
+
+```bash
+# building and publishing build-base image
+bash build-scripts/build-containers.sh build_base
+podman login -u="someuser" -p="topsecret" quay.io
+podman manifest push quay.io/bluechi/build-base:latest docker://quay.io/bluechi/build-base:latest
+```

--- a/tests/containers/build-base
+++ b/tests/containers/build-base
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9
+FROM --platform=$TARGETPLATFORM quay.io/centos/centos:stream9
 
 # CRB is required for meson
 # EPEL is required for lcov, python3-flake8, python3-html2text and codespell

--- a/tests/containers/integration-test-base
+++ b/tests/containers/integration-test-base
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9
+FROM --platform=$TARGETPLATFORM quay.io/centos/centos:stream9
 
 RUN dnf upgrade --refresh -y --nodocs && \
     dnf install --nodocs \

--- a/tests/containers/integration-test-local
+++ b/tests/containers/integration-test-local
@@ -1,4 +1,4 @@
-FROM quay.io/hirte/integration-test-base:latest
+FROM quay.io/bluechi/integration-test-base:latest
 
 RUN mkdir -p /tmp/bluechi-rpms
 COPY ./bluechi-rpms /tmp/bluechi-rpms

--- a/tests/containers/integration-test-snapshot
+++ b/tests/containers/integration-test-snapshot
@@ -1,4 +1,4 @@
-FROM quay.io/hirte/integration-test-base:latest
+FROM quay.io/bluechi/integration-test-base:latest
 
 RUN dnf install -y --repo hirte-snapshot \
     --repofrompath hirte-snapshot,https://download.copr.fedorainfracloud.org/results/mperina/hirte-snapshot/centos-stream-9-$(uname -m)/ \


### PR DESCRIPTION
This PR
- updates the quay organization where the base images for this project are 
from: https://quay.io/organization/hirte
to: https://quay.io/organization/bluechi
- provides the images for multiple platforms (amd64 and arm64, currently)
(addressing #437)

The images have already been built and published. For now, we should keep it simple and update the images as needed manually since they shouldn't change often. 