### PR TITLE
remove sudo from tests readme for base image creation

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -163,7 +163,7 @@ From the root directory of the project run the following commands:
 ```bash
 # In order to build and directly push, login first
 buildah login -u="someuser" -p="topsecret" quay.io
-sudo PUSH_MANIFEST=yes bash build-scripts/build-push-containers.sh build_base
+PUSH_MANIFEST=yes bash build-scripts/build-push-containers.sh build_base
 
 # Only build locally
 bash build-scripts/build-push-containers.sh build_base


### PR DESCRIPTION
The tests/README.md instructs the codeowners how to build base images and push them to the registry. Specifically, the user is instructed to run:

`$ buildah login ...`

and then:

`$ sudo PUSH_MANIFEST=yes bash build-scripts...`

This does not work, since buildah logs in for the current user, but the base images are created by the build script for root user, thus eventually the push action fails.

No need to run the build script as root, removing the `sudo` statement