### PR TITLE
added integration test for wildcard subscription with reconnecting node

### DIFF
--- a/tests/tests/tier0/monitor-wildcard-node-reconnect/main.fmf
+++ b/tests/tests/tier0/monitor-wildcard-node-reconnect/main.fmf
@@ -1,0 +1,1 @@
+summary: Test if the proper virtual signals are emitted when a monitor with wildcard subscription is active and a node disconnects and reconnects again

--- a/tests/tests/tier0/monitor-wildcard-node-reconnect/python/monitor.py
+++ b/tests/tests/tier0/monitor-wildcard-node-reconnect/python/monitor.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import unittest
+
+from dasbus.error import DBusError
+from dasbus.loop import EventLoop
+
+from bluechi.api import Manager, Monitor, Node
+
+
+class TestMonitorWildcardNodeReconnect(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.expected_nodes_unit_new = ["node-foo", "node-bar", "node-baz"]
+        self.expected_nodes_unit_removed = ["node-foo"]
+
+        self.loop = EventLoop()
+        self.mgr = Manager()
+        self.monitor = Monitor(self.mgr.create_monitor())
+
+        def on_unit_new(node: str, unit: str, reason: str) -> None:
+            if unit == "*" and reason == "virtual":
+                self.expected_nodes_unit_new.remove(node)
+
+            if not self.expected_nodes_unit_new:
+                self.loop.quit()
+
+        def on_unit_removed(node: str, unit: str, reason: str) -> None:
+            if unit == "*" and reason == "virtual":
+                self.expected_nodes_unit_removed.remove(node)
+
+        self.monitor.on_unit_new(on_unit_new)
+        self.monitor.on_unit_removed(on_unit_removed)
+
+    def test_monitor_wildcard_node_reconnect(self):
+
+        # start subscription on all nodes and units
+        self.monitor.subscribe('*', '*')
+        # will stop when all virtual unit_new signals for all nodes are received
+        self.loop.run()
+
+        assert len(self.expected_nodes_unit_new) == 0
+        assert len(self.expected_nodes_unit_removed) == 1
+
+        # node-foo is about to be restarted, so the unit_new and unit_removed
+        # callbacks should be called - push node-foo back into the list
+        node_name_foo = self.expected_nodes_unit_removed[0]
+        self.expected_nodes_unit_new.append(node_name_foo)
+        node = Node(node_name_foo)
+        # for an explanation for the try-except please see monitor-node-disconnect/monitor.py
+        try:
+            node.restart_unit('bluechi-agent.service', 'replace')
+        except DBusError:
+            pass
+
+        # will stop when the virtual unit_new signal for node-foo is received
+        self.loop.run()
+
+        assert len(self.expected_nodes_unit_new) == 0
+        assert len(self.expected_nodes_unit_removed) == 0
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/monitor-wildcard-node-reconnect/test_monitor_wildcard_node_reconnect.py
+++ b/tests/tests/tier0/monitor-wildcard-node-reconnect/test_monitor_wildcard_node_reconnect.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import os
+import pytest
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+
+
+node_name_foo = "node-foo"
+node_name_bar = "node-bar"
+node_name_baz = "node-baz"
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+    result, output = ctrl.run_python(os.path.join("python", "monitor.py"))
+    if result != 0:
+        raise Exception(output)
+
+
+@pytest.mark.timeout(10)
+def test_monitor_wildcard_node_reconnect(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiNodeConfig):
+
+    config_node_foo = bluechi_node_default_config.deep_copy()
+    config_node_bar = bluechi_node_default_config.deep_copy()
+    config_node_baz = bluechi_node_default_config.deep_copy()
+
+    config_node_foo.node_name = node_name_foo
+    config_node_bar.node_name = node_name_bar
+    config_node_baz.node_name = node_name_baz
+
+    bluechi_ctrl_default_config.allowed_node_names = [
+        node_name_foo,
+        node_name_bar,
+        node_name_baz,
+    ]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_node_config(config_node_foo)
+    bluechi_test.add_bluechi_node_config(config_node_bar)
+    bluechi_test.add_bluechi_node_config(config_node_baz)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Fixes: https://github.com/containers/bluechi/issues/420 
Relates to: https://github.com/containers/bluechi/issues/414

This PR adds an integration test that verifies that the proper virtual unit_new and unit_removed signals are emitted to a monitor when a node disconnects and reconnects again.