### PR TITLE
Extended the D-Bus API specification

### DIFF
--- a/data/org.eclipse.bluechi.Agent.xml
+++ b/data/org.eclipse.bluechi.Agent.xml
@@ -1,12 +1,39 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
 <node>
+
+  <!-- 
+    org.eclipse.bluechi.Agent:
+    @short_description: Public interface of BlueChi on the managed node providing methods and signals for the respective node.
+
+    This interface is used to create proxy services resolving dependencies on services of other managed nodes.
+  -->
   <interface name="org.eclipse.bluechi.Agent">
+
+    <!-- 
+      CreateProxy:
+      @local_service_name: The service name which requests the external dependency
+      @node: The requested node to provide the service
+      @unit: The external unit requested from the local service
+
+      BlueChi internal usage only.
+      CreateProxy() creates a new proxy service. It is part in the chain of resolving dependencies on services running on other managed nodes.
+    -->
     <method name="CreateProxy">
       <arg name="local_service_name" type="s" direction="in" />
       <arg name="node" type="s" direction="in" />
       <arg name="unit" type="s" direction="in" />
     </method>
+
+    <!-- 
+      RemoveProxy:
+      @local_service_name: The service name which requests the external dependency
+      @node: The requested node to provide the service
+      @unit: The external unit requested from the local service
+
+      BlueChi internal usage only.
+      RemoveProxy() removes a new proxy service. It is part in the chain of resolving dependencies on services running on other managed nodes.
+    -->
     <method name="RemoveProxy">
       <arg name="local_service_name" type="s" direction="in" />
       <arg name="node" type="s" direction="in" />

--- a/data/org.eclipse.bluechi.Job.xml
+++ b/data/org.eclipse.bluechi.Job.xml
@@ -1,13 +1,67 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
 <node>
+
+  <!-- 
+    org.eclipse.bluechi.Job:
+    @short_description: Public interface of BlueChi on the managing node for all job objects.
+
+    This interface is used to either cancel a job, get its properties and monitor its state.
+  -->
   <interface name="org.eclipse.bluechi.Job">
+
+    <!-- 
+      Cancel:
+      
+      Cancels the job. 
+      It cancels the corresponding systemd job if it was already started. Otherwise it cancels the BlueChi job. 
+    -->
     <method name="Cancel" />
 
-    <property name="Id" type="u" access="read" />
-    <property name="Node" type="s" access="read" />
-    <property name="Unit" type="s" access="read" />
-    <property name="JobType" type="s" access="read" />
-    <property name="State" type="s" access="read" />
+    <!-- 
+      Id:
+
+      An integer giving the id of the job. 
+    -->
+    <property name="Id" type="u" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+
+    <!-- 
+      Node:
+
+      The name of the node the job is on. 
+    -->
+    <property name="Node" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+
+    <!-- 
+      Unit:
+
+      The name of the unit the job works on. 
+    -->
+    <property name="Unit" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+
+    <!-- 
+      JobType:
+
+      Type of the job, either Start or Stop. 
+    -->
+    <property name="JobType" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+
+    <!-- 
+      State:
+
+      The current state of the job, one of: waiting (queued jobs) or running. 
+      On any change, a signal is emitted on the org.freedesktop.DBus.Properties interface. 
+    -->
+    <property name="State" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true" />
+    </property>
   </interface>
 </node>

--- a/data/org.eclipse.bluechi.Manager.xml
+++ b/data/org.eclipse.bluechi.Manager.xml
@@ -1,30 +1,120 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
 <node>
+
+  <!-- 
+    org.eclipse.bluechi.Manager:
+    @short_description: Public interface of BlueChi on the managing node providing methods and signals for all nodes.
+
+    This interface can be used to get information about all nodes and their units, create monitors and listen for job signals.
+  -->
   <interface name="org.eclipse.bluechi.Manager">
+
+    <!-- 
+      ListUnits:
+      @units: A list of all units on each node:
+        - The node name
+        - The primary unit name as string
+        - The human readable description string
+        - The load state (i.e. whether the unit file has been loaded successfully)
+        - The active state (i.e. whether the unit is currently started or not)
+        - The sub state (a more fine-grained version of the active state that is specific to the unit type, which the active state is not)
+        - A unit that is being followed in its state by this unit, if there is any, otherwise the empty string.
+        - The unit object path
+        - If there is a job queued for the job unit the numeric job id, 0 otherwise
+        - The job type as string
+        - The job object path
+
+      List all loaded systemd units on all nodes which are online.
+    -->
     <method name="ListUnits">
-      <arg name="units" type="a(ssssssouso)" direction="out" />
+      <arg name="units" type="a(sssssssouso)" direction="out" />
     </method>
