### PR TITLE
adds a status and disconnected timestamp property to the agent interface

### DIFF
--- a/data/org.eclipse.bluechi.Agent.xml
+++ b/data/org.eclipse.bluechi.Agent.xml
@@ -39,5 +39,27 @@
       <arg name="node" type="s" direction="in" />
       <arg name="unit" type="s" direction="in" />
     </method>
+
+
+    <!-- 
+      Status:
+
+      The connection status of the agent with the BlueChi controller.
+      On any change, a signal is emitted on the org.freedesktop.DBus.Properties interface. 
+    -->
+    <property name="Status" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true" />
+    </property>
+
+    <!-- 
+      DisconnectTimestamp:
+
+      A timestamp indicating when the agent lost connection to the BlueChi controller.
+      If the connection is active (agent is online), this value is 0.
+    -->
+    <property name="DisconnectTimestamp" type="t" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false" />
+    </property>
+
   </interface>
 </node>

--- a/src/agent/agent.h
+++ b/src/agent/agent.h
@@ -57,6 +57,7 @@ struct Agent {
 
         AgentConnectionState connection_state;
         uint64_t connection_retry_count;
+        time_t disconnect_timestamp;
 
         char *orch_addr;
         char *api_bus_service_name;
@@ -107,6 +108,7 @@ bool agent_start(Agent *agent);
 bool agent_stop(Agent *agent);
 
 bool agent_is_connected(Agent *agent);
+char *agent_is_online(Agent *agent);
 
 void agent_remove_proxy(Agent *agent, ProxyService *proxy, bool emit);
 

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -875,3 +875,42 @@ class Agent(ApiBase):
             node,
             unit,
         )
+
+    @property
+    def status(self) -> str:
+        """
+          Status:
+
+        The connection status of the agent with the BlueChi controller.
+        On any change, a signal is emitted on the org.freedesktop.DBus.Properties interface.
+        """
+        return self.get_proxy().Status
+
+    def on_status_changed(self, callback: Callable[[Variant], None]):
+        """
+          Status:
+
+        The connection status of the agent with the BlueChi controller.
+        On any change, a signal is emitted on the org.freedesktop.DBus.Properties interface.
+        """
+
+        def on_properties_changed(
+            interface: str,
+            changed_props: Dict[str, Variant],
+            invalidated_props: Dict[str, Variant],
+        ) -> None:
+            value = changed_props.get("Status")
+            if value is not None:
+                callback(value)
+
+        self.get_properties_proxy().PropertiesChanged.connect(on_properties_changed)
+
+    @property
+    def disconnect_timestamp(self) -> UInt64:
+        """
+          DisconnectTimestamp:
+
+        A timestamp indicating when the agent lost connection to the BlueChi controller.
+        If the connection is active (agent is online), this value is 0.
+        """
+        return self.get_proxy().DisconnectTimestamp

--- a/tests/bluechi_test/container.py
+++ b/tests/bluechi_test/container.py
@@ -114,6 +114,21 @@ class BluechiContainer():
               Latest state: {latest_state}")
         return False
 
+    def run_python(self, python_script_path: str) -> \
+            Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
+
+        target_file_dir = os.path.join("/", "tmp")
+        target_file_name = get_random_name(10)
+        content = read_file(python_script_path)
+        self.create_file(target_file_dir, target_file_name, content)
+
+        target_file_path = os.path.join(target_file_dir, target_file_name)
+        result, output = self.exec_run(f'python3 {target_file_path}')
+        try:
+            os.remove(target_file_path)
+        finally:
+            return result, output
+
 
 class BluechiNodeContainer(BluechiContainer):
 
@@ -183,18 +198,3 @@ class BluechiControllerContainer(BluechiContainer):
         result, output = self.exec_run(f"bluechictl thaw {node_name} {unit_name}")
         if result != 0:
             raise Exception(f"Failed to thaw service {unit_name} on node {node_name}: {output}")
-
-    def run_python(self, python_script_path: str) -> \
-            Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
-
-        target_file_dir = os.path.join("/", "tmp")
-        target_file_name = get_random_name(10)
-        content = read_file(python_script_path)
-        self.create_file(target_file_dir, target_file_name, content)
-
-        target_file_path = os.path.join(target_file_dir, target_file_name)
-        result, output = self.exec_run(f'python3 {target_file_path}')
-        try:
-            os.remove(target_file_path)
-        finally:
-            return result, output

