### PR TITLE
aarch64 run on c9s aarch fixes

### DIFF
--- a/tests/scripts/tests-setup.sh
+++ b/tests/scripts/tests-setup.sh
@@ -3,7 +3,12 @@
 
 set -x
 
-podman build -f ./containers/$CONTAINER_USED -t $BLUECHI_IMAGE_NAME .
+if [ "$CONTAINER_USED" = "integration-test-snapshot" ]; then
+   export ARCH="--arch=$(uname -m)"
+fi
+
+podman build $ARCH -f ./containers/$CONTAINER_USED -t $BLUECHI_IMAGE_NAME .
+
 if [[ $? -ne 0 ]]; then
     exit 1
 fi


### PR DESCRIPTION
Adding podman build arg for local arch build

Container files build on aarch64 was not installing bluchi aarch64 bits 