### PR TITLE
Add integration test monitor multiple units

### DIFF
--- a/data/org.eclipse.bluechi.Monitor.xml
+++ b/data/org.eclipse.bluechi.Monitor.xml
@@ -12,7 +12,8 @@
       <arg name="id" type="u" direction="in" />
     </method>
     <method name="SubscribeList">
-      <arg name="targets" type="sas" direction="in" />
+      <arg name="node" type="s" direction="in" />
+      <arg name="units" type="as" direction="in" />
       <arg name="id" type="u" direction="out" />
     </method>
 

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -92,9 +92,10 @@ class Monitor(ApiBase):
             id,
         )
 
-    def subscribe_list(self, targets: Tuple[str, List[str]]) -> UInt32:
+    def subscribe_list(self, node: str, units: List[str]) -> UInt32:
         return self.get_proxy().SubscribeList(
-            targets,
+            node,
+            units,
         )
 
     def on_unit_properties_changed(

--- a/tests/tests/tier0/monitor-multiple-nodes-and-units/main.fmf
+++ b/tests/tests/tier0/monitor-multiple-nodes-and-units/main.fmf
@@ -1,0 +1,1 @@
+summary: Test if a montor with a subscription to a list of units on a single node receives the relevant signals, but none from a different node with the same unit

--- a/tests/tests/tier0/monitor-multiple-nodes-and-units/python/monitor.py
+++ b/tests/tests/tier0/monitor-multiple-nodes-and-units/python/monitor.py
@@ -7,11 +7,13 @@ from dasbus.loop import EventLoop
 from bluechi.api import Manager, Monitor, Node, Structure
 
 node_name_foo = "node-foo"
+node_name_bar = "node-bar"
 
 service_simple = "simple.service"
+service_also_simple = "also-simple.service"
 
 
-class TestMonitorSpecificNodeAndUnit(unittest.TestCase):
+class TestMonitorMultipleNodesAndUnits(unittest.TestCase):
 
     def setUp(self) -> None:
         self.loop = EventLoop()
@@ -21,40 +23,54 @@ class TestMonitorSpecificNodeAndUnit(unittest.TestCase):
         self.times_state_changed_called = 0
         self.times_prop_changed_called = 0
         self.times_removed_called = 0
+        self.received_signal_from_node_bar = False
 
-    def test_monitor_specific_node_and_unit(self):
+    def test_monitor_multiple_nodes_and_units(self):
 
         monitor_path = self.mgr.create_monitor()
         monitor = Monitor(monitor_path=monitor_path)
 
         def on_unit_new(node: str, unit: str, reason: str) -> None:
             self.times_new_called += 1
+            self.received_signal_from_node_bar = (node == node_name_bar)
 
         def on_unit_state_changed(node: str, unit: str, active_state: str, sub_state: str, reason: str) -> None:
             self.times_state_changed_called += 1
+            self.received_signal_from_node_bar = (node == node_name_bar)
 
         def on_unit_property_changed(node: str, unit: str, interface: str, props: Structure) -> None:
             self.times_prop_changed_called += 1
+            self.received_signal_from_node_bar = (node == node_name_bar)
 
         def on_unit_removed(node: str, unit: str, reason: str) -> None:
             self.times_removed_called += 1
-            self.loop.quit()
+            self.received_signal_from_node_bar = (node == node_name_bar)
+
+            # received two unit_removed signals (simple.service and also-simple.service)
+            if self.times_removed_called == 2:
+                self.loop.quit()
 
         monitor.on_unit_new(on_unit_new)
         monitor.on_unit_state_changed(on_unit_state_changed)
         monitor.on_unit_properties_changed(on_unit_property_changed)
         monitor.on_unit_removed(on_unit_removed)
 
-        monitor.subscribe(node_name_foo, service_simple)
+        monitor.subscribe_list(node_name_foo, [service_simple, service_also_simple])
+
+        node_bar = Node(node_name_bar)
+        assert node_bar.start_unit(service_simple, "replace") != ""
 
         node_foo = Node(node_name_foo)
         assert node_foo.start_unit(service_simple, "replace") != ""
+        assert node_foo.start_unit(service_also_simple, "replace") != ""
+
         self.loop.run()
 
-        assert self.times_new_called >= 1
-        assert self.times_state_changed_called >= 1
-        assert self.times_prop_changed_called >= 1
-        assert self.times_removed_called >= 1
+        assert not self.received_signal_from_node_bar
+        assert self.times_new_called >= 2
+        assert self.times_state_changed_called >= 2
+        assert self.times_prop_changed_called >= 2
+        assert self.times_removed_called >= 2
 
 
 if __name__ == "__main__":

--- a/tests/tests/tier0/monitor-multiple-nodes-and-units/systemd/also-simple.service
+++ b/tests/tests/tier0/monitor-multiple-nodes-and-units/systemd/also-simple.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Just being true once
+
+[Service]
+Type=simple
+ExecStart=/bin/true

--- a/tests/tests/tier0/monitor-multiple-nodes-and-units/systemd/simple.service
+++ b/tests/tests/tier0/monitor-multiple-nodes-and-units/systemd/simple.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Just being true once
+
+[Service]
+Type=simple
+ExecStart=/bin/true

--- a/tests/tests/tier0/monitor-multiple-nodes-and-units/test_monitor_multiple_nodes_and_units.py
+++ b/tests/tests/tier0/monitor-multiple-nodes-and-units/test_monitor_multiple_nodes_and_units.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import pytest
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+
+node_name_foo = "node-foo"
+node_name_bar = "node-bar"
+service_simple = "simple.service"
+service_also_simple = "also-simple.service"
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+    nodes[node_name_foo].copy_systemd_service(
+        service_simple, "systemd", os.path.join("/", "etc", "systemd", "system"))
+    assert nodes[node_name_foo].wait_for_unit_state_to_be(service_simple, "inactive")
+
+    nodes[node_name_foo].copy_systemd_service(
+        service_also_simple, "systemd", os.path.join("/", "etc", "systemd", "system"))
+    assert nodes[node_name_foo].wait_for_unit_state_to_be(service_also_simple, "inactive")
+
+    nodes[node_name_bar].copy_systemd_service(
+        service_simple, "systemd", os.path.join("/", "etc", "systemd", "system"))
+    assert nodes[node_name_bar].wait_for_unit_state_to_be(service_simple, "inactive")
+
+    result, output = ctrl.run_python(os.path.join("python", "monitor.py"))
+    if result != 0:
+        raise Exception(output)
+
+
+@pytest.mark.timeout(10)
+def test_monitor_specific_node_and_unit(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiNodeConfig):
+
+    node_foo_config = bluechi_node_default_config.deep_copy()
+    node_bar_config = bluechi_node_default_config.deep_copy()
+
+    node_foo_config.node_name = node_name_foo
+    node_bar_config.node_name = node_name_bar
+    bluechi_ctrl_default_config.allowed_node_names = [node_foo_config.node_name, node_bar_config.node_name]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_node_config(node_foo_config)
+    bluechi_test.add_bluechi_node_config(node_bar_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Fixes #412 

Adds an integration test that verifies that subscribing for a list of units on a single node works as expected and starting a unit with the same name on a different node does not interfere.