--- a/tests/tests/tier0/monitor-agent-loses-connection/main.fmf
+++ b/tests/tests/tier0/monitor-agent-loses-connection/main.fmf
@@ -1,0 +1,1 @@
+summary: Test if the bluechi agent emits a status changed signal when it disconnects from the controller, e.g. when the controller goes down

--- a/tests/tests/tier0/monitor-agent-loses-connection/python/is_agent_connected.py
+++ b/tests/tests/tier0/monitor-agent-loses-connection/python/is_agent_connected.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from bluechi.api import Agent
+
+# Test to verify that the agent on the node is connected to the controller
+# and the properties for status and disconnected timestamp are set
+
+
+class TestAgentIsConnected(unittest.TestCase):
+
+    def test_agent_is_connected(self):
+        agent = Agent()
+        assert agent.status == "online"
+        assert agent.disconnect_timestamp == 0
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/monitor-agent-loses-connection/python/monitor_ctrl_down.py
+++ b/tests/tests/tier0/monitor-agent-loses-connection/python/monitor_ctrl_down.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from dasbus.error import DBusError
+from dasbus.loop import EventLoop
+from dasbus.typing import Variant
+
+from bluechi.api import Node, Agent
+
+
+class TestMonitorCtrlDown(unittest.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.agent_state = None
+        self.agent_disconnected_timestamp = 0
+        self.agent_on_node = Agent()
+
+    def test_monitor_ctrl_down(self):
+        loop = EventLoop()
+
+        def on_state_change(state: Variant):
+            self.agent_state = state.get_string()
+            self.agent_disconnected_timestamp = self.agent_on_node.disconnect_timestamp
+            loop.quit()
+
+        self.agent_on_node.on_status_changed(on_state_change)
+
+        # stop the bluechi controller service to trigger a disconnected message in the agent
+        # hacky solution to cause a disconnect:
+        #   stop the controller service
+        # problem:
+        #   dasbus will raise a DBusError for connection timeout on v1.4, v1.7 doesn't
+        #   the command will be executed anyway, resulting in the desired shutdown of the node
+        #   therefore, the DBusError is silenced for now, but all other errors are still raised
+        try:
+            node = Node("node-foo")
+            node.stop_unit('bluechi.service', 'replace')
+        except DBusError:
+            pass
+
+        loop.run()
+
+        assert self.agent_state == "offline"
+        assert self.agent_disconnected_timestamp != 0
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/monitor-agent-loses-connection/test_monitor_agent_loses_connection.py
+++ b/tests/tests/tier0/monitor-agent-loses-connection/test_monitor_agent_loses_connection.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+
+node_foo_name = "node-foo"
+
+
+def start_agent_in_ctrl_container(ctrl: BluechiControllerContainer):
+    assert ctrl.wait_for_unit_state_to_be("bluechi", "active")
+
+    node_foo_config = BluechiNodeConfig(
+        file_name="agent.conf",
+        node_name=node_foo_name,
+        manager_host="localhost",
+        manager_port=ctrl.config.port,
+    )
+    ctrl.create_file(node_foo_config.get_confd_dir(), node_foo_config.file_name, node_foo_config.serialize())
+    result, _ = ctrl.exec_run("systemctl start bluechi-agent")
+    assert result == 0
+    assert ctrl.wait_for_unit_state_to_be("bluechi-agent", "active")
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+    start_agent_in_ctrl_container(ctrl)
+
+    # bluechi-agent is running, check if it is connected in Agent
+    result, output = ctrl.run_python(os.path.join("python", "is_agent_connected.py"))
+    if result != 0:
+        raise Exception(output)
+
+    # stop bluechi service and verify that the agent emits a status changed signal
+    result, output = ctrl.run_python(os.path.join("python", "monitor_ctrl_down.py"))
+    if result != 0:
+        raise Exception(output)
+
+
+def test_monitor_agent_loses_connection(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig):
+
+    bluechi_ctrl_default_config.allowed_node_names = [node_foo_name]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    # don't add node_foo_config to bluechi_test to prevent it being started
+    # as separate container
+    bluechi_test.run(exec)


### PR DESCRIPTION
Fixes https://github.com/containers/bluechi/issues/543 

In order to enable other applications on the managed node to react to connection loss of the agent with the controller, add two new properties: `Status` and `DisconnectTimestamp`
If the status will change, the agent will emit a property changed signal on which other applications can listen. To provide information for later when the disconnect happened, the timestamp property can be queried.
This change also includes extending the D-Bus API description and adding an integration test to it.