### PR TITLE
added integration test for bluechi with invalid values of the port

### DIFF
--- a/tests/bluechi_test/container.py
+++ b/tests/bluechi_test/container.py
@@ -16,7 +16,6 @@ class BluechiContainer():
 
     def __init__(self, container: Container, config: BluechiConfig) -> None:
         self.container: Container = container
-        self.config: BluechiConfig = config
 
         # add confd file to container
         self.create_file(config.get_confd_dir(), config.file_name, config.serialize())
@@ -120,6 +119,8 @@ class BluechiNodeContainer(BluechiContainer):
 
     def __init__(self, container: Container, config: BluechiNodeConfig) -> None:
         super().__init__(container, config)
+
+        self.config = config
         self.node_name = config.node_name
 
     def wait_for_bluechi_agent(self):
@@ -136,6 +137,8 @@ class BluechiControllerContainer(BluechiContainer):
 
     def __init__(self, container: Container, config: BluechiControllerConfig) -> None:
         super().__init__(container, config)
+
+        self.config = config
 
     def wait_for_bluechi(self):
         should_wait = True

--- a/tests/tests/tier0/bluechi-agent-invalid-port-configuration/test_agent_invalid_port_configuration.py
+++ b/tests/tests/tier0/bluechi-agent-invalid-port-configuration/test_agent_invalid_port_configuration.py
@@ -12,15 +12,11 @@ NODE_BAR = "node-bar"
 
 
 def start_with_invalid_port(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
-    _, output = nodes[NODE_FOO].exec_run('systemctl status bluechi-agent')
-    output_systemd = str(output)
-    if "fail" in output_systemd.lower():
-        raise Exception(f"{NODE_FOO} bluechi-agent should NOT failed during the tart of the service")
+    node_foo_with_valid_port = nodes[NODE_FOO]
+    assert node_foo_with_valid_port.wait_for_unit_state_to_be("bluechi-agent", "active")
 
-    _, output = nodes[NODE_BAR].exec_run('systemctl status bluechi-agent')
-    output_systemd = str(output)
-    if "fail" not in output_systemd.lower():
-        raise Exception(f"{NODE_BAR} bluechi-agent should FAILED during the start but DO NOT FAILED")
+    node_bar_with_invalid_port = nodes[NODE_BAR]
+    assert node_bar_with_invalid_port.wait_for_unit_state_to_be("bluechi-agent", "failed")
 
 
 @pytest.mark.timeout(15)

--- a/tests/tests/tier0/bluechi-invalid-port/main.fmf
+++ b/tests/tests/tier0/bluechi-invalid-port/main.fmf
@@ -1,0 +1,1 @@
+summary: Test if bluechi can handle invalid values for the port in the configuration properly

--- a/tests/tests/tier0/bluechi-invalid-port/test_agent_invalid_port.py
+++ b/tests/tests/tier0/bluechi-invalid-port/test_agent_invalid_port.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import pytest
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig
+
+
+def exec(ctrl: BluechiControllerContainer, _: Dict[str, BluechiNodeContainer]):
+
+    assert ctrl.wait_for_unit_state_to_be("bluechi", "active")
+
+    original_cfg = ctrl.config.deep_copy()
+
+    # port contains an 'O' instead of a '0'
+    new_cfg = original_cfg.deep_copy()
+    new_cfg.port = "542O"
+    ctrl.create_file(new_cfg.get_confd_dir(), new_cfg.file_name, new_cfg.serialize())
+    ctrl.exec_run("systemctl restart bluechi")
+    assert ctrl.wait_for_unit_state_to_be("bluechi", "failed")
+
+    # port out of range
+    new_cfg = original_cfg.deep_copy()
+    new_cfg.port = "65538"
+    ctrl.create_file(new_cfg.get_confd_dir(), new_cfg.file_name, new_cfg.serialize())
+    # to ensure that a restart is possible, reset the lock due to too many failed attempts
+    ctrl.exec_run("systemctl reset-failed bluechi")
+    ctrl.exec_run("systemctl restart bluechi")
+    assert ctrl.wait_for_unit_state_to_be("bluechi", "failed")
+
+    # valid config again
+    new_cfg = original_cfg.deep_copy()
+    ctrl.create_file(new_cfg.get_confd_dir(), new_cfg.file_name, new_cfg.serialize())
+    # to ensure that a restart is possible, reset the lock due to too many failed attempts
+    ctrl.exec_run("systemctl reset-failed bluechi")
+    ctrl.exec_run("systemctl restart bluechi")
+    assert ctrl.wait_for_unit_state_to_be("bluechi", "active")
+
+
+@pytest.mark.timeout(40)
+def test_agent_invalid_port(bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.run(exec)


### PR DESCRIPTION
Fixes https://github.com/containers/bluechi/issues/416 (last test for this issue)
Adds an integration test that verifies BlueChi handles invalid port values properly.

