### PR TITLE
added integration test for the automatic reconnect of the bluechi-agent

### DIFF
--- a/tests/tests/tier0/monitor-node-reconnect/main.fmf
+++ b/tests/tests/tier0/monitor-node-reconnect/main.fmf
@@ -1,0 +1,1 @@
+summary: Test if the bluechi-agent automatically reconnects on a successful heartbeat after the controller has been stopped and restarted

--- a/tests/tests/tier0/monitor-node-reconnect/python/is_node_connected.py
+++ b/tests/tests/tier0/monitor-node-reconnect/python/is_node_connected.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import time
+import unittest
+
+from bluechi.api import Node
+
+
+class TestNodeIsConnected(unittest.TestCase):
+
+    def test_node_is_connected(self):
+        n = Node("node-foo")
+        assert n.status == "online"
+
+        # verify that the last seen timestamp is updated with each heartbeat
+        timestamp = n.last_seen_timestamp
+        time.sleep(2)
+        assert n.last_seen_timestamp > timestamp
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/monitor-node-reconnect/test_monitor_node_reconnect.py
+++ b/tests/tests/tier0/monitor-node-reconnect/test_monitor_node_reconnect.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import os
+import time
+import pytest
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+
+
+node_name = "node-foo"
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+    result, output = ctrl.run_python(os.path.join("python", "is_node_connected.py"))
+    if result != 0:
+        raise Exception(output)
+
+    ctrl.exec_run("systemctl stop bluechi")
+    _, output = ctrl.exec_run('systemctl is-active bluechi')
+    assert output == 'inactive'
+
+    ctrl.exec_run("systemctl start bluechi")
+    ctrl.wait_for_bluechi()
+    # since the heartbeat (incl. a try to reconnect) is going to happen
+    # every n milliseconds, lets wait a bit so this test is not becoming flaky
+    time.sleep(1)
+
+    result, output = ctrl.run_python(os.path.join("python", "is_node_connected.py"))
+    if result != 0:
+        raise Exception(output)
+
+
+@pytest.mark.timeout(15)
+def test_monitor_node_disconnect(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiNodeConfig):
+
+    node_foo_config = bluechi_node_default_config.deep_copy()
+    node_foo_config.node_name = node_name
+    node_foo_config.heartbeat_interval = "500"
+
+    bluechi_ctrl_default_config.allowed_node_names = [node_foo_config.node_name]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_node_config(node_foo_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Fixes #419.
Tests that the `bluechi-agent` automatically reconnects to the controller on a successful heartbeat.