### PR TITLE
Enforce enabling tty for exec_run

### DIFF
--- a/tests/bluechi_test/container.py
+++ b/tests/bluechi_test/container.py
@@ -69,10 +69,10 @@ class BluechiContainer():
             self.container.stop(**kw_params)
         self.container.remove()
 
-    def exec_run(self, command: (Union[str, list[str]]), raw_output: bool = False) -> \
+    def exec_run(self, command: (Union[str, list[str]]), raw_output: bool = False, tty: bool = True) -> \
             Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
 
-        result, output = self.container.exec_run(command)
+        result, output = self.container.exec_run(command, tty=tty)
 
         if not raw_output and output:
             output = output.decode('utf-8').strip()


### PR DESCRIPTION
podman-py 4.7.0 changed backward compatibility in [1], so we need to
enforce enabling tty for exec_run to prevent having non-printable
characters in the stdout/stderr received from executed commands.

[1] https://github.com/containers/podman-py/issues/323

Signed-off-by: Martin Perina <mperina@redhat.com>
