### PR TITLE
added integration test for monitoring specific unit

### DIFF
--- a/tests/tests/tier0/monitor-specific-node-and-unit/main.fmf
+++ b/tests/tests/tier0/monitor-specific-node-and-unit/main.fmf
@@ -1,0 +1,1 @@
+summary: Test if all signals for a subscription on a specific node and unit are emitted

--- a/tests/tests/tier0/monitor-specific-node-and-unit/python/monitor.py
+++ b/tests/tests/tier0/monitor-specific-node-and-unit/python/monitor.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from dasbus.loop import EventLoop
+
+from bluechi.api import Manager, Monitor, Node, Structure
+
+node_name_foo = "node-foo"
+
+service_simple = "simple.service"
+requesting_simple = "requesting.service"
+
+
+class TestMonitorSpecificNodeAndUnit(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.loop = EventLoop()
+        self.mgr = Manager()
+
+        self.times_new_called = 0
+        self.times_state_changed_called = 0
+        self.times_prop_changed_called = 0
+        self.times_removed_called = 0
+
+    def test_monitor_specific_node_and_unit(self):
+
+        monitor_path = self.mgr.create_monitor()
+        monitor = Monitor(monitor_path=monitor_path)
+
+        def on_unit_new(node: str, unit: str, reason: str) -> None:
+            self.times_new_called += 1
+
+        def on_unit_state_changed(node: str, unit: str, active_state: str, sub_state: str, reason: str) -> None:
+            self.times_state_changed_called += 1
+
+        def on_unit_property_changed(node: str, unit: str, interface: str, props: Structure) -> None:
+            self.times_prop_changed_called += 1
+
+        def on_unit_removed(node: str, unit: str, reason: str) -> None:
+            self.times_removed_called += 1
+            self.loop.quit()
+
+        monitor.on_unit_new(on_unit_new)
+        monitor.on_unit_state_changed(on_unit_state_changed)
+        monitor.on_unit_properties_changed(on_unit_property_changed)
+        monitor.on_unit_removed(on_unit_removed)
+
+        monitor.subscribe(node_name_foo, service_simple)
+
+        node_foo = Node(node_name_foo)
+        assert node_foo.start_unit(service_simple, "replace") != ""
+        self.loop.run()
+
+        assert self.times_new_called >= 1
+        assert self.times_state_changed_called >= 1
+        assert self.times_prop_changed_called >= 1
+        assert self.times_removed_called >= 1
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/monitor-specific-node-and-unit/systemd/simple.service
+++ b/tests/tests/tier0/monitor-specific-node-and-unit/systemd/simple.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Just being true once
+
+[Service]
+Type=simple
+ExecStart=/bin/true

--- a/tests/tests/tier0/monitor-specific-node-and-unit/test_monitor_specific_node_and_unit.py
+++ b/tests/tests/tier0/monitor-specific-node-and-unit/test_monitor_specific_node_and_unit.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import pytest
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+
+node_name_foo = "node-foo"
+service_simple = "simple.service"
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+    nodes[node_name_foo].copy_systemd_service(
+        service_simple, "systemd", os.path.join("/", "etc", "systemd", "system"))
+    assert nodes[node_name_foo].wait_for_unit_state_to_be(service_simple, "inactive")
+
+    result, output = ctrl.run_python(os.path.join("python", "monitor.py"))
+    if result != 0:
+        raise Exception(output)
+
+
+@pytest.mark.timeout(10)
+def test_monitor_specific_node_and_unit(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiNodeConfig):
+
+    bluechi_node_default_config.node_name = node_name_foo
+    bluechi_ctrl_default_config.allowed_node_names = [bluechi_node_default_config.node_name]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_node_config(bluechi_node_default_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Relates https://github.com/containers/bluechi/issues/412
Relates https://github.com/containers/bluechi/issues/418

Adds a simple integration test to verify that all kinds of signals when a unit is started (and stopped) are emitted and a monitor to this specific node and unit receives them.