### PR TITLE
Re-add README.developer.md into markdown lint checked files

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,6 +1,15 @@
+# Documentation for available configuration options can be found at
+# https://github.com/DavidAnson/markdownlint/tree/main/doc
 config:
+  MD010:
+    # Ignore tab characters in code blocks
+    code_blocks: false
   MD013:
+    # Ignore line length in code blocks
+    code_blocks: false
+    # Maximum line length
     line_length: 120
+    # Ignore line length for tables
     tables: false
 
 globs:
@@ -9,4 +18,3 @@ globs:
 ignores:
   - "doc/man/*.md"
   - "subprojects/*/*.md"
-  - "README.developer.md"

--- a/README.developer.md
+++ b/README.developer.md
@@ -61,6 +61,7 @@ of installation for your setup.
 **busctl** is a systemd tool to introspect and monitor the D-Bus bus. See below some examples using busctl with bluechi service.
 
 **Instrospect org.eclipse.bluechi**:
+
 ```bash
 # busctl introspect \
          org.eclipse.bluechi \
@@ -94,6 +95,7 @@ org.freedesktop.DBus.Properties     interface -         -              -
 ```
 
 **Example calling ListNodes**:
+
 ```bash
 export SERVICE="org.eclipse.bluechi"
 export OBJECT="/org/eclipse/bluechi"


### PR DESCRIPTION
1. Change default markdown lint configuration
  - Ignore maximum line length inside code blocks
  - Ignore tab characters inside code blocks
2. Add missing empty lines around code blocks
3. Re-add README.developer.md into checked files

Signed-off-by: Martin Perina <mperina@redhat.com>
