### PR TITLE
Add operations for FreezeUnit and ThawUnit

### DIFF
--- a/data/org.eclipse.bluechi.Node.xml
+++ b/data/org.eclipse.bluechi.Node.xml
@@ -12,6 +12,12 @@
       <arg name="mode" type="s" direction="in" />
       <arg name="job" type="o" direction="out" />
     </method>
+    <method name="FreezeUnit">
+      <arg name="name" type="s" direction="in" />
+    </method>
+    <method name="ThawUnit">
+      <arg name="name" type="s" direction="in" />
+    </method>
     <method name="ReloadUnit">
       <arg name="name" type="s" direction="in" />
       <arg name="mode" type="s" direction="in" />

--- a/data/org.eclipse.bluechi.internal.Agent.xml
+++ b/data/org.eclipse.bluechi.internal.Agent.xml
@@ -12,6 +12,12 @@
       <arg name="mode" type="s" direction="in" />
       <arg name="jobid" type="u" direction="in" />
     </method>
+    <method name="FreezeUnit">
+      <arg name="name" type="s" direction="in" />
+    </method>
+    <method name="ThawUnit">
+      <arg name="name" type="s" direction="in" />
+    </method>
     <method name="ReloadUnit">
       <arg name="name" type="s" direction="in" />
       <arg name="mode" type="s" direction="in" />

--- a/doc/man/bluechictl.1.md
+++ b/doc/man/bluechictl.1.md
@@ -26,7 +26,7 @@ Print current bluechictl version
 
 ## Commands
 
