### PR TITLE
Improve SPDX header checks

### DIFF
--- a/build-scripts/spdx-header-check.sh
+++ b/build-scripts/spdx-header-check.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 # Checked files regex
-CHECKED_FILES=".*\(\.c\|\.h\|\.py\|\.sh\|\.xml\|meson\.build\)"
+CHECKED_FILES=".*\(\.c\|\.h\|\.go\|\.py\|\.rs\|\.sh\|\.xml\|meson\.build\)"
 
 #
 # List of licenses which are OK when found in a source code

--- a/build-scripts/spdx-header-check.sh
+++ b/build-scripts/spdx-header-check.sh
@@ -1,43 +1,80 @@
 #!/usr/bin/bash -e
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+#
 # Checked files regex
+#
 CHECKED_FILES=".*\(\.c\|\.h\|\.go\|\.py\|\.rs\|\.sh\|\.xml\|meson\.build\)"
 
 #
-# List of licenses which are OK when found in a source code
+# List of licenses which are OK when found in the project except examples
 #
-APPROVED_LICENSES=""
 # Used for bluechi original code and in src/libbluechi/common/list.h
-APPROVED_LICENSES="${APPROVED_LICENSES} LGPL-2.1-or-later"
+MAIN_LICENSES="LGPL-2.1-or-later"
+
+#
+# List of licenses which are OK when found in the project examples
+#
 # Used for examples in doc/api-examples and doc/bluechi-examples
-APPROVED_LICENSES="${APPROVED_LICENSES} MIT-0"
+EXAMPLES_LICENSES="MIT-0"
 
-result=0
-found_files="
-    $(find -type f -regex ${CHECKED_FILES} \
-        -not -path './builddir/*' \
-        -not -path './subprojects/*')
-"
+#
+# List of files to check using the main project licenses
+#
+MAIN_FILES="$(find -type f \
+    -regex ${CHECKED_FILES} \
+    -not -path './builddir/*' \
+    -not -path './subprojects/*' \
+    -not -path './doc/*-examples/*')"
 
-for f in ${found_files} ; do
-    # scan for license only within the 1st 5 lines of each file
-    license_found=$(head -n 5 ${f} | grep -Po '.*SPDX-License-Identifier\: \K\S+' || echo "-1")
-    if [ "${license_found}" == "-1" ]; then
-        result=1
-        echo "File '${f}' does not contain SPDX header!"
-    else
-        valid_license=1
-        for l in ${APPROVED_LICENSES} ; do
-            if [ "${license_found}" == "$l" ] ; then
-                valid_license=0
+#
+# List of files to check using the examples licenses
+#
+EXAMPLES_FILES="$(find -type f \
+    -regex ${CHECKED_FILES} \
+    -path './doc/*-examples/*')"
+
+
+#
+# Iterate over files within a path and check the allowed licenses
+#
+# Parameters:
+#    files    - a list of files to check the license
+#    licences - a list of approved licenses
+#
+# Result:
+#    cl_result - 0 if all files contain valid license, otherwise 1
+#
+check_licenses() {
+    local files=$1
+    local licenses=$2
+    cl_result=0
+
+    for f in ${files} ; do
+        # scan for license only within the 1st 5 lines of each file
+        license_found=$(head -n 5 ${f} | grep -Po '.*SPDX-License-Identifier\: \K\S+' || echo "-1")
+        if [ "${license_found}" == "-1" ]; then
+            cl_result=1
+            echo "File '${f}' does not contain SPDX header!"
+        else
+            valid_license=1
+            for l in ${licenses} ; do
+                if [ "${license_found}" == "$l" ] ; then
+                    valid_license=0
+                fi
+            done
+            if [ "${valid_license}" == "1" ] ; then
+                cl_result=1
+                echo "File '${f}' contains unapproved license '${license_found}'"
             fi
-        done
-        if [ "${valid_license}" == "1" ] ; then
-            result=1
-            echo "File '${f}' contains unapproved license '${license_found}'"
         fi
-    fi
-done
+    done
+}
 
-exit ${result}
+
+check_licenses "${MAIN_FILES}" "${MAIN_LICENSES}"
+main_result=$cl_result
+check_licenses "${EXAMPLES_FILES}" "${EXAMPLES_LICENSES}"
+examples_result=$cl_result
+
+exit $((${main_result} | ${examples_result}))


### PR DESCRIPTION
- Check SPDX header for Golang and Rust examples
- Check separately for the main and examples licenses

Signed-off-by: Martin Perina <mperina@redhat.com>
