### PR TITLE
Increase default timeout for tests to 45 seconds

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,17 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import pytest
+
+
 pytest_plugins = [
     "bluechi_test.fixtures"
 ]
+
+
+# Set minimum timeout for all tests to 45 seconds.
+# If some test needs bigger timeout, please override it for the specific test
+# using @pytest.mark.timeout annotation
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if item.get_closest_marker('timeout') is None:
+            item.add_marker(pytest.mark.timeout(45))

--- a/tests/tests/tier0/bluechi-agent-invalid-port-configuration/test_agent_invalid_port_configuration.py
+++ b/tests/tests/tier0/bluechi-agent-invalid-port-configuration/test_agent_invalid_port_configuration.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -19,7 +18,6 @@ def start_with_invalid_port(ctrl: BluechiControllerContainer, nodes: Dict[str, B
     assert node_bar_with_invalid_port.wait_for_unit_state_to_be("bluechi-agent", "failed")
 
 
-@pytest.mark.timeout(15)
 def test_agent_invalid_port_configuration(
         bluechi_test: BluechiTest,
         bluechi_node_default_config: BluechiNodeConfig, bluechi_ctrl_default_config: BluechiControllerConfig):

--- a/tests/tests/tier0/bluechi-agent-logisquiet/test_agent_logisquiet.py
+++ b/tests/tests/tier0/bluechi-agent-logisquiet/test_agent_logisquiet.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -27,7 +26,6 @@ def start_with_invalid_logisquiet(ctrl: BluechiControllerContainer, nodes: Dict[
     assert node_with_numbers_only_in_logisquiet.wait_for_unit_state_to_be("bluechi-agent", "active")
 
 
-@pytest.mark.timeout(25)
 def test_agent_invalid_configuration(
         bluechi_test: BluechiTest,
         bluechi_node_default_config: BluechiNodeConfig, bluechi_ctrl_default_config: BluechiControllerConfig):

--- a/tests/tests/tier0/bluechi-agent-loglevel/test_agent_loglevel.py
+++ b/tests/tests/tier0/bluechi-agent-loglevel/test_agent_loglevel.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -28,7 +27,6 @@ def start_with_invalid_loglevel(ctrl: BluechiControllerContainer, nodes: Dict[st
     assert node_with_numbers_only_in_loglevel.wait_for_unit_state_to_be("bluechi-agent", "active")
 
 
-@pytest.mark.timeout(25)
 def test_agent_invalid_configuration(
         bluechi_test: BluechiTest,
         bluechi_node_default_config: BluechiNodeConfig, bluechi_ctrl_default_config: BluechiControllerConfig):

--- a/tests/tests/tier0/bluechi-agent-logtarget/test_agent_logtarget.py
+++ b/tests/tests/tier0/bluechi-agent-logtarget/test_agent_logtarget.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -27,7 +26,6 @@ def start_with_invalid_logtarget(ctrl: BluechiControllerContainer, nodes: Dict[s
     assert node_with_not_valid_value.wait_for_unit_state_to_be("bluechi-agent", "active")
 
 
-@pytest.mark.timeout(40)
 def test_agent_invalid_logtarget_configuration(
         bluechi_test: BluechiTest,
         bluechi_node_default_config: BluechiNodeConfig, bluechi_ctrl_default_config: BluechiControllerConfig):

--- a/tests/tests/tier0/bluechi-agent-resolve-fqdn/test_bluechi_agent_resolve_fqdn.py
+++ b/tests/tests/tier0/bluechi-agent-resolve-fqdn/test_bluechi_agent_resolve_fqdn.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import pytest
 from typing import Dict
 
 from bluechi_test.fixtures import get_primary_ip
@@ -39,7 +38,6 @@ def verify_resolving_fqdn(ctrl: BluechiControllerContainer, _: Dict[str, Bluechi
     assert result == 0
 
 
-@pytest.mark.timeout(10)
 def test_agent_resolve_fqdn(bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
     bluechi_ctrl_default_config.allowed_node_names = [local_node_name]
 

--- a/tests/tests/tier0/bluechi-agent-started-and-connected/test_agent_started_and_connected.py
+++ b/tests/tests/tier0/bluechi-agent-started-and-connected/test_agent_started_and_connected.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -22,7 +21,6 @@ def foo_startup_verify(ctrl: BluechiControllerContainer, nodes: Dict[str, Bluech
     # TODO: Add code to test that agent on node foo is successfully connected to bluechi controller
 
 
-@pytest.mark.timeout(10)
 def test_agent_foo_startup(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/bluechi-and-agent-on-same-machine/test_bluechi_and_agent_on_same_machine.py
+++ b/tests/tests/tier0/bluechi-and-agent-on-same-machine/test_bluechi_and_agent_on_same_machine.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -32,7 +31,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(output)
 
 
-@pytest.mark.timeout(40)
 def test_bluechi_and_agent_on_same_machine(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig):

--- a/tests/tests/tier0/bluechi-anonymous-node/test_anonymous_node.py
+++ b/tests/tests/tier0/bluechi-anonymous-node/test_anonymous_node.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -24,7 +23,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(output)
 
 
-@pytest.mark.timeout(40)
 def test_anonymous_node(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/bluechi-enable-service/test_bluechi_enable_service.py
+++ b/tests/tests/tier0/bluechi-enable-service/test_bluechi_enable_service.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
@@ -32,7 +31,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(f"Unit {simple_service} expected to be enabled, but got: {output}")
 
 
-@pytest.mark.timeout(15)
 def test_proxy_service_start(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/bluechi-freeze-and-thaw-service/test_bluechi_freeze_and_thaw_service.py
+++ b/tests/tests/tier0/bluechi-freeze-and-thaw-service/test_bluechi_freeze_and_thaw_service.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
@@ -45,7 +44,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_service_thaw(foo)
 
 
-@pytest.mark.timeout(20)
 def test_service_freeze_and_thaw(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/bluechi-invalid-port/test_agent_invalid_port.py
+++ b/tests/tests/tier0/bluechi-invalid-port/test_agent_invalid_port.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -39,7 +38,6 @@ def exec(ctrl: BluechiControllerContainer, _: Dict[str, BluechiNodeContainer]):
     assert ctrl.wait_for_unit_state_to_be("bluechi", "active")
 
 
-@pytest.mark.timeout(40)
 def test_agent_invalid_port(bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
 
     bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)

--- a/tests/tests/tier0/bluechi-long-multiline-config-setting/test_long_multiline_config_setting.py
+++ b/tests/tests/tier0/bluechi-long-multiline-config-setting/test_long_multiline_config_setting.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -15,7 +14,6 @@ def startup_verify(ctrl: BluechiControllerContainer, _: Dict[str, BluechiNodeCon
     assert output == 'active'
 
 
-@pytest.mark.timeout(10)
 def test_long_multiline_config_setting(bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
     config = bluechi_ctrl_default_config.deep_copy()
     for i in range(150):

--- a/tests/tests/tier0/bluechi-service-startup/test_service_startup.py
+++ b/tests/tests/tier0/bluechi-service-startup/test_service_startup.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -15,7 +14,6 @@ def startup_verify(ctrl: BluechiControllerContainer, _: Dict[str, BluechiNodeCon
     assert output == 'active'
 
 
-@pytest.mark.timeout(10)
 def test_controller_startup(bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
     bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
 

--- a/tests/tests/tier0/monitor-multiple-nodes-and-units/test_monitor_multiple_nodes_and_units.py
+++ b/tests/tests/tier0/monitor-multiple-nodes-and-units/test_monitor_multiple_nodes_and_units.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -32,7 +31,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(output)
 
 
-@pytest.mark.timeout(10)
 def test_monitor_specific_node_and_unit(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/monitor-node-disconnect/test_monitor_node_disconnect.py
+++ b/tests/tests/tier0/monitor-node-disconnect/test_monitor_node_disconnect.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -19,7 +18,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(output)
 
 
-@pytest.mark.timeout(10)
 def test_monitor_node_disconnect(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/monitor-node-reconnect/test_monitor_node_reconnect.py
+++ b/tests/tests/tier0/monitor-node-reconnect/test_monitor_node_reconnect.py
@@ -2,7 +2,6 @@
 
 import os
 import time
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -33,7 +32,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(output)
 
 
-@pytest.mark.timeout(15)
 def test_monitor_node_disconnect(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/monitor-open-close/test_monitor_open_close.py
+++ b/tests/tests/tier0/monitor-open-close/test_monitor_open_close.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -16,7 +15,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(output)
 
 
-@pytest.mark.timeout(10)
 def test_monitor_open_close(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/monitor-specific-node-and-unit/test_monitor_specific_node_and_unit.py
+++ b/tests/tests/tier0/monitor-specific-node-and-unit/test_monitor_specific_node_and_unit.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -22,7 +21,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(output)
 
 
-@pytest.mark.timeout(10)
 def test_monitor_specific_node_and_unit(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/monitor-wildcard-node-reconnect/test_monitor_wildcard_node_reconnect.py
+++ b/tests/tests/tier0/monitor-wildcard-node-reconnect/test_monitor_wildcard_node_reconnect.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -20,7 +19,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(output)
 
 
-@pytest.mark.timeout(25)
 def test_monitor_wildcard_node_reconnect(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/monitor-wildcard-unit-changes/test_monitor_wildcard_unit_changes.py
+++ b/tests/tests/tier0/monitor-wildcard-unit-changes/test_monitor_wildcard_unit_changes.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -31,7 +30,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(output)
 
 
-@pytest.mark.timeout(20)
 def test_monitor_wildcard_unit_changes(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/properties-get/test_properties_get.py
+++ b/tests/tests/tier0/properties-get/test_properties_get.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -15,7 +14,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(output)
 
 
-@pytest.mark.timeout(40)
 def test_properties_get(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/property-get/test_property_get.py
+++ b/tests/tests/tier0/property-get/test_property_get.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -15,7 +14,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(output)
 
 
-@pytest.mark.timeout(40)
 def test_property_get(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/property-set/test_property_set.py
+++ b/tests/tests/tier0/property-set/test_property_set.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.test import BluechiTest
@@ -23,7 +22,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(output)
 
 
-@pytest.mark.timeout(40)
 def test_property_set(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-fails-on-execstart/test_proxy_service_fails_on_execstart.py
+++ b/tests/tests/tier0/proxy-service-fails-on-execstart/test_proxy_service_fails_on_execstart.py
@@ -42,7 +42,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
 
 
 @pytest.mark.skip(reason="Currently flaky. Tracked in https://github.com/containers/bluechi/issues/320. ")
-@pytest.mark.timeout(25)
 def test_proxy_service_fails_on_execstart(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-fails-on-non-existent-service/test_proxy_service_fails_on_non_existent_service.py
+++ b/tests/tests/tier0/proxy-service-fails-on-non-existent-service/test_proxy_service_fails_on_non_existent_service.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
@@ -35,7 +34,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_start_failed(foo)
 
 
-@pytest.mark.timeout(20)
 def test_proxy_service_fails_on_non_existent_service(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-fails-on-typo-in-file/test_proxy_service_fails_on_typo_in_file.py
+++ b/tests/tests/tier0/proxy-service-fails-on-typo-in-file/test_proxy_service_fails_on_typo_in_file.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
@@ -41,7 +40,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_start_failed(foo, bar)
 
 
-@pytest.mark.timeout(20)
 def test_proxy_service_fails_on_typo_in_file(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-multiple-services-multiple-nodes/test_proxy_service_multiple_services_multiple_nodes.py
+++ b/tests/tests/tier0/proxy-service-multiple-services-multiple-nodes/test_proxy_service_multiple_services_multiple_nodes.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
@@ -58,7 +57,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     assert foo1.wait_for_unit_state_to_be(bluechi_proxy_service, "inactive")
 
 
-@pytest.mark.timeout(25)
 def test_proxy_service_multiple_services_multiple_nodes(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-multiple-services-one-node/test_proxy_service_multiple_services_one_node.py
+++ b/tests/tests/tier0/proxy-service-multiple-services-one-node/test_proxy_service_multiple_services_one_node.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
@@ -57,7 +56,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     assert foo.wait_for_unit_state_to_be(bluechi_proxy_service, "inactive")
 
 
-@pytest.mark.timeout(20)
 def test_proxy_service_multiple_services_one_node(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-start/test_proxy_service_start.py
+++ b/tests/tests/tier0/proxy-service-start/test_proxy_service_start.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
@@ -41,7 +40,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_start(foo, bar)
 
 
-@pytest.mark.timeout(20)
 def test_proxy_service_start(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-stop-bluechi-dep/test_proxy_service_stop_bluechi_dep.py
+++ b/tests/tests/tier0/proxy-service-stop-bluechi-dep/test_proxy_service_stop_bluechi_dep.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
@@ -53,7 +52,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_stop(foo, bar)
 
 
-@pytest.mark.timeout(20)
 def test_proxy_service_stop_bluechi_dep(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-stop-requesting-with-unneeded/test_proxy_service_stop_requesting_with_unneeded.py
+++ b/tests/tests/tier0/proxy-service-stop-requesting-with-unneeded/test_proxy_service_stop_requesting_with_unneeded.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
@@ -53,7 +52,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_stop(foo, bar)
 
 
-@pytest.mark.timeout(20)
 def test_proxy_service_stop_requesting(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-stop-requesting/test_proxy_service_stop_requesting.py
+++ b/tests/tests/tier0/proxy-service-stop-requesting/test_proxy_service_stop_requesting.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
@@ -53,7 +52,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_stop(foo, bar)
 
 
-@pytest.mark.timeout(20)
 def test_proxy_service_stop_requesting(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,

--- a/tests/tests/tier0/proxy-service-stop-target/test_proxy_service_stop_target.py
+++ b/tests/tests/tier0/proxy-service-stop-target/test_proxy_service_stop_target.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
@@ -53,7 +52,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_stop(foo, bar)
 
 
-@pytest.mark.timeout(20)
 def test_proxy_service_stop_target(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,


### PR DESCRIPTION
Default timeout of 45 seconds is automatically added to each test to
pass successfully on the testing farm. Tests, which needs even more
time, can use the annotation on each method to override the default.

Signed-off-by: Martin Perina <mperina@redhat.com>
