### PR TITLE
Use macro value for conditional build instead of bcond

### DIFF
--- a/README.developer.md
+++ b/README.developer.md
@@ -275,12 +275,10 @@ The package build process can be adjusted using following environment variables:
 
 - `ARTIFACTS_DIR`
   - A full path to a directory where the RPMs will be saved. The script will create the directory if it does not exist.
-- `BUILD_RPM_OPTS`
-  - Additional options passed to RPM creation, following options are available:
-    - `--without python`
-      - Disable building of python bluechi module RPM package
 - `SKIP_BUILDDEP`
   - To skip installation of build dependencies this option should contain `yes` value.
+- `WITH_PYTHON`
+  - To skip building python bluechi modules this option should contain `0`.
 
 So for example following command will skip build dependencies installation and store create RPM packages into `output`
 subdirectory:

--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -1,5 +1,7 @@
-# python bluechi module is enabled by default, it can be disabled passing `--without python` option to rpmbuild
-%bcond_without python
+# python bluechi module is enabled by default, it can be disabled passing `--define "with_python 0"` option to rpmbuild
+%if 0%{!?with_python:1}
+%global with_python 1
+%endif
 
 
 Name:    bluechi
@@ -175,7 +177,7 @@ This package contains the service controller command line tool.
 %{_bindir}/bluechictl
 %{_mandir}/man1/bluechictl.*
 
-%if %{with python}
+%if %{with_python}
 %package -n python3-bluechi
 Summary: Python bindings for BlueChi
 BuildRequires:  python3-devel
@@ -200,23 +202,23 @@ API description and manually written code to simplify recurring tasks.
 %prep
 %autosetup
 
-%if %{with python}
-cp -r src/bindings/python/* ./
-%endif
-
 %build
 %meson -Dapi_bus=system
 %meson_build
 
-%if %{with python}
+%if %{with_python}
+pushd src/bindings/python
 %py3_build
+popd
 %endif
 
 %install
 %meson_install
 
-%if %{with python}
+%if %{with_python}
+pushd src/bindings/python
 %py3_install
+popd
 %endif
 
 %check

--- a/build-scripts/build-rpm.sh
+++ b/build-scripts/build-rpm.sh
@@ -12,7 +12,7 @@ fi
 rpmbuild \
     --define "_topmdir rpmbuild" \
     --define "_rpmdir rpmbuild" \
-    ${BUILD_RPM_OPTS} \
+    --define "with_python ${WITH_PYTHON:=1}" \
     --rebuild rpmbuild/SRPMS/*src.rpm
 
 # Move RPMs to exported artifacts


### PR DESCRIPTION
Use `%{with_python}` macro to enable/disable building python bluechi
module. By default building of the bluechi python module is enabled,
to disable it pass `--define "with_python 0"` to rpmbuild.

Fixes: https://github.com/containers/bluechi/issues/396
Signed-off-by: Martin Perina <mperina@redhat.com>
