### PR TITLE
Gather journal from test executor host

### DIFF
--- a/tests/bluechi_test/command.py
+++ b/tests/bluechi_test/command.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import subprocess
+
+from typing import Union
+
+
+class ExecutionError(Exception):
+    """ Raised when executed command has non-zero result code.The class contains the command result code and its stdout
+    and strerr content.
+    """
+    def __init__(
+            self,
+            code: int,
+            out: str,
+            err: str) -> None:
+        self.code = code
+        self.out = out
+        self.err = err
+
+    def __str__(self):
+        return f"Command failed with rc={self.code}. Stdout:\n{self.out}\nStderr:\n{self.err}\n"
+
+
+class Command():
+    """ Execute a shell command and capture its output
+
+    Arguments:
+      args: A string, or a sequence of program arguments
+      shell: If true, then command is executed within shell
+    """
+
+    def __init__(
+            self,
+            args: Union[str, list[str]],
+            shell: bool = True) -> None:
+        self.args = args
+        self.shell = shell
+
+    def run(self, **kwargs):
+        """Run the command and return its stdout.
+        """
+        process = subprocess.Popen(
+                self.args,
+                shell=self.shell,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                **kwargs)
+        out, err = process.communicate()
+
+        out = out.decode("utf-8")
+        err = err.decode("utf-8")
+
+        if process.returncode != 0:
+            raise ExecutionError(process.returncode, out, err)
+
+        return out


### PR DESCRIPTION
Gather journal logs from test executor host to be able to debug testing
container infrastructure issues.

Signed-off-by: Martin Perina <mperina@redhat.com>
