### PR TITLE
Introduce support for packit builds

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,58 @@
+---
+
+upstream_project_url: https://github.com/eclipse-bluechi/bluechi
+issue_repository: https://github.com/eclipse-bluechi/bluechi
+specfile_path: bluechi.spec
+upstream_package_name: bluechi
+downstream_package_name: bluechi
+
+update_release: false
+
+srpm_build_deps:
+  - gcc
+  - gcc-c++
+  - git
+  - jq
+  - meson
+  - systemd-devel
+  - rpm-build
+
+actions:
+  post-upstream-clone:
+    - bash -c './build-scripts/create-spec.sh'
+
+  get-current-version:
+    - bash -c './build-scripts/get-version.sh'
+
+  create-archive:
+    - bash -c './build-scripts/create-archive.sh'
+    - bash -c 'echo bluechi-$PACKIT_PROJECT_VERSION.tar.gz'
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - epel-9-x86_64
+      - fedora-rawhide-aarch64
+      - fedora-rawhide-i386
+      - fedora-rawhide-ppc64le
+      - fedora-rawhide-s390x
+      - fedora-rawhide-x86_64
+
+  - job: copr_build
+    trigger: commit
+    owner: '@centos-automotive-sig'
+    project: bluechi-snapshot
+    targets:
+      - centos-stream-9-aarch64
+      - centos-stream-9-ppc64le
+      - centos-stream-9-x86_64
+      - epel-9-aarch64
+      - epel-9-ppc64le
+      - epel-9-s390x
+      - epel-9-x86_64
+      - fedora-rawhide-aarch64
+      - fedora-rawhide-i386
+      - fedora-rawhide-ppc64le
+      - fedora-rawhide-s390x
+      - fedora-rawhide-x86_64

--- a/.packit.yml
+++ b/.packit.yml
@@ -39,6 +39,16 @@ jobs:
       - fedora-rawhide-s390x
       - fedora-rawhide-x86_64
 
+  - job: tests
+    trigger: pull_request
+    fmf_path: tests
+    env:
+      INSTALL_DEPS: "yes"
+    targets:
+      # Run integration tests on Fedora using CS9 containers, because running integrations tests on CS9 using CS9
+      # containers is very flaky
+      - fedora-rawhide-x86_64
+
   - job: copr_build
     trigger: commit
     owner: '@centos-automotive-sig'

--- a/README.maintainer.md
+++ b/README.maintainer.md
@@ -58,7 +58,7 @@ manually add a **Highlights** section describing the most important changes.
 
 Following files need to be updated to switch the build from release build back to snapshot build:
 
-* `RELEASE` variable needs to be updated in `build-scripts/build-srpm.sh` to contain a date and git hash instead of
+* `RELEASE` variable needs to be updated in `build-scripts/create-spec.sh` to contain a date and git hash instead of
   a number.
 * Project version needs to be increased in `meson.build`
 

--- a/build-scripts/build-srpm.sh
+++ b/build-scripts/build-srpm.sh
@@ -1,38 +1,8 @@
 #!/bin/bash -xe
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-# Parse package version from the project
-meson setup builddir
-VERSION="$(meson introspect --projectinfo builddir | jq -r '.version')"
+source $(dirname "$(readlink -f "$0")")/create-archive.sh
 
-# Mark current directory as safe for git to be able to parse git hash
-if [ "${SKIP_GIT_CONFIG}" != "yes" ]; then
-    git config --global --add safe.directory $(pwd)
-fi
-
-# Package release
-#
-# Use following for official releases
-#RELEASE="1"
-# Use following for nightly builds
-RELEASE="0.$(date +%04Y%02m%02d%02H%02M).git$(git rev-parse --short ${GITHUB_SHA:-HEAD})"
-
-
-# Set version and release
-sed \
-    -e "s|@VERSION@|${VERSION}|g" \
-    -e "s|@RELEASE@|${RELEASE}|g" \
-    < bluechi.spec.in \
-    > bluechi.spec
-
-# Prepare source archive
-[[ -d rpmbuild/SOURCES ]] || mkdir -p rpmbuild/SOURCES
-
-git archive --format=tar --prefix=bluechi-$VERSION/ --add-file=bluechi.spec -o bluechi-$VERSION.tar HEAD
-git submodule foreach --recursive \
-    "git archive --prefix=bluechi-$VERSION/\$path/ --output=\$sha1.tar HEAD && \
-     tar --concatenate --file=$(pwd)/bluechi-$VERSION.tar \$sha1.tar && rm \$sha1.tar"
-gzip bluechi-$VERSION.tar
 mv bluechi-$VERSION.tar.gz rpmbuild/SOURCES/
 
 # Build source package