+
+    <!-- 
+      ListNodes:
+      @nodes: A list of all nodes:
+        - The node name
+        - The object path of the node
+        - the current state of that node, either online or offline
+      
+      List all nodes managed by BlueChi regardless if they are offline or online.
+    -->
     <method name="ListNodes">
-      <arg name="node" type="a(sos)" direction="out" />
+      <arg name="nodes" type="a(sos)" direction="out" />
     </method>
+
+    <!-- 
+      GetNode:
+      @name: Name of the node
+      @path: The path of the requested node
+
+      Get the object path of the named node.
+    -->
     <method name="GetNode">
       <arg name="name" type="s" direction="in" />
       <arg name="path" type="o" direction="out" />
     </method>
+
+    <!-- 
+      CreateMonitor:
+      @monitor: The path of the created monitor.
+
+      Create a new monitor on which subscriptions can be added. It will automatically be closed as soon as the connection is closed.
+    -->
     <method name="CreateMonitor">
       <arg name="monitor" type="o" direction="out" />
     </method>
+
+    <!-- 
+      EnableMetrics:
+
+      Enable collecting performance metrics.
+    -->
     <method name="EnableMetrics" />
+
+    <!-- 
+      DisableMetrics:
+
+      Disable collecting performance metrics.
+    -->
     <method name="DisableMetrics" />
+
+    <!-- 
+      SetLogLevel:
+      @loglevel: The new loglevel to use. 
+
+      Change the loglevel of the manager.
+    -->
     <method name="SetLogLevel">
       <arg name="loglevel" type="s" direction="in" />
     </method>
-    
+
+
+    <!-- 
+      JobNew:
+      @id: The id of the new job
+      @job: The path of the job
+
+      Emitted each time a new BlueChi job is queued.
+    -->
     <signal name="JobNew">
       <arg name="id" type="u" />
       <arg name="job" type="o" />
     </signal>
+
+    <!-- 
+      JobRemoved:
+      @id: The id of the new job
+      @job: The path of the job
+      @node: The name of the node the job has been completed on
+      @unit: The name of the unit the job has been completed on
+      @result: The result of the job
+
+      Emitted each time a new job is dequeued or the underlying systemd job finished. result is one of: done, failed, cancelled, timeout, dependency,
+    skipped. This is either the result from systemd on the node, or cancelled if the job was cancelled in BlueChi before any systemd job was started
+    for it.
+    -->
     <signal name="JobRemoved">
       <arg name="id" type="u" />
       <arg name="job" type="o" />
@@ -32,6 +122,7 @@
       <arg name="unit" type="s" />
       <arg name="result" type="s" />
     </signal>
+
     <signal name="NodeConnectionStateChanged">
       <arg name="node" type="s" />
       <arg name="connection_state" type="s" />

--- a/data/org.eclipse.bluechi.Metrics.xml
+++ b/data/org.eclipse.bluechi.Metrics.xml
@@ -1,7 +1,25 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
 <node>
+
+  <!-- 
+    org.eclipse.bluechi.Metrics:
+    @short_description: Public interface of BlueChi on the managing node providing signals for performance metrics.
+
+    This interface is only available if the metrics have been enabled before via the Manager interface.
+  -->
   <interface name="org.eclipse.bluechi.Metrics">
+
+    <!-- 
+      StartUnitJobMetrics:
+      @node_name: The node name this metrics has been collected for
+      @job_id: The id of the job linked to the collected metrics
+      @unit: The unit name this metrics has been collected for
+      @job_measured_time_micros: The measured time it took starting the unit on the node in microseconds
+      @unit_start_prop_time_micros: The systemd time it took starting the unit on the node in microseconds
+
+      Emitted when a start operation processed by BlueChi finishes and the collection of metrics has been enabled previously.
+    -->
     <signal name="StartUnitJobMetrics">
       <arg name="node_name" type="s" />
       <arg name="job_id" type="s" />
@@ -9,6 +27,17 @@
       <arg name="job_measured_time_micros" type="t" />
       <arg name="unit_start_prop_time_micros" type="t" />
     </signal>
+
+    <!-- 
+      AgentJobMetrics:
+      @node_name: The node name this metrics has been collected for
+      @unit: The unit name this metrics has been collected for
+      @method: The lifecycle operation
+      @systemd_job_time_micros: The systemd time it took starting the unit on the node in microseconds
+
+      Emitted for all unit lifecycle operations (e.g. Start, Stop, Reload, etc.) processed by BlueChi when these finish and the collection of metrics has
+    been enabled previously.
+    -->
     <signal name="AgentJobMetrics">
       <arg name="node_name" type="s" />
       <arg name="unit" type="s" />

