### PR TITLE
build: create a make target for test-with-coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build fmt check-fmt lint lint-c-fix codespell rpm srpm
+.PHONY: build fmt check-fmt lint lint-c-fix codespell rpm srpm check-coverage-tools test-with-coverage
 
 DESTDIR ?=
 BUILDDIR=builddir
@@ -16,7 +16,12 @@ test:
 	meson configure -Db_coverage=true $(BUILDDIR)
 	meson compile -C $(BUILDDIR)
 	meson test -C $(BUILDDIR)
-	ninja coverage-html -C $(BUILDDIR)
+
+check-coverage-tools:
+	@build-scripts/check-required-tools-for-coverage
+
+test-with-coverage: check-coverage-tools test
+	@ninja coverage-html -C $(BUILDDIR)
 
 test-with-valgrind: build
 	meson test --wrap='valgrind --leak-check=full --error-exitcode=1 --track-origins=yes' -C $(BUILDDIR)

--- a/build-scripts/check-required-tools-for-coverage
+++ b/build-scripts/check-required-tools-for-coverage
@@ -1,0 +1,20 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+TOOLS_COVERAGE_REPORT=("lcov" "gcovr" "genhtml")
+FOUND=0
+
+for cmd in "${TOOLS_COVERAGE_REPORT[@]}"; do
+    if command -v "$cmd" &> /dev/null; then
+        FOUND=1
+    fi
+done
+
+if [ "$FOUND" -eq 0 ]; then
+    RED="\033[91m"
+    ENDCOLOR="\033[0m"
+    echo -e "[ ${RED}FAILED${ENDCOLOR} ] None of the following tools were found: ${TOOLS_COVERAGE_REPORT[*]}."
+    echo -e "[ ${RED}FAILED${ENDCOLOR} ] To generate a coverage report, at least one tool is required in the system."
+    exit 1
+fi
+


### PR DESCRIPTION
Currently the make check command will try to generate a coverage report without check if any tool is available (for such task without validation can lead to an error).

This patch split the make check in three parts:

- make test: to the tests without generating the coverage report

- make test-with-coverage: execute the tests and generate the report

- make check-coverage-tools: look for required tools to be used

Fixes: #461

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>