--- a/build-scripts/create-archive.sh
+++ b/build-scripts/create-archive.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -xe
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+source $(dirname "$(readlink -f "$0")")/create-spec.sh
+
+# Prepare source archive
+[[ -d rpmbuild/SOURCES ]] || mkdir -p rpmbuild/SOURCES
+
+git archive --format=tar --prefix=bluechi-$VERSION/ --add-file=bluechi.spec -o bluechi-$VERSION.tar HEAD
+git submodule foreach --recursive \
+    "git archive --prefix=bluechi-$VERSION/\$path/ --output=\$sha1.tar HEAD && \
+     tar --concatenate --file=$(pwd)/bluechi-$VERSION.tar \$sha1.tar && rm \$sha1.tar"
+gzip bluechi-$VERSION.tar

--- a/build-scripts/create-spec.sh
+++ b/build-scripts/create-spec.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -xe
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+VERSION="$($(dirname "$(readlink -f "$0")")/get-version.sh)"
+
+# Mark current directory as safe for git to be able to parse git hash
+git config --global --add safe.directory $(pwd)
+
+# Package release
+#
+# Use following for official releases
+#RELEASE="1"
+# Use following for nightly builds
+RELEASE="0.$(date +%04Y%02m%02d%02H%02M).git$(git rev-parse --short ${GITHUB_SHA:-HEAD})"
+
+
+# Set version and release
+sed \
+    -e "s|@VERSION@|${VERSION}|g" \
+    -e "s|@RELEASE@|${RELEASE}|g" \
+    < bluechi.spec.in \
+    > bluechi.spec

--- a/build-scripts/get-version.sh
+++ b/build-scripts/get-version.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# Parse package version from the project
+meson setup builddir 1>&2
+VERSION="$(meson introspect --projectinfo builddir | jq -r '.version')"
+
+echo ${VERSION}

--- a/tests/containers/integration-test-snapshot
+++ b/tests/containers/integration-test-snapshot
@@ -1,8 +1,10 @@
 FROM quay.io/bluechi/integration-test-base:latest
 
+ARG copr_repo
+
 RUN dnf install -y dnf-plugin-config-manager
 
-RUN dnf copr enable -y @centos-automotive-sig/bluechi-snapshot
+RUN dnf copr enable -y $copr_repo
 
 RUN dnf install \
         --nogpgcheck \

--- a/tests/plans/tier0.fmf
+++ b/tests/plans/tier0.fmf
@@ -9,14 +9,15 @@ environment:
     BLUECHI_CTRL_SVC_PORT: 8420
     BLUECHI_IMAGE_NAME: bluechi-image
     CONTAINER_USED: integration-test-snapshot
+    INSTALL_DEPS: no
     LOG_LEVEL: INFO
     WITH_COVERAGE: 0
     WITH_VALGRIND: 0
 prepare:
-  - name: Set containers setup
-    how: shell
-    script: |
-        bash ./scripts/tests-setup.sh
+    - name: Prepare containers setup
+      how: shell
+      script: |
+          bash scripts/tests-setup.sh
 execute:
     how: tmt
 report:

--- a/tests/scripts/tests-setup.sh
+++ b/tests/scripts/tests-setup.sh
@@ -3,11 +3,7 @@
 
 set -x
 
-if [ "$CONTAINER_USED" = "integration-test-snapshot" ]; then
-   export ARCH="--arch=$(uname -m)"
-fi
-
-podman build $ARCH -f ./containers/$CONTAINER_USED -t $BLUECHI_IMAGE_NAME .
+podman build -f ./containers/$CONTAINER_USED -t $BLUECHI_IMAGE_NAME .
 
 if [[ $? -ne 0 ]]; then
     exit 1


### PR DESCRIPTION
Introduces ability to build RPMs using packit and run integration tests within testing farm.

Current Github CI to build RPMs and run integrations tests will be remove in follow up PR.

Fixes: https://github.com/containers/bluechi/issues/452