-### **bluechictl** [*start|stop|restart|reload*] [*agent*] [*unit*]
+### **bluechictl** [*start|stop|freeze|thaw|restart|reload*] [*agent*] [*unit*]
 
 Performs one of the listed lifecycle operations on the given systemd unit for the `bluechi-agent`.
 

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -25,6 +25,8 @@ static int node_method_get_unit_property(sd_bus_message *m, void *userdata, UNUS
 static int node_method_set_unit_properties(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
 static int node_method_start_unit(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
 static int node_method_stop_unit(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
+static int node_method_freeze_unit(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
+static int node_method_thaw_unit(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
 static int node_method_restart_unit(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
 static int node_method_reload_unit(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
 static int node_method_passthrough_to_agent(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
@@ -63,6 +65,8 @@ static const sd_bus_vtable node_vtable[] = {
         SD_BUS_METHOD("ListUnits", "", UNIT_INFO_STRUCT_ARRAY_TYPESTRING, node_method_list_units, 0),
         SD_BUS_METHOD("StartUnit", "ss", "o", node_method_start_unit, 0),
         SD_BUS_METHOD("StopUnit", "ss", "o", node_method_stop_unit, 0),
+        SD_BUS_METHOD("FreezeUnit", "s", "", node_method_freeze_unit, 0),
+        SD_BUS_METHOD("ThawUnit", "s", "", node_method_thaw_unit, 0),
         SD_BUS_METHOD("RestartUnit", "ss", "o", node_method_restart_unit, 0),
         SD_BUS_METHOD("ReloadUnit", "ss", "o", node_method_reload_unit, 0),
         SD_BUS_METHOD("GetUnitProperties", "ss", "a{sv}", node_method_get_unit_properties, 0),
@@ -1340,6 +1344,114 @@ static int node_method_set_unit_properties(sd_bus_message *m, void *userdata, UN
         }
 
         r = sd_bus_message_copy(req->message, m, false);
+        if (r < 0) {
+                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Internal error");
+        }
+
+        if (agent_request_start(req) < 0) {
+                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Internal error");
+        }
+
+        return 1;
+}
+
+/*************************************************************************
+ ********** org.eclipse.bluechi.Node.FreezeUnit ***********************
+ ************************************************************************/
+
+static int node_method_freeze_unit_callback(AgentRequest *req, sd_bus_message *m, UNUSED sd_bus_error *ret_error) {
+        sd_bus_message *request_message = req->userdata;
+
+        if (sd_bus_message_is_method_error(m, NULL)) {
+                /* Forward error */
+                return sd_bus_reply_method_error(request_message, sd_bus_message_get_error(m));
+        }
+
+        _cleanup_sd_bus_message_ sd_bus_message *reply = NULL;
+        int r = sd_bus_message_new_method_return(request_message, &reply);
+        if (r < 0) {
+                return sd_bus_reply_method_errorf(request_message, SD_BUS_ERROR_FAILED, "Internal error");
+        }
+
+        return sd_bus_message_send(reply);
+}
+
+static int node_method_freeze_unit(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
+        Node *node = userdata;
+        const char *unit = NULL;
+
+        int r = sd_bus_message_read(m, "s", &unit);
+        if (r < 0) {
+                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_INVALID_ARGS, "Invalid arguments");
+        }
+
+        _cleanup_agent_request_ AgentRequest *req = NULL;
+        node_create_request(
+                        &req,
+                        node,
+                        "FreezeUnit",
+                        node_method_freeze_unit_callback,
+                        sd_bus_message_ref(m),
+                        (free_func_t) sd_bus_message_unref);
+        if (req == NULL) {
+                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Internal error");
+        }
+
+        r = sd_bus_message_append(req->message, "s", unit);
+        if (r < 0) {
+                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Internal error");
+        }
+
+        if (agent_request_start(req) < 0) {
+                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Internal error");
+        }
+
+        return 1;
+}
+
+/*************************************************************************
+ ********** org.eclipse.bluechi.Node.ThawUnit *************************
+ ************************************************************************/
+
+static int node_method_thaw_unit_callback(AgentRequest *req, sd_bus_message *m, UNUSED sd_bus_error *ret_error) {
+        sd_bus_message *request_message = req->userdata;
+
+        if (sd_bus_message_is_method_error(m, NULL)) {
+                /* Forward error */
+                return sd_bus_reply_method_error(request_message, sd_bus_message_get_error(m));
+        }
+
+        _cleanup_sd_bus_message_ sd_bus_message *reply = NULL;
+        int r = sd_bus_message_new_method_return(request_message, &reply);
+        if (r < 0) {
+                return sd_bus_reply_method_errorf(request_message, SD_BUS_ERROR_FAILED, "Internal error");
+        }
+
+        return sd_bus_message_send(reply);
+}
+
+static int node_method_thaw_unit(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
+        Node *node = userdata;
+        const char *unit = NULL;
+
+        int r = sd_bus_message_read(m, "s", &unit);
+        if (r < 0) {
+                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_INVALID_ARGS, "Invalid arguments");
+        }
+
+        _cleanup_agent_request_ AgentRequest *req = NULL;
+        node_create_request(
+                        &req,
+                        node,
+                        "ThawUnit",
+                        node_method_thaw_unit_callback,
+                        sd_bus_message_ref(m),
+                        (free_func_t) sd_bus_message_unref);
+        if (req == NULL) {
+                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Internal error");
+        }
+
+        r = sd_bus_message_append(req->message, "s", unit);
         if (r < 0) {
                 return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Internal error");
         }


### PR DESCRIPTION
We are trying to use bluechi for multi-node container ochestration in our automotive HPC.
In our system, we have additional requirements for suspend and resume of units.
From systemd 246, it supports "systemctl freeze/thaw" and D-Bus APIs for those based on cgroup v2.
So we added a new feature that supports freeze and thaw units on multi-node to bluechi, and we would like to submit this patch.

This PR contains following changes.
- Add FreezeUnit/ThawUnit operations to agent and manager
- Add freeze/thaw commands to client
- Add FreezeUnit/ThawUnit interfaces to DBus-API

Example test results
```
# bluechictl freeze ak7_master_sub v2x-client.service
Unit v2x-client.service freeze operation done


# systemctl status v2x-client.service
● v2x-client.service - systemd service for v2x client container
Loaded: loaded (/etc/containers/systemd/v2x-client.container; generated)
Active: active (running) (frozen) since Wed 2023-08-21 14:26:34 KST; 2min 37s ago
Main PID: 3451 (conmon)
  Tasks: 21 (limit: 7782)
Memory: 25.8M
    CPU: 6.107s
CGroup: /system.slice/v2x-client.service
         ├─libpod-payload-7ea31bcb6eb869693e09d7ca49b57cfbb3cbf51adfdaa0c54cc008c5068119a4
         │ ├─3454 /bin/bash /usr/local/akitos/communications/v2xservice/bin/v2x_client.sh start_sync
         │ └─3496 /usr/lib/v2x_agent/v2x_agent --config=/tmp/v2xservice/conf/v2x_config.json
         └─runtime
           └─3451 /usr/bin/conmon --api-version 1 -c 7ea31bcb6eb869693e09d7ca49b57cfbb3cbf51adfdaa0c54cc008c5068119a4 -u 7ea31bcb6eb869693e09d7ca49b57cfbb3cbf51adfdaa0c54cc008c5068119a4 -r /usr/bin/crun>


# bluechictl thaw ak7_master_sub v2x-client.service
Unit v2x-client.service thaw operation done
``` 