--- a/data/org.eclipse.bluechi.Monitor.xml
+++ b/data/org.eclipse.bluechi.Monitor.xml
@@ -1,28 +1,90 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
 <node>
+
+  <!-- 
+    org.eclipse.bluechi.Monitor:
+    @short_description: Public interface of BlueChi on the managing node providing monitoring functionality.
+
+    This interface is only available if a monitor has been created before via the Manager interface.
+    It provides methods to subscribe to changes in systemd units on managed nodes as well as signals for those changes.
+  -->
   <interface name="org.eclipse.bluechi.Monitor">
+
+    <!-- 
+      Close:
+
+      Close the monitor.
+    -->
     <method name="Close" />
+
+    <!-- 
+      Subscribe:
+      @node: The name of the node to subscribe to
+      @unit: The name of the unit to subscribe to
+      @id: The id of the created subscription. 
+
+      Subscribe to changes of a unit on a node. Both fields support a wildcard '*'. A wildcard in the node name will create the subscription for all nodes.
+    If the unit name is a wildcard, then the subscription matches changes for all units on the node.
+    -->
     <method name="Subscribe">
       <arg name="node" type="s" direction="in" />
       <arg name="unit" type="s" direction="in" />
       <arg name="id" type="u" direction="out" />
     </method>
+
+    <!-- 
+      Unsubscribe:
+      @id: The id of the subscription to cancel
+
+      Cancel the subscription by ID.
+    -->
     <method name="Unsubscribe">
       <arg name="id" type="u" direction="in" />
     </method>
+
+    <!-- 
+      SubscribeList:
+      @node: The name of the node to subscribe to
+      @units: A list of unit names to subscribe to
+      @id: The id of the created subscription
+
+      Subscribe to changes of a list of units on a node. The node field supports a wildcard '*'. A wildcard in the node name will create the subscription
+    for all nodes.
+    -->
     <method name="SubscribeList">
       <arg name="node" type="s" direction="in" />
       <arg name="units" type="as" direction="in" />
       <arg name="id" type="u" direction="out" />
     </method>
 
+
+    <!-- 
+      UnitPropertiesChanged:
+      @node: The node name this signal originated from
+      @unit: The unit for which the properties changed
+      @interface: The originating interface
+      @props: The changed properties as key-value pair with the name of the property as key
+
+      Whenever the properties change for any of the units that are currently subscribed to, this signal is emitted. 
+    -->
     <signal name="UnitPropertiesChanged">
       <arg name="node" type="s" />
       <arg name="unit" type="s" />
       <arg name="interface" type="s" />
       <arg name="props" type="a{sv}" />
     </signal>
+
+    <!-- 
+      UnitStateChanged:
+      @node: The node name this signal originated from
+      @unit: The unit for which the properties changed
+      @active_state: The active state of the unit
+      @sub_state: The sub state of the unit
+      @reason: The reason for the state change, the value is either real or virtual
+
+      Emitted when the active state (and substate) of a monitored unit changes.
+    -->
     <signal name="UnitStateChanged">
       <arg name="node" type="s" />
       <arg name="unit" type="s" />
@@ -30,11 +92,31 @@
       <arg name="sub_state" type="s" />
       <arg name="reason" type="s" />
     </signal>
+
+    <!-- 
+      UnitNew:
+      @node: The node name this signal originated from
+      @unit: The unit for which the properties changed
+      @reason: The reason for the state change, the value is either real or virtual
+
+      Emitted when a new unit is loaded by systemd, for example when a service is started (reason=real), or if BlueChi learns of an already loaded unit
+    (reason=virtual).
+    -->
     <signal name="UnitNew">
       <arg name="node" type="s" />
       <arg name="unit" type="s" />
       <arg name="reason" type="s" />
     </signal>
+
+    <!-- 
+      UnitRemoved:
+      @node: The node name this signal originated from
+      @unit: The unit for which the properties changed
+      @reason: The reason for the state change, the value is either real or virtual
+
+      Emitted when a unit is unloaded by systemd (reason=real), or when the agent disconnects and we previously reported the unit as loaded
+    (reason=virtual).
+    -->
     <signal name="UnitRemoved">
       <arg name="node" type="s" />
       <arg name="unit" type="s" />

--- a/data/org.eclipse.bluechi.Node.xml
+++ b/data/org.eclipse.bluechi.Node.xml
@@ -1,49 +1,154 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
 <node>
