### PR TITLE
removed duplicate NodeConnectionState signal

### DIFF
--- a/README.developer.md
+++ b/README.developer.md
@@ -79,7 +79,6 @@ org.eclipse.bluechi.Manager         interface -         -              -
 .SetLogLevel                        method    s         -              -
 .JobNew                             signal    uo        -              -
 .JobRemoved                         signal    uosss     -              -
-.NodeConnectionStateChanged         signal    ss        -              -
 org.eclipse.bluechi.Shutdown        interface -         -              -
 .Shutdown                           method    -         -              -
 org.freedesktop.DBus.Introspectable interface -         -              -

--- a/data/org.eclipse.bluechi.Manager.xml
+++ b/data/org.eclipse.bluechi.Manager.xml
@@ -122,10 +122,5 @@
       <arg name="unit" type="s" />
       <arg name="result" type="s" />
     </signal>
-
-    <signal name="NodeConnectionStateChanged">
-      <arg name="node" type="s" />
-      <arg name="connection_state" type="s" />
-    </signal>
   </interface>
 </node>

--- a/doc/docs/api/description.md
+++ b/doc/docs/api/description.md
@@ -57,10 +57,6 @@ Note that all properties also come with change events, so you can easily track w
     `failed`, `cancelled`, `timeout`, `dependency`, `skipped`. This is either the result from systemd on the node, or
     `cancelled` if the job was cancelled in BlueChi before any systemd job was started for it.
 
-  * `NodeConnectionStateChanged(s node, s state)`
-
-    Emitted each time a listed node in BlueChi changes its connection state from offline to online and vice versa. A node is considered online only when its registration at BlueChi succeeds.
-
 #### Properties
 
   * `Nodes` - `as`

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -540,19 +540,6 @@ class Manager(ApiBase):
         """
         self.get_proxy().JobRemoved.connect(callback)
 
-    def on_node_connection_state_changed(
-        self,
-        callback: Callable[
-            [
-                str,
-                str,
-            ],
-            None,
-        ],
-    ) -> None:
-        """ """
-        self.get_proxy().NodeConnectionStateChanged.connect(callback)
-
 
 class Node(ApiBase):
     """

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -239,29 +239,6 @@ void manager_job_state_changed(Manager *manager, uint32_t job_id, const char *st
         }
 }
 
-void manager_node_connection_state_changed(Manager *manager, const char *node_name, const char *state) {
-        /* skip emitting state changed for anonymous node
-           since it wasn't (fully) connected in the first place */
-        if (node_name == NULL) {
-                return;
-        }
-
-        int r = sd_bus_emit_signal(
-                        manager->api_bus,
-                        BC_MANAGER_OBJECT_PATH,
-                        MANAGER_INTERFACE,
-                        "NodeConnectionStateChanged",
-                        "ss",
-                        node_name,
-                        state);
-        if (r < 0) {
-                bc_log_debugf("Failed to emit NodeConnectionStateChanged signal for node %s and new state %s: %s",
-                              node_name,
-                              state,
-                              strerror(-r));
-        }
-}
-
 void manager_finish_job(Manager *manager, uint32_t job_id, const char *result) {
         Job *job = NULL;
         LIST_FOREACH(jobs, job, manager->jobs) {
@@ -854,8 +831,6 @@ static const sd_bus_vtable manager_vtable[] = {
                         SD_BUS_PARAM(id) SD_BUS_PARAM(job) SD_BUS_PARAM(node) SD_BUS_PARAM(unit)
                                         SD_BUS_PARAM(result),
                         0),
-        SD_BUS_SIGNAL_WITH_NAMES(
-                        "NodeConnectionStateChanged", "ss", SD_BUS_PARAM(node) SD_BUS_PARAM(connection_state), 0),
         SD_BUS_VTABLE_END
 };
 

--- a/src/manager/manager.h
+++ b/src/manager/manager.h
@@ -56,7 +56,6 @@ bool manager_add_job(Manager *manager, Job *job);
 void manager_remove_job(Manager *manager, Job *job, const char *result);
 void manager_finish_job(Manager *manager, uint32_t job_id, const char *result);
 void manager_job_state_changed(Manager *manager, uint32_t job_id, const char *state);
-void manager_node_connection_state_changed(Manager *manager, const char *node_name, const char *state);
 
 void manager_remove_monitor(Manager *manager, Monitor *monitor);
 

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -868,7 +868,6 @@ static int node_method_register(sd_bus_message *m, void *userdata, UNUSED sd_bus
         node_unset_agent_bus(node);
 
         bc_log_infof("Registered managed node from fd %d as '%s'", sd_bus_get_fd(agent_bus), name);
-        manager_node_connection_state_changed(named_node->manager, named_node->name, "online");
 
         return sd_bus_reply_method_return(m, "");
 }
@@ -971,7 +970,6 @@ static int node_disconnected(UNUSED sd_bus_message *message, void *userdata, UNU
         } else {
                 bc_log_info("Anonymous node disconnected");
         }
-        manager_node_connection_state_changed(node->manager, node->name, "offline");
 
         return 0;
 }

--- a/tests/tests/tier0/monitor-node-disconnect/python/monitor.py
+++ b/tests/tests/tier0/monitor-node-disconnect/python/monitor.py
@@ -4,6 +4,7 @@ import unittest
 
 from dasbus.error import DBusError
 from dasbus.loop import EventLoop
+from dasbus.typing import Variant
 
 from bluechi.api import Manager, Node
 
@@ -15,13 +16,11 @@ class TestNodeDisconnect(unittest.TestCase):
     def test_node_disconnect(self):
         loop = EventLoop()
 
-        def on_state_change(_: str, state: str):
-            self.node_state = state
+        def on_state_change(state: Variant):
+            self.node_state = state.get_string()
             loop.quit()
 
         mgr = Manager()
-        mgr.on_node_connection_state_changed(on_state_change)
-
         nodes = mgr.list_nodes()
         if len(nodes) < 1:
             raise Exception("No connected node found")
@@ -29,6 +28,8 @@ class TestNodeDisconnect(unittest.TestCase):
         # get name of first node
         node_name = nodes[0][0]
         node = Node(node_name)
+
+        node.on_status_changed(on_state_change)
 
         # stop the bluechi-agent service to trigger a disconnected message
         # hacky solution to cause a disconnect:


### PR DESCRIPTION
Fixes https://github.com/containers/bluechi/issues/551 

Since the property for the node status on the D-Bus API is marked as emitting change (and signal is emitted), the signal of NodeConnectionStateChanged signal is a duplicate and can be removed. All usages of the NodeConnectionStateChanged signal in tests and bluechictl are replaced by listening to the property change of Status.

~~Requires https://github.com/containers/bluechi/pull/555 to be merged first, then rebase.~~