### PR TITLE
added integration test for trying to connect with an anonymous node

### DIFF
--- a/tests/tests/tier0/bluechi-anonymous-node/main.fmf
+++ b/tests/tests/tier0/bluechi-anonymous-node/main.fmf
@@ -1,0 +1,1 @@
+summary: Test if a monitor can be created and closed successfully

--- a/tests/tests/tier0/bluechi-anonymous-node/python/node_foo_not_connected.py
+++ b/tests/tests/tier0/bluechi-anonymous-node/python/node_foo_not_connected.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from bluechi.api import Manager
+
+
+class TestNodeFooNotConnected(unittest.TestCase):
+
+    def test_node_foo_not_connected(self):
+        mgr = Manager()
+
+        nodes = mgr.list_nodes()
+        assert len(nodes) == 1
+        assert nodes[0][0] == "everyone-but-foo"
+        assert nodes[0][2] == "offline"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechi-anonymous-node/test_anonymous_node.py
+++ b/tests/tests/tier0/bluechi-anonymous-node/test_anonymous_node.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import pytest
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+
+node_foo_name = "node-foo"
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+
+    node_foo = nodes[node_foo_name]
+
+    assert ctrl.wait_for_unit_state_to_be("bluechi", "active")
+    assert node_foo.wait_for_unit_state_to_be("bluechi-agent", "active")
+
+    # bluechi and bluechi-agent are running, check that agent is not connected
+    result, output = ctrl.run_python(os.path.join("python", "node_foo_not_connected.py"))
+    if result != 0:
+        raise Exception(output)
+
+
+@pytest.mark.timeout(40)
+def test_anonymous_node(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiNodeConfig):
+
+    node_foo_config = bluechi_node_default_config.deep_copy()
+    node_foo_config.node_name = node_foo_name
+
+    bluechi_ctrl_default_config.allowed_node_names = ["everyone-but-foo"]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_node_config(node_foo_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Fixes https://github.com/containers/bluechi/issues/524 

Adds an integration test that verifies a connection request of an anonymous node is not accepted by bluechi controller. An anonymous node is a bluechi-agent with a name not in the allowed node name list of the controller.