+
+  <!-- 
+    org.eclipse.bluechi.Node:
+    @short_description: Public interface of BlueChi on the managing node providing methods, signals and  for a specific node.
+
+    This interface can be used to get information about a specific node and its units as well as control them, e.g. by starting or stopping them.
+  -->
   <interface name="org.eclipse.bluechi.Node">
+
+    <!-- 
+      StartUnit:
+      @name: The name of the unit to start 
+      @mode: The mode used to start the unit
+      @job: The path for the job associated with the start operation
+
+      Queues a unit activate job for the named unit on this node. The queue is per-unit name, which means there is only ever one active job per unit. Mode
+    can be one of replace or fail. If there is an outstanding queued (but not running) job, that is replaced if mode is replace, or the job
+    fails if mode is fail.
+
+      The job returned is an object path for an object implementing org.eclipse.bluechi.Job, and which be monitored for the progress of the job, or used
+    to cancel the job. To track the result of the job, follow the JobRemoved signal on the Manager.
+    -->
     <method name="StartUnit">
       <arg name="name" type="s" direction="in" />
       <arg name="mode" type="s" direction="in" />
       <arg name="job" type="o" direction="out" />
     </method>
+
+    <!-- 
+      StopUnit:
+      @name: The name of the unit to stop 
+      @mode: The mode used to stop the unit
+      @job: The path for the job associated with the stop operation
+
+      StopUnit() is similar to StartUnit() but stops the specified unit rather than starting it.
+    -->
     <method name="StopUnit">
       <arg name="name" type="s" direction="in" />
       <arg name="mode" type="s" direction="in" />
       <arg name="job" type="o" direction="out" />
     </method>
+
+    <!-- 
+      FreezeUnit:
+      @name: The name of the unit to freeze
+
+      Freezing the unit will cause all processes contained within the cgroup corresponding to the unit to be suspended. Being suspended means that unit's
+    processes won't be scheduled to run on CPU until thawed.
+    -->
     <method name="FreezeUnit">
       <arg name="name" type="s" direction="in" />
     </method>
+
+    <!-- 
+      ThawUnit:
+      @name: The name of the unit to thaw
+
+      This is the inverse operation to the freeze command and resumes the execution of processes in the unit's cgroup.
+    -->
     <method name="ThawUnit">
       <arg name="name" type="s" direction="in" />
     </method>
+
+    <!-- 
+      ReloadUnit:
+      @name: The name of the unit to reload 
+      @mode: The mode used to reload the unit
+      @job: The path for the job associated with the reload operation
+
+      ReloadUnit() is similar to StartUnit() but can be used to reload a unit instead. See equivalent systemd methods for details.
+    -->
     <method name="ReloadUnit">
       <arg name="name" type="s" direction="in" />
       <arg name="mode" type="s" direction="in" />
       <arg name="job" type="o" direction="out" />
     </method>
+
+    <!-- 
+      RestartUnit:
+      @name: The name of the unit to restart 
+      @mode: The mode used to restart the unit
+      @job: The path for the job associated with the restart operation
+
+      RestartUnit() is similar to StartUnit() but can be used to restart a unit instead. See equivalent systemd methods for details.
+    -->
     <method name="RestartUnit">
       <arg name="name" type="s" direction="in" />
       <arg name="mode" type="s" direction="in" />
       <arg name="job" type="o" direction="out" />
     </method>
-    <method name="GetUnitProperties">
+
+    <!-- 
+      GetUnit:
+      @name: The name of unit
+      @interface: The interface name
+      @props: The  as key-value pair with the name of the property as key
+
+      Returns the current  for a named unit on the node. The returned  are the same as you would get in the systemd  apis.
+    -->
+    <method name="GetUnit">
       <arg name="name" type="s" direction="in" />
       <arg name="interface" type="s" direction="in" />
       <arg name="props" type="a{sv}" direction="out" />
     </method>
+
+    <!-- 
+      GetUnitProperty:
+      @name: The name of unit
+      @interface: The interface name
+      @property: The property name
+      @value: The value of the property
+
+      Get one named property, otherwise similar to GetUnit.
+    -->
     <method name="GetUnitProperty">
       <arg name="name" type="s" direction="in" />
       <arg name="interface" type="s" direction="in" />
       <arg name="property" type="s" direction="in" />
       <arg name="value" type="v" direction="out" />
     </method>
-    <method name="SetUnitProperties">
+
+    <!-- 
+      SetUnit:
+      @name: The name of the unit
+      @runtime: Specify if the changes should persist after reboot or not
+      @keyvalues: A list of the new values as key-value pair with the key being the name of the property
+
+      Set named . If runtime is true the property changes do not persist across reboots.
+    -->
+    <method name="SetUnit">
       <arg name="name" type="s" direction="in" />
       <arg name="runtime" type="b" direction="in" />
       <arg name="keyvalues" type="a(sv)" direction="in" />
     </method>
