### PR TITLE
Move BlueChi daemons to `/usr/libexec`

### DIFF
--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -52,7 +52,7 @@ This package contains the controller and command line tool.
 %doc README.md
 %doc README.developer.md
 %license LICENSE
-%{_bindir}/bluechi-controller
+%{_libexecdir}/bluechi-controller
 %{_datadir}/dbus-1/interfaces/org.eclipse.bluechi.Job.xml
 %{_datadir}/dbus-1/interfaces/org.eclipse.bluechi.Manager.xml
 %{_datadir}/dbus-1/interfaces/org.eclipse.bluechi.Monitor.xml
@@ -95,8 +95,8 @@ This package contains the node agent.
 %dir %{_sysconfdir}/bluechi/agent.conf.d
 %doc README.md
 %license LICENSE
-%{_bindir}/bluechi-agent
-%{_bindir}/bluechi-proxy
+%{_libexecdir}/bluechi-agent
+%{_libexecdir}/bluechi-proxy
 %{_datadir}/dbus-1/system.d/org.eclipse.bluechi.Agent.conf
 %{_datadir}/bluechi-agent/config/agent.conf
 %{_datadir}/dbus-1/interfaces/org.eclipse.bluechi.Agent.xml

--- a/selinux/bluechi.fc
+++ b/selinux/bluechi.fc
@@ -1,4 +1,6 @@
 /usr/bin/bluechi-controller	--	gen_context(system_u:object_r:bluechi_exec_t,s0)
+/usr/libexec/bluechi-controller	--	gen_context(system_u:object_r:bluechi_exec_t,s0)
 
 /usr/bin/bluechi-agent	--	gen_context(system_u:object_r:bluechi_agent_exec_t,s0)
+/usr/libexec/bluechi-agent	--	gen_context(system_u:object_r:bluechi_agent_exec_t,s0)
 

--- a/selinux/bluechi_agent_selinux.8
+++ b/selinux/bluechi_agent_selinux.8
@@ -19,6 +19,7 @@ The bluechi_agent_t SELinux type can be entered via the \fBbluechi_agent_exec_t\
 The default entrypoint paths for the bluechi_agent_t domain are the following:
 
 /usr/bin/bluechi-agent
+/usr/libexec/bluechi-agent
 .SH PROCESS TYPES
 SELinux defines process types (domains) for each process running on the system
 .PP

--- a/selinux/bluechi_controller_selinux.8
+++ b/selinux/bluechi_controller_selinux.8
@@ -19,6 +19,7 @@ The bluechi_t SELinux type can be entered via the \fBbluechi_exec_t\fP file type
 The default entrypoint paths for the bluechi_t domain are the following:
 
 /usr/bin/bluechi-controller
+/usr/libexec/bluechi-controller
 .SH PROCESS TYPES
 SELinux defines process types (domains) for each process running on the system
 .PP

--- a/src/agent/meson.build
+++ b/src/agent/meson.build
@@ -21,5 +21,6 @@ executable(
   ],
   c_args: common_cflags,
   include_directories: include_directories('..'),
-  install: true
+  install: true,
+  install_dir: join_paths(prefixdir, get_option('libexecdir'))
 )

--- a/src/manager/meson.build
+++ b/src/manager/meson.build
@@ -30,6 +30,7 @@ executable(
     bluechi_lib,
   ],
   install: true,
+  install_dir: join_paths(prefixdir, get_option('libexecdir')),
   c_args: common_cflags,
   include_directories: include_directories('..')
 )

--- a/src/proxy/meson.build
+++ b/src/proxy/meson.build
@@ -16,5 +16,6 @@ executable(
   ],
   c_args: common_cflags,
   include_directories: include_directories('..'),
-  install: true
+  install: true,
+  install_dir: join_paths(prefixdir, get_option('libexecdir'))
 )

--- a/systemd-units/bluechi-agent-user.service
+++ b/systemd-units/bluechi-agent-user.service
@@ -9,4 +9,4 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/bluechi-agent --user
+ExecStart=/usr/libexec/bluechi-agent --user

--- a/systemd-units/bluechi-agent.service
+++ b/systemd-units/bluechi-agent.service
@@ -9,7 +9,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/bluechi-agent
+ExecStart=/usr/libexec/bluechi-agent
 Restart=on-failure
 
 [Install]

--- a/systemd-units/bluechi-controller.service
+++ b/systemd-units/bluechi-controller.service
@@ -9,7 +9,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/bluechi-controller
+ExecStart=/usr/libexec/bluechi-controller
 Restart=on-failure
 
 [Install]

--- a/systemd-units/bluechi-proxy-user@.service
+++ b/systemd-units/bluechi-proxy-user@.service
@@ -8,8 +8,8 @@ Documentation=man:bluechi-proxy(1)
 StopWhenUnneeded=yes
 
 [Service]
-ExecStart=bluechi-proxy --user create %i.service
-ExecStop=bluechi-proxy --user remove %i.service
+ExecStart=/usr/libexec/bluechi-proxy --user create %i.service
+ExecStop=/usr/libexec/bluechi-proxy --user remove %i.service
 RemainAfterExit=yes
 Type=oneshot
 KillMode=mixed

--- a/systemd-units/bluechi-proxy@.service
+++ b/systemd-units/bluechi-proxy@.service
@@ -8,8 +8,8 @@ Documentation=man:bluechi-proxy(1)
 StopWhenUnneeded=yes
 
 [Service]
-ExecStart=bluechi-proxy create %i.service
-ExecStop=bluechi-proxy remove %i.service
+ExecStart=/usr/libexec/bluechi-proxy create %i.service
+ExecStop=/usr/libexec/bluechi-proxy remove %i.service
 RemainAfterExit=yes
 Type=oneshot
 KillMode=mixed


### PR DESCRIPTION
Moves `bluechi-controller`, `bluechi-agent` and `bluechi-proxy` daemons
to `/usr/libexec` directory, so users can use shell auto completion
feature for `bluechictl` much more effectively.

Fixes: https://github.com/containers/bluechi/issues/571
Signed-off-by: Martin Perina <mperina@redhat.com>
