### PR TITLE
Introduce running integration tests with valgrind

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -76,6 +76,16 @@ tmt run
 This will use latest BlueChi packages from
 [hirte-snapshot](https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/) repository.
 
+## Running integration tests with memory leak detection
+
+To run integration tests with `valgrind`, set `WITH_VALGRIND` environment variable as follows:
+
+```shell
+WITH_VALGRIND=1 tmt run -v
+```
+
+If `valgrind` detects a memory leak in a test, the test will fail, and the logs will be found in the test `data` directory.
+
 ## Running integration tests with local BlueChi build
 
 In order to run integration tests for your local BlueChi build, you need have BlueChi RPM packages built from your source

--- a/tests/bluechi_test/fixtures.py
+++ b/tests/bluechi_test/fixtures.py
@@ -46,6 +46,13 @@ def bluechi_network_name() -> str:
     return _get_env_value('BLUECHI_NETWORK_NAME', 'bluechi-test')
 
 
+@pytest.fixture(scope='session')
+def run_with_valgrind() -> bool:
+    """Returns 1 if bluechi should be run with valgrind for memory management testing"""
+
+    return _get_env_value('WITH_VALGRIND', 0) == '1'
+
+
 def _get_env_value(env_var: str, default_value: str) -> str:
     value = os.getenv(env_var)
     if value is None:
@@ -95,7 +102,8 @@ def bluechi_test(
         bluechi_network_name: str,
         bluechi_ctrl_host_port: str,
         bluechi_ctrl_svc_port: str,
-        tmt_test_data_dir: str):
+        tmt_test_data_dir: str,
+        run_with_valgrind: bool):
 
     return BluechiTest(
         podman_client,
@@ -104,4 +112,5 @@ def bluechi_test(
         bluechi_ctrl_host_port,
         bluechi_ctrl_svc_port,
         tmt_test_data_dir,
+        run_with_valgrind,
     )

--- a/tests/containers/integration-test-base
+++ b/tests/containers/integration-test-base
@@ -7,5 +7,6 @@ RUN dnf upgrade --refresh -y --nodocs && \
         selinux-policy \
         systemd \
         systemd-devel \
+        valgrind \
     -y && \
     dnf -y clean all

--- a/tests/tests/tier0/bluechi-agent-resolve-fqdn/test_bluechi_agent_resolve_fqdn.py
+++ b/tests/tests/tier0/bluechi-agent-resolve-fqdn/test_bluechi_agent_resolve_fqdn.py
@@ -29,7 +29,7 @@ def verify_resolving_fqdn(ctrl: BluechiControllerContainer, _: Dict[str, Bluechi
     local_node_cfg.manager_host = "localhost"
     ctrl.create_file(local_node_cfg.get_confd_dir(), local_node_cfg.file_name, local_node_cfg.serialize())
 
-    ctrl.exec_run('systemctl start bluechi-agent')
+    ctrl.systemctl_start_and_wait("bluechi-agent", 1)
     result, output = ctrl.exec_run('systemctl is-active bluechi-agent')
     assert result == 0
     assert output == 'active'

--- a/tests/tests/tier0/bluechi-and-agent-on-same-machine/test_bluechi_and_agent_on_same_machine.py
+++ b/tests/tests/tier0/bluechi-and-agent-on-same-machine/test_bluechi_and_agent_on_same_machine.py
@@ -21,9 +21,9 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         manager_port=ctrl.config.port,
     )
     ctrl.create_file(node_foo_config.get_confd_dir(), node_foo_config.file_name, node_foo_config.serialize())
-    result, _ = ctrl.exec_run("systemctl start bluechi-agent")
+    result, _, wait_result = ctrl.systemctl_start_and_wait("bluechi-agent", 1)
     assert result == 0
-    assert ctrl.wait_for_unit_state_to_be("bluechi-agent", "active")
+    assert wait_result
 
     # bluechi-agent is running, check if it is connected
     result, output = ctrl.run_python(os.path.join("python", "is_node_connected.py"))

--- a/tests/tests/tier0/monitor-agent-loses-connection/test_monitor_agent_loses_connection.py
+++ b/tests/tests/tier0/monitor-agent-loses-connection/test_monitor_agent_loses_connection.py
@@ -20,9 +20,9 @@ def start_agent_in_ctrl_container(ctrl: BluechiControllerContainer):
         manager_port=ctrl.config.port,
     )
     ctrl.create_file(node_foo_config.get_confd_dir(), node_foo_config.file_name, node_foo_config.serialize())
-    result, _ = ctrl.exec_run("systemctl start bluechi-agent")
+    result, _, wait_result = ctrl.systemctl_start_and_wait("bluechi-agent", 1)
     assert result == 0
-    assert ctrl.wait_for_unit_state_to_be("bluechi-agent", "active")
+    assert wait_result
 
 
 def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):


### PR DESCRIPTION
In order to track memory leaks in various flows, adding an option to run integration tests with valgrind. 
If environment variable WITH_VALGRIND is set:

`$ WITH_VALGRIND=1 tmt run -v`

the bluechi-controller and bluechi-agent unit files will be configured to run the binaries via valgrind, and then the process will collect valgrind logs and will place them in the data directory of the test. 

In addition, if any memory leaks would be detected - the test will fail.

This PR works towards implementing #325 