### PR TITLE
forward the error when setting default cfg values fails

### DIFF
--- a/src/libbluechi/common/cfg.c
+++ b/src/libbluechi/common/cfg.c
@@ -398,42 +398,41 @@ const char *cfg_dump(struct config *config) {
 }
 
 int cfg_agent_def_conf(struct config *config) {
-        int result = 0;
-
-        result = cfg_set_default_section(config, CFG_SECT_AGENT);
+        int result = cfg_set_default_section(config, CFG_SECT_AGENT);
         if (result != 0) {
                 return result;
         }
 
         _cleanup_free_ char *default_node_name = get_hostname();
-        if (cfg_set_value(config, CFG_NODE_NAME, default_node_name) != 0) {
-                return -1;
+        if ((result = cfg_set_value(config, CFG_NODE_NAME, default_node_name)) != 0) {
+                return result;
         }
 
-        if (cfg_set_value(config, CFG_MANAGER_HOST, BC_DEFAULT_HOST) != 0) {
-                return -1;
+        if ((result = cfg_set_value(config, CFG_MANAGER_HOST, BC_DEFAULT_HOST)) != 0) {
+                return result;
         }
 
-        if (cfg_set_value(config, CFG_HEARTBEAT_INTERVAL, AGENT_HEARTBEAT_INTERVAL_MSEC) != 0) {
-                return -1;
+        if ((result = cfg_set_value(config, CFG_HEARTBEAT_INTERVAL, AGENT_HEARTBEAT_INTERVAL_MSEC)) != 0) {
+                return result;
         }
 
-        if (cfg_set_value(config, CFG_MANAGER_PORT, BC_DEFAULT_PORT) != 0) {
-                return -1;
+        if ((result = cfg_set_value(config, CFG_MANAGER_PORT, BC_DEFAULT_PORT)) != 0) {
+                return result;
         }
 
         const char *LOG_LEVEL_INFO = "INFO";
-        if (cfg_set_value(config, CFG_LOG_LEVEL, LOG_LEVEL_INFO) != 0) {
-                return -1;
+        if ((result = cfg_set_value(config, CFG_LOG_LEVEL, LOG_LEVEL_INFO)) != 0) {
+                return result;
         }
 
-        if (cfg_set_value(config, CFG_LOG_TARGET, BC_LOG_TARGET_STDERR) != 0) {
-                return -1;
+        if ((result = cfg_set_value(config, CFG_LOG_TARGET, BC_LOG_TARGET_STDERR)) != 0) {
+                return result;
         }
 
-        if (cfg_set_value(config, CFG_LOG_IS_QUIET, NULL) != 0) {
-                return -1;
+        if ((result = cfg_set_value(config, CFG_LOG_IS_QUIET, NULL)) != 0) {
+                return result;
         }
+
         return 0;
 }
 
@@ -445,24 +444,25 @@ int cfg_manager_def_conf(struct config *config) {
                 return result;
         }
 
-        if (cfg_set_value(config, CFG_MANAGER_PORT, BC_DEFAULT_PORT) != 0) {
-                return -1;
+        if ((result = cfg_set_value(config, CFG_MANAGER_PORT, BC_DEFAULT_PORT)) != 0) {
+                return result;
         }
 
-        if (cfg_set_value(config, CFG_ALLOWED_NODE_NAMES, "") != 0) {
-                return -1;
+        if ((result = cfg_set_value(config, CFG_ALLOWED_NODE_NAMES, "")) != 0) {
+                return result;
         }
 
-        if (cfg_set_value(config, CFG_LOG_LEVEL, log_level_to_string(LOG_LEVEL_INFO)) != 0) {
-                return -1;
+        if ((result = cfg_set_value(config, CFG_LOG_LEVEL, log_level_to_string(LOG_LEVEL_INFO))) != 0) {
+                return result;
         }
 
-        if (cfg_set_value(config, CFG_LOG_TARGET, BC_LOG_TARGET_STDERR) != 0) {
-                return -1;
+        if ((result = cfg_set_value(config, CFG_LOG_TARGET, BC_LOG_TARGET_STDERR)) != 0) {
+                return result;
         }
 
-        if (cfg_set_value(config, CFG_LOG_IS_QUIET, NULL) != 0) {
-                return -1;
+        if ((result = cfg_set_value(config, CFG_LOG_IS_QUIET, NULL)) != 0) {
+                return result;
         }
+
         return 0;
 }


### PR DESCRIPTION
Instead of just returning -1, return the result of `cfg_set_value` so that a better error message can be provided on the calling side.  