### PR TITLE
Fix examples license to CC0-1.0

### DIFF
--- a/doc/api-examples/go/list_nodes.go
+++ b/doc/api-examples/go/list_nodes.go
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: CC0-1.0
 
 package main
 

--- a/doc/api-examples/ruby/list_nodes.rb
+++ b/doc/api-examples/ruby/list_nodes.rb
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: CC0-1.0
+
 require "dbus"
 
 sysbus = DBus.system_bus

--- a/doc/api-examples/rust/list_nodes.rs
+++ b/doc/api-examples/rust/list_nodes.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 mod bluechi;
 
 use std::time::Duration;


### PR DESCRIPTION
- Change Golang examples license to CC0-1.0
- Change Ruby examples license to CC0-1.0
- Change Rust examples license to CC0-1.0
