### PR TITLE
Fix due to aboot machine  tests

### DIFF
--- a/tests/bluechi_test/container.py
+++ b/tests/bluechi_test/container.py
@@ -60,7 +60,8 @@ class BluechiContainer():
 
     def cleanup(self):
         if self.container.status == 'running':
-            self.container.kill()
+            kw_params = {'timeout': 0}
+            self.container.stop(**kw_params)
         self.container.remove()
 
     def exec_run(self, command: (Union[str, list[str]]), raw_output: bool = False) -> \

--- a/tests/bluechi_test/container.py
+++ b/tests/bluechi_test/container.py
@@ -60,7 +60,7 @@ class BluechiContainer():
 
     def cleanup(self):
         if self.container.status == 'running':
-            self.container.stop()
+            self.container.kill()
         self.container.remove()
 
     def exec_run(self, command: (Union[str, list[str]]), raw_output: bool = False) -> \

--- a/tests/tests/tier0/bluechi-agent-logisquiet/test_agent_logisquiet.py
+++ b/tests/tests/tier0/bluechi-agent-logisquiet/test_agent_logisquiet.py
@@ -42,7 +42,7 @@ def start_with_invalid_port(ctrl: BluechiControllerContainer, nodes: Dict[str, B
                 "NOT failed during the start of the service")
 
 
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(25)
 def test_agent_invalid_port_configuration(
         bluechi_test: BluechiTest,
         bluechi_node_default_config: BluechiNodeConfig, bluechi_ctrl_default_config: BluechiControllerConfig):

--- a/tests/tests/tier0/bluechi-agent-loglevel/test_agent_loglevel.py
+++ b/tests/tests/tier0/bluechi-agent-loglevel/test_agent_loglevel.py
@@ -42,7 +42,7 @@ def start_with_invalid_port(ctrl: BluechiControllerContainer, nodes: Dict[str, B
                 "NOT failed during the start of the service")
 
 
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(25)
 def test_agent_invalid_port_configuration(
         bluechi_test: BluechiTest,
         bluechi_node_default_config: BluechiNodeConfig, bluechi_ctrl_default_config: BluechiControllerConfig):

--- a/tests/tests/tier0/bluechi-agent-resolve-fqdn/test_bluechi_agent_resolve_fqdn.py
+++ b/tests/tests/tier0/bluechi-agent-resolve-fqdn/test_bluechi_agent_resolve_fqdn.py
@@ -39,7 +39,7 @@ def verify_resolving_fqdn(ctrl: BluechiControllerContainer, _: Dict[str, Bluechi
     assert result == 0
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(10)
 def test_agent_resolve_fqdn(bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
     bluechi_ctrl_default_config.allowed_node_names = [local_node_name]
 

--- a/tests/tests/tier0/bluechi-agent-started-and-connected/test_agent_started_and_connected.py
+++ b/tests/tests/tier0/bluechi-agent-started-and-connected/test_agent_started_and_connected.py
@@ -22,7 +22,7 @@ def foo_startup_verify(ctrl: BluechiControllerContainer, nodes: Dict[str, Bluech
     # TODO: Add code to test that agent on node foo is successfully connected to bluechi controller
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(10)
 def test_agent_foo_startup(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/bluechi-enable-service/test_bluechi_enable_service.py
+++ b/tests/tests/tier0/bluechi-enable-service/test_bluechi_enable_service.py
@@ -32,7 +32,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(f"Unit {simple_service} expected to be enabled, but got: {output}")
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(15)
 def test_proxy_service_start(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/bluechi-freeze-and-thaw-service/test_bluechi_freeze_and_thaw_service.py
+++ b/tests/tests/tier0/bluechi-freeze-and-thaw-service/test_bluechi_freeze_and_thaw_service.py
@@ -45,7 +45,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_service_thaw(foo)
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(20)
 def test_service_freeze_and_thaw(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/bluechi-long-multiline-config-setting/test_long_multiline_config_setting.py
+++ b/tests/tests/tier0/bluechi-long-multiline-config-setting/test_long_multiline_config_setting.py
@@ -15,7 +15,7 @@ def startup_verify(ctrl: BluechiControllerContainer, _: Dict[str, BluechiNodeCon
     assert output == 'active'
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(10)
 def test_long_multiline_config_setting(bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
     config = bluechi_ctrl_default_config.deep_copy()
     for i in range(150):

--- a/tests/tests/tier0/bluechi-service-startup/test_service_startup.py
+++ b/tests/tests/tier0/bluechi-service-startup/test_service_startup.py
@@ -15,7 +15,7 @@ def startup_verify(ctrl: BluechiControllerContainer, _: Dict[str, BluechiNodeCon
     assert output == 'active'
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(10)
 def test_controller_startup(bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
     bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
 

--- a/tests/tests/tier0/monitor-wildcard-node-reconnect/test_monitor_wildcard_node_reconnect.py
+++ b/tests/tests/tier0/monitor-wildcard-node-reconnect/test_monitor_wildcard_node_reconnect.py
@@ -20,7 +20,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(output)
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(25)
 def test_monitor_wildcard_node_reconnect(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/monitor-wildcard-unit-changes/test_monitor_wildcard_unit_changes.py
+++ b/tests/tests/tier0/monitor-wildcard-unit-changes/test_monitor_wildcard_unit_changes.py
@@ -31,7 +31,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(output)
 
 
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(20)
 def test_monitor_wildcard_unit_changes(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-fails-on-execstart/test_proxy_service_fails_on_execstart.py
+++ b/tests/tests/tier0/proxy-service-fails-on-execstart/test_proxy_service_fails_on_execstart.py
@@ -42,7 +42,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
 
 
 @pytest.mark.skip(reason="Currently flaky. Tracked in https://github.com/containers/bluechi/issues/320. ")
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(25)
 def test_proxy_service_fails_on_execstart(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-fails-on-non-existent-service/test_proxy_service_fails_on_non_existent_service.py
+++ b/tests/tests/tier0/proxy-service-fails-on-non-existent-service/test_proxy_service_fails_on_non_existent_service.py
@@ -35,7 +35,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_start_failed(foo)
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(20)
 def test_proxy_service_fails_on_non_existent_service(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-fails-on-typo-in-file/test_proxy_service_fails_on_typo_in_file.py
+++ b/tests/tests/tier0/proxy-service-fails-on-typo-in-file/test_proxy_service_fails_on_typo_in_file.py
@@ -41,7 +41,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_start_failed(foo, bar)
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(20)
 def test_proxy_service_fails_on_typo_in_file(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-multiple-services-multiple-nodes/test_proxy_service_multiple_services_multiple_nodes.py
+++ b/tests/tests/tier0/proxy-service-multiple-services-multiple-nodes/test_proxy_service_multiple_services_multiple_nodes.py
@@ -58,7 +58,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     assert foo1.wait_for_unit_state_to_be(bluechi_proxy_service, "inactive")
 
 
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(25)
 def test_proxy_service_multiple_services_multiple_nodes(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-multiple-services-one-node/test_proxy_service_multiple_services_one_node.py
+++ b/tests/tests/tier0/proxy-service-multiple-services-one-node/test_proxy_service_multiple_services_one_node.py
@@ -57,7 +57,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     assert foo.wait_for_unit_state_to_be(bluechi_proxy_service, "inactive")
 
 
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(20)
 def test_proxy_service_multiple_services_one_node(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-start/test_proxy_service_start.py
+++ b/tests/tests/tier0/proxy-service-start/test_proxy_service_start.py
@@ -41,7 +41,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_start(foo, bar)
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(20)
 def test_proxy_service_start(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-stop-bluechi-dep/test_proxy_service_stop_bluechi_dep.py
+++ b/tests/tests/tier0/proxy-service-stop-bluechi-dep/test_proxy_service_stop_bluechi_dep.py
@@ -53,7 +53,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_stop(foo, bar)
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(20)
 def test_proxy_service_stop_bluechi_dep(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-stop-requesting-with-unneeded/test_proxy_service_stop_requesting_with_unneeded.py
+++ b/tests/tests/tier0/proxy-service-stop-requesting-with-unneeded/test_proxy_service_stop_requesting_with_unneeded.py
@@ -53,7 +53,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_stop(foo, bar)
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(20)
 def test_proxy_service_stop_requesting(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-stop-requesting/test_proxy_service_stop_requesting.py
+++ b/tests/tests/tier0/proxy-service-stop-requesting/test_proxy_service_stop_requesting.py
@@ -53,7 +53,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_stop(foo, bar)
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(20)
 def test_proxy_service_stop_requesting(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-stop-target/test_proxy_service_stop_target.py
+++ b/tests/tests/tier0/proxy-service-stop-target/test_proxy_service_stop_target.py
@@ -53,7 +53,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_stop(foo, bar)
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(20)
 def test_proxy_service_stop_target(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,


### PR DESCRIPTION
Changing to containers.kill instead of containers.stop python api It reduce failures during cleanup.
containers killed instead of stop+wait option exist in API.

Updated test timeouts to complete success in slow OS.