+
+    <!-- 
+      EnableUnitFiles:
+      @files: A list of units to enable
+      @runtime: Specify if the changes should persist after reboot or not
+      @force: Specify if replacing the symlinks pointing to other units should be enforced
+      @carries_install_info: True if the units contained enablement information
+      @changes: The changes made
+        - type of change (one of: symlink, unlink)
+        - file name of the symlink
+        - destination of the symlink
+      
+      EnableUnitFiles() may be used to enable one or more units in the system (by creating symlinks to them in /etc/ or /run/).
+    -->
     <method name="EnableUnitFiles">
       <arg name="files" type="as" direction="in" />
       <arg name="runtime" type="b" direction="in" />
@@ -51,21 +156,88 @@
       <arg name="carries_install_info" type="b" direction="out" />
       <arg name="changes" type="a(sss)" direction="out" />
     </method>
+
+    <!-- 
+      DisableUnitFiles:
+      @files: A list of units to enable
+      @runtime: Specify if the changes should persist after reboot or not
+      @changes: The changes made
+        - type of change (one of: symlink, unlink)
+        - file name of the symlink
+        - destination of the symlink
+
+      DisableUnitFiles() is similar to EnableUnitFiles() but disables the specified units by removing all symlinks to them in /etc/ and /run/
+    -->
     <method name="DisableUnitFiles">
       <arg name="files" type="as" direction="in" />
       <arg name="runtime" type="b" direction="in" />
       <arg name="changes" type="a(sss)" direction="out" />
     </method>
+
+    <!-- 
+      ListUnits:
+      @units: A list of all units on the node:
+        - The primary unit name as string
+        - The human readable description string
+        - The load state (i.e. whether the unit file has been loaded successfully)
+        - The active state (i.e. whether the unit is currently started or not)
+        - The sub state (a more fine-grained version of the active state that is specific to the unit type, which the active state is not)
+        - A unit that is being followed in its state by this unit, if there is any, otherwise the empty string.
+        - The unit object path
+        - If there is a job queued for the job unit the numeric job id, 0 otherwise
+        - The job type as string
+        - The job object path
+
+      List all loaded systemd units. 
+    -->
     <method name="ListUnits">
       <arg name="units" type="a(ssssssouso)" direction="out" />
     </method>
+
+    <!-- 
+      Reload:
+      
+      Reload() may be invoked to reload all unit files. 
+    -->
     <method name="Reload" />
+
+    <!-- 
+      SetLogLevel:
+      @loglevel: The new loglevel to use. 
+
+      Change the loglevel of the manager.
+    -->
     <method name="SetLogLevel">
       <arg name="level" type="s" direction="in" />
     </method>
 
-    <property name="Name" type="s" access="read" />
-    <property name="Status" type="s" access="read" />
-    <property name="LastSeenTimestamp" type="t" access="read" />
+
+    <!-- 
+      Name:
+
+      The name of the node.
+    -->
+    <property name="Name" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+    </property>
+
+    <!-- 
+      Status:
+
+      The connection status of the node with the BlueChi controller.
+      On any change, a signal is emitted on the org.freedesktop.DBus.Properties interface. 
+    -->
+    <property name="Status" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true" />
+    </property>
+
+    <!-- 
+      LastSeenTimestamp:
+
+      A timestamp indicating when the last connection test (e.g. via heartbeat) was successful.
+    -->
+    <property name="LastSeenTimestamp" type="t" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false" />
+    </property>
   </interface>
 </node>

--- a/doc/docs/api/description.md
+++ b/doc/docs/api/description.md
@@ -274,7 +274,7 @@ interface.
 
 ### interface org.eclipse.bluechi.Metrics
 
-This interface is provides signals for collecting metrics. It is created by calling `EnableMetrics` on the `org.eclipse.bluechi.Manager` interface and removed by calling `DisableMetrics`.
+This interface provides signals for collecting metrics. It is created by calling `EnableMetrics` on the `org.eclipse.bluechi.Manager` interface and removed by calling `DisableMetrics`.
 
 #### Signals
 


### PR DESCRIPTION
Fixes https://github.com/containers/bluechi/issues/549

The BlueChi D-Bus API can be enriched by documentation comments in order to provide more information about its interfaces, methods, etc.. This can also be used for code generators to provide inline comments, improving the developer experience.
In addition, the org.freedesktop.DBus.Property.EmitsChangedSignal annotation has been added to properties. This indicates to clients if they can expect change signals or if they have to requery. This is also very useful for code generation (and is actually a followup, see #550)