### PR TITLE
added integration test for running bluechi-agent alongside bluechi

### DIFF
--- a/tests/tests/tier0/bluechi-and-agent-on-same-machine/main.fmf
+++ b/tests/tests/tier0/bluechi-and-agent-on-same-machine/main.fmf
@@ -1,0 +1,1 @@
+summary: Test if a bluechi-agent can run alongside bluechi controller on the same machine

--- a/tests/tests/tier0/bluechi-and-agent-on-same-machine/python/is_node_connected.py
+++ b/tests/tests/tier0/bluechi-and-agent-on-same-machine/python/is_node_connected.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from bluechi.api import Node
+
+
+class TestNodeIsConnected(unittest.TestCase):
+
+    def test_node_is_connected(self):
+        n = Node("node-foo")
+        assert n.status == "online"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechi-and-agent-on-same-machine/test_bluechi_and_agent_on_same_machine.py
+++ b/tests/tests/tier0/bluechi-and-agent-on-same-machine/test_bluechi_and_agent_on_same_machine.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import pytest
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+
+node_foo_name = "node-foo"
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+
+    assert ctrl.wait_for_unit_state_to_be("bluechi", "active")
+
+    node_foo_config = BluechiNodeConfig(
+        file_name="agent.conf",
+        node_name=node_foo_name,
+        manager_host="localhost",
+        manager_port=ctrl.config.port,
+    )
+    ctrl.create_file(node_foo_config.get_confd_dir(), node_foo_config.file_name, node_foo_config.serialize())
+    result, _ = ctrl.exec_run("systemctl start bluechi-agent")
+    assert result == 0
+    assert ctrl.wait_for_unit_state_to_be("bluechi-agent", "active")
+
+    # bluechi-agent is running, check if it is connected
+    result, output = ctrl.run_python(os.path.join("python", "is_node_connected.py"))
+    if result != 0:
+        raise Exception(output)
+
+
+@pytest.mark.timeout(40)
+def test_bluechi_and_agent_on_same_machine(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig):
+
+    bluechi_ctrl_default_config.allowed_node_names = [node_foo_name]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    # don't add node_foo_config to bluechi_test to prevent it being started
+    # as separate container
+    bluechi_test.run(exec)


### PR DESCRIPTION
Fixes https://github.com/containers/bluechi/issues/525 

Adds an integration test that verifies that bluechi-agent can run alongside bluechi controller on the same machine.