### PR TITLE
Add log unit tests

### DIFF
--- a/src/libbluechi/common/cfg.c
+++ b/src/libbluechi/common/cfg.c
@@ -425,7 +425,7 @@ int cfg_agent_def_conf(struct config *config) {
                 return result;
         }
 
-        if ((result = cfg_set_value(config, CFG_LOG_TARGET, BC_LOG_TARGET_STDERR)) != 0) {
+        if ((result = cfg_set_value(config, CFG_LOG_TARGET, BC_LOG_TARGET_JOURNALD)) != 0) {
                 return result;
         }
 
@@ -456,7 +456,7 @@ int cfg_manager_def_conf(struct config *config) {
                 return result;
         }
 
-        if ((result = cfg_set_value(config, CFG_LOG_TARGET, BC_LOG_TARGET_STDERR)) != 0) {
+        if ((result = cfg_set_value(config, CFG_LOG_TARGET, BC_LOG_TARGET_JOURNALD)) != 0) {
                 return result;
         }
 

--- a/src/libbluechi/log/log.c
+++ b/src/libbluechi/log/log.c
@@ -132,13 +132,26 @@ void bc_log_set_log_fn(LogFn log_fn) {
         BcLogConfig.log_fn = log_fn;
 }
 
+LogFn bc_log_get_log_fn() {
+        return BcLogConfig.log_fn;
+}
+
 void bc_log_set_level(LogLevel level) {
         BcLogConfig.level = level;
+}
+
+LogLevel bc_log_get_level() {
+        return BcLogConfig.level;
 }
 
 void bc_log_set_quiet(bool is_quiet) {
         BcLogConfig.is_quiet = is_quiet;
 }
+
+bool bc_log_get_quiet() {
+        return BcLogConfig.is_quiet;
+}
+
 
 int bc_log_init(struct config *config) {
         // load log settings from configuration

--- a/src/libbluechi/log/log.c
+++ b/src/libbluechi/log/log.c
@@ -154,16 +154,18 @@ bool bc_log_get_quiet() {
 
 
 int bc_log_init(struct config *config) {
-        // load log settings from configuration
-        const char *target = NULL;
-        const char *quiet = NULL;
+
+        // set default logging settings
+        bc_log_set_level(LOG_LEVEL_INFO);
+        bc_log_set_log_fn(bc_log_to_journald_with_location);
+        bc_log_set_quiet(false);
 
         LogLevel level = string_to_log_level(cfg_get_value(config, CFG_LOG_LEVEL));
         if (level != LOG_LEVEL_INVALID) {
                 bc_log_set_level(level);
         }
 
-        target = cfg_get_value(config, CFG_LOG_TARGET);
+        const char *target = cfg_get_value(config, CFG_LOG_TARGET);
         if (target != NULL) {
                 if (streqi(BC_LOG_TARGET_JOURNALD, target)) {
                         bc_log_set_log_fn(bc_log_to_journald_with_location);
@@ -174,7 +176,7 @@ int bc_log_init(struct config *config) {
                 }
         }
 
-        quiet = cfg_get_value(config, CFG_LOG_IS_QUIET);
+        const char *quiet = cfg_get_value(config, CFG_LOG_IS_QUIET);
         if (quiet != NULL) {
                 bc_log_set_quiet(cfg_get_bool_value(config, CFG_LOG_IS_QUIET));
         }

--- a/src/libbluechi/log/log.h
+++ b/src/libbluechi/log/log.h
@@ -56,6 +56,9 @@ int bc_log_to_stderr_with_location(
 void bc_log_set_log_fn(LogFn log_fn);
 void bc_log_set_level(LogLevel level);
 void bc_log_set_quiet(bool is_quiet);
+LogFn bc_log_get_log_fn();
+LogLevel bc_log_get_level();
+bool bc_log_get_quiet();
 
 int bc_log_init(struct config *config);
 

--- a/src/libbluechi/test/log/bc_log_init_test.c
+++ b/src/libbluechi/test/log/bc_log_init_test.c
@@ -1,0 +1,96 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libbluechi/log/log.h"
+
+
+typedef struct log_test_param {
+        char *log_func;
+        char *log_level;
+        char *is_quiet;
+
+        LogFn expected_log_func;
+        LogLevel expected_log_level;
+        bool expected_is_quiet;
+} log_test_param;
+
+
+struct log_test_param test_data[] = {
+        // test valid log targets
+        { "journald", "INFO", "false", bc_log_to_journald_with_location, LOG_LEVEL_INFO, false },
+        { "stderr", "INFO", "false", bc_log_to_stderr_with_location, LOG_LEVEL_INFO, false },
+        { "stderr-full", "INFO", "false", bc_log_to_stderr_full_with_location, LOG_LEVEL_INFO, false },
+        // test valid log levels
+        { "journald", "DEBUG", "false", bc_log_to_journald_with_location, LOG_LEVEL_DEBUG, false },
+        { "journald", "INFO", "false", bc_log_to_journald_with_location, LOG_LEVEL_INFO, false },
+        { "journald", "ERROR", "false", bc_log_to_journald_with_location, LOG_LEVEL_ERROR, false },
+        { "journald", "WARN", "false", bc_log_to_journald_with_location, LOG_LEVEL_WARN, false },
+        // test valid is quiet
+        { "journald", "INFO", "true", bc_log_to_journald_with_location, LOG_LEVEL_INFO, true },
+
+        // test invalid log targets: should result in a default log function
+        { NULL, "INFO", "false", bc_log_to_journald_with_location, LOG_LEVEL_INFO, false },
+        { "", "INFO", "false", bc_log_to_journald_with_location, LOG_LEVEL_INFO, false },
+        { "stderr-ful", "INFO", "false", bc_log_to_journald_with_location, LOG_LEVEL_INFO, false },
+
+        // test invalid log levels: should result in a default log function
+        { "journald", NULL, "false", bc_log_to_journald_with_location, LOG_LEVEL_INFO, false },
+        { "journald", "", "false", bc_log_to_journald_with_location, LOG_LEVEL_INFO, false },
+        { "journald", "info", "false", bc_log_to_journald_with_location, LOG_LEVEL_INFO, false },
+        { "journald", "just wrong", "false", bc_log_to_journald_with_location, LOG_LEVEL_INFO, false },
+
+        // test is quiet: different string values interpreted as true
+        { "journald", "INFO", "true", bc_log_to_journald_with_location, LOG_LEVEL_INFO, true },
+        { "journald", "INFO", "t", bc_log_to_journald_with_location, LOG_LEVEL_INFO, true },
+        { "journald", "INFO", "yes", bc_log_to_journald_with_location, LOG_LEVEL_INFO, true },
+        { "journald", "INFO", "y", bc_log_to_journald_with_location, LOG_LEVEL_INFO, true },
+        { "journald", "INFO", "on", bc_log_to_journald_with_location, LOG_LEVEL_INFO, true },
+        // test is quiet: invalid values should result in false
+        { "journald", "INFO", "f", bc_log_to_journald_with_location, LOG_LEVEL_INFO, false },
+        { "journald", "INFO", "false", bc_log_to_journald_with_location, LOG_LEVEL_INFO, false },
+        { "journald", "INFO", "invalid", bc_log_to_journald_with_location, LOG_LEVEL_INFO, false },
+};
+
+
+bool test_bc_log_init(log_test_param test_case) {
+        struct config *config = NULL;
+        cfg_initialize(&config);
+        cfg_set_value(config, CFG_LOG_LEVEL, test_case.log_level);
+        cfg_set_value(config, CFG_LOG_TARGET, test_case.log_func);
+        cfg_set_value(config, CFG_LOG_IS_QUIET, test_case.is_quiet);
+
+        bc_log_init(config);
+
+        bool result = true;
+        if (bc_log_get_level() != test_case.expected_log_level) {
+                fprintf(stdout, "FAILED: Wrong log level initialized for value '%s'\n", test_case.log_level);
+                result = false;
+        }
+        if (bc_log_get_log_fn() != test_case.expected_log_func) {
+                fprintf(stdout, "FAILED: Wrong log function initialized for value '%s'\n", test_case.log_func);
+                result = false;
+        }
+        if (bc_log_get_quiet() != test_case.expected_is_quiet) {
+                fprintf(stdout, "FAILED: Wrongly initialized log is quiet for value '%s'\n", test_case.is_quiet);
+                result = false;
+        }
+
+        cfg_dispose(config);
+        return result;
+}
+
+int main() {
+        bool result = true;
+
+        for (unsigned int i = 0; i < sizeof(test_data) / sizeof(log_test_param); i++) {
+                result = result && test_bc_log_init(test_data[i]);
+        }
+
+        if (result) {
+                return EXIT_SUCCESS;
+        }
+        return EXIT_FAILURE;
+}

--- a/src/libbluechi/test/log/meson.build
+++ b/src/libbluechi/test/log/meson.build
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+common_src = [
+  'string_to_log_level_test',
+  'bc_log_init_test',
+]
+
+foreach src : common_src
+  exec_test = executable(src, src + '.c',
+    link_with: [
+      bluechi_lib,
+    ],
+    include_directories: include_directories('../../..'),
+  )
+  test(src, exec_test)
+endforeach

--- a/src/libbluechi/test/log/string_to_log_level_test.c
+++ b/src/libbluechi/test/log/string_to_log_level_test.c
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libbluechi/log/log.h"
+
+bool test_string_to_log_level(const char *in, LogLevel expected_log_level) {
+        LogLevel result = string_to_log_level(in);
+        if (result == expected_log_level) {
+                return true;
+        }
+        fprintf(stdout,
+                "FAILED: string_to_log_level('%s') - Expected %s, but got %s\n",
+                in,
+                log_level_to_string(expected_log_level),
+                log_level_to_string(result));
+        return false;
+}
+
+int main() {
+        bool result = true;
+
+        result = result && test_string_to_log_level("DEBUG", LOG_LEVEL_DEBUG);
+        result = result && test_string_to_log_level("INFO", LOG_LEVEL_INFO);
+        result = result && test_string_to_log_level("ERROR", LOG_LEVEL_ERROR);
+        result = result && test_string_to_log_level("WARN", LOG_LEVEL_WARN);
+
+        result = result && test_string_to_log_level(NULL, LOG_LEVEL_INVALID);
+        result = result && test_string_to_log_level("", LOG_LEVEL_INVALID);
+        result = result && test_string_to_log_level("info", LOG_LEVEL_INVALID);
+
+        if (result) {
+                return EXIT_SUCCESS;
+        }
+        return EXIT_FAILURE;
+}

--- a/src/libbluechi/test/meson.build
+++ b/src/libbluechi/test/meson.build
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 subdir('common')
+subdir('log')


### PR DESCRIPTION
Relates: #403 

Adds unit tests for parsing a string to the log level enum as well as a unit test for initializing the logging utility. It also sets the default logging target to journald. 