### PR TITLE
add integration test for automatic unsubscribe

### DIFF
--- a/tests/bluechi_test/util.py
+++ b/tests/bluechi_test/util.py
@@ -40,4 +40,4 @@ def assemble_bluechi_proxy_service_name(node_name: str, unit_name: str) -> str:
 def get_random_name(name_length: int) -> str:
     # choose from all lowercase letter
     letters = string.ascii_lowercase
-    return ''.join(random.choice(letters) for i in range(name_length))
+    return ''.join(random.choice(letters) for _ in range(name_length))

--- a/tests/tests/tier0/monitor-unsubscribe/main.fmf
+++ b/tests/tests/tier0/monitor-unsubscribe/main.fmf
@@ -1,0 +1,1 @@
+summary: Test if a monitor can be created and closed successfully

--- a/tests/tests/tier0/monitor-unsubscribe/python/unsubscribe-automatically.py
+++ b/tests/tests/tier0/monitor-unsubscribe/python/unsubscribe-automatically.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from dasbus.error import DBusError
+from dasbus.loop import EventLoop
+
+from bluechi.api import Manager, Monitor, Node
+
+
+node_name_foo = "node-foo"
+service_simple = "simple.service"
+
+
+class TestUnsubscribe(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.loop = EventLoop()
+        self.mgr = Manager()
+        monitor_path = self.mgr.create_monitor()
+        self.monitor = Monitor(monitor_path=monitor_path)
+
+        self.times_removed_called = 0
+
+        def on_unit_removed(node: str, unit: str, reason: str) -> None:
+            self.times_removed_called += 1
+            self.loop.quit()
+
+        self.monitor.on_unit_removed(on_unit_removed)
+
+    def test_unsubscribe(self):
+
+        node_foo = Node(node_name_foo)
+
+        # create subscription, start unit and run event loop till removed signal is received
+        sub_id = self.monitor.subscribe(node_name_foo, service_simple)
+        assert node_foo.start_unit(service_simple, "replace") != ""
+        self.loop.run()
+
+        # subscription is already automatically removed when the event loop quits (no consumer)
+        # therefore, expect a DBussError to be raised
+        with self.assertRaises(DBusError):
+            self.monitor.unsubscribe(sub_id)
+
+        assert self.times_removed_called == 1
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/monitor-unsubscribe/systemd/simple.service
+++ b/tests/tests/tier0/monitor-unsubscribe/systemd/simple.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Just being true once
+
+[Service]
+Type=simple
+ExecStart=/bin/true

--- a/tests/tests/tier0/monitor-unsubscribe/test_monitor_unsubscribe.py
+++ b/tests/tests/tier0/monitor-unsubscribe/test_monitor_unsubscribe.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import pytest
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+
+
+node_name_foo = "node-foo"
+service_simple = "simple.service"
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+
+    nodes[node_name_foo].copy_systemd_service(
+        service_simple, "systemd", os.path.join("/", "etc", "systemd", "system"))
+    assert nodes[node_name_foo].wait_for_unit_state_to_be(service_simple, "inactive")
+
+    result, output = ctrl.run_python(os.path.join("python", "unsubscribe-automatically.py"))
+    if result != 0:
+        raise Exception(output)
+
+
+@pytest.mark.timeout(10)
+def test_monitor_unsubscribe(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiNodeConfig):
+
+    bluechi_node_default_config.node_name = node_name_foo
+    bluechi_ctrl_default_config.allowed_node_names = [bluechi_node_default_config.node_name]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_node_config(bluechi_node_default_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Fixes: https://github.com/containers/bluechi/issues/413 

Adds an integration test to verify that unsubscribe is automatically called as soon as the consumer stops the connection (the event loop, in this case).