### PR TITLE
Fix missing symbol when renaming logging instance variable

### DIFF
--- a/tests/bluechi_test/container.py
+++ b/tests/bluechi_test/container.py
@@ -118,7 +118,7 @@ class BluechiContainer():
 
     def _is_unit_in_state(self, unit_name: str, expected_state: str) -> bool:
         latest_state = self.get_unit_state(unit_name)
-        logger.debug(f"Got state '{latest_state}' for unit {unit_name}")
+        LOGGER.debug(f"Got state '{latest_state}' for unit {unit_name}")
         return latest_state == expected_state
 
     def wait_for_unit_state_to_be(


### PR DESCRIPTION
Signed-off-by: Martin Perina <mperina@redhat.com>
