### PR TITLE
Change the license of python bluechi module examples to CC0-1.0

### DIFF
--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -28,6 +28,7 @@ The following exceptions apply:
   [flatpak](https://github.com/flatpak/flatpak) project and they are licensed under the original license,
   **LGPL-2.1-or-later**.
 * Files under [`doc/api-examples`](../doc/api-examples/) are licensed under **CC0-1.0**
+* Files under [`doc/bluechi-examples`](../doc/bluechi-examples/) are licensed under **CC0-1.0**
 * Files under [`subprojects/`](../subprojects/) are integrated as git submodules and they are licensed under
 their respective original license as follows:
 

--- a/doc/bluechi-examples/CPUWeight
+++ b/doc/bluechi-examples/CPUWeight
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-License-Identifier: CC0-1.0
 #
 # vim:sw=4:ts=4:et
 from bluechi.api import Node

--- a/doc/bluechi-examples/DisableUnit
+++ b/doc/bluechi-examples/DisableUnit
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-License-Identifier: CC0-1.0
 #
 # vim:sw=4:ts=4:et
 from bluechi.ext import Unit

--- a/doc/bluechi-examples/EnableUnit
+++ b/doc/bluechi-examples/EnableUnit
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-License-Identifier: CC0-1.0
 #
 # vim:sw=4:ts=4:et
 from bluechi.ext import Unit

--- a/doc/bluechi-examples/ListActiveServices
+++ b/doc/bluechi-examples/ListActiveServices
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-License-Identifier: CC0-1.0
 #
 # vim:sw=4:ts=4:et
 from bluechi.api import Manager

--- a/doc/bluechi-examples/ListAllNodes
+++ b/doc/bluechi-examples/ListAllNodes
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-License-Identifier: CC0-1.0
 #
 # vim:sw=4:ts=4:et
 from bluechi.api import Manager

--- a/doc/bluechi-examples/ListNodeUnits
+++ b/doc/bluechi-examples/ListNodeUnits
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-License-Identifier: CC0-1.0
 #
 # vim:sw=4:ts=4:et
 from bluechi.api import Node

--- a/doc/bluechi-examples/SetCPUWeight
+++ b/doc/bluechi-examples/SetCPUWeight
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-License-Identifier: CC0-1.0
 #
 # vim:sw=4:ts=4:et
 from dasbus.typing import Variant

--- a/doc/bluechi-examples/StartUnit
+++ b/doc/bluechi-examples/StartUnit
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-License-Identifier: CC0-1.0
 #
 # vim:sw=4:ts=4:et
 from bluechi.ext import Unit

--- a/doc/bluechi-examples/StopUnit
+++ b/doc/bluechi-examples/StopUnit
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-License-Identifier: CC0-1.0
 #
 # vim:sw=4:ts=4:et
 from bluechi.ext import Unit


### PR DESCRIPTION
Fixes: https://github.com/containers/bluechi/issues/477
Signed-off-by: Martin Perina <mperina@redhat.com>
