### PR TITLE
Add option to enable code coverage support when building RPMs 

### DIFF
--- a/README.developer.md
+++ b/README.developer.md
@@ -334,6 +334,8 @@ The package build process can be adjusted using following environment variables:
   - To skip installation of build dependencies this option should contain `yes` value.
 - `WITH_PYTHON`
   - To skip building python bluechi modules this option should contain `0`.
+- `WITH_COVERAGE`
+  - To start collecting coverage this option should contain `1`.
 
 So for example following command will skip build dependencies installation and store create RPM packages into `output`
 subdirectory:

--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -3,6 +3,10 @@
 %global with_python 1
 %endif
 
+# coverage collection is disabled by default , it can be enabled passing `--define "with_coverage 1"` option to rpmbuild
+%if 0%{?with_coverage} 
+%global coverage_flags -Dwith_coverage=true
+%endif
 
 Name:    bluechi
 Version: @VERSION@
@@ -203,7 +207,7 @@ API description and manually written code to simplify recurring tasks.
 %autosetup
 
 %build
-%meson -Dapi_bus=system
+%meson -Dapi_bus=system %{?coverage_flags}
 %meson_build
 
 %if %{with_python}

--- a/build-scripts/build-rpm.sh
+++ b/build-scripts/build-rpm.sh
@@ -12,6 +12,7 @@ fi
 rpmbuild \
     --define "_topmdir rpmbuild" \
     --define "_rpmdir rpmbuild" \
+    --define "with_coverage ${WITH_COVERAGE:=0}"\
     --define "with_python ${WITH_PYTHON:=1}" \
     --rebuild rpmbuild/SRPMS/*src.rpm
 


### PR DESCRIPTION
To enable building RPMs with code coverage support `-Dwith_coverage=1`
parameter can be passed to rpmbuild. Code coverage support is turned
off by default when building RPMs.

Related: https://github.com/containers/bluechi/issues/397
Signed-off-by: Artiom Divak <adivak@redhat.com>