### PR TITLE
Save .gcno files after meson build

### DIFF
--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -203,6 +203,19 @@ API description and manually written code to simplify recurring tasks.
 %{python3_sitelib}/bluechi/
 %endif
 
+%if 0%{?with_coverage}
+%package coverage
+Summary: Code coverage files for BlueChi
+
+%description coverage
+This package contains code coverage files created during the build. Those files
+will be used during integration tests when creating code coverage report.
+
+%files coverage
+%license LICENSE
+%{_datadir}/bluechi-coverage/*.gcno
+%endif
+
 %prep
 %autosetup
 

--- a/build-scripts/install-coverage.sh
+++ b/build-scripts/install-coverage.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -xe
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+COV_DIR="${MESON_INSTALL_DESTDIR_PREFIX}/share/bluechi-coverage"
+mkdir -p "${COV_DIR}"
+find "${MESON_BUILD_ROOT}" -name '*.gcno' -exec cp "{}" "${COV_DIR}" \;
+

--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,10 @@ with_coverage = get_option('with_coverage')
 if with_coverage == 'true'
    add_project_arguments('-coverage', language : 'c')
    add_project_link_arguments('-lgcov', language : 'c')
+   # Coverage source code mapping files `*.gcno` are created as a part of the build for each `*.c` file, but it's
+   # very hard to tell meson to install files, which are created as a side effect from the build, so it's easier
+   # to use custom install script
+   meson.add_install_script('build-scripts/install-coverage.sh')
 endif
 
 # Build time configuration header file


### PR DESCRIPTION
.gcno files are needed to get full coverage.
This PR will save those files in a ${datadir}/coverage so we can use
them later on to get the coverage with .gcna files.

Fixes:https://github.com/containers/bluechi/issues/397
Signed-off-by: Artiom Divak <adivak@redhat.com>