### PR TITLE
fix invalid read on disconnecting anonymous node

### DIFF
--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -947,10 +947,11 @@ static int node_disconnected(UNUSED sd_bus_message *message, void *userdata, UNU
 
         /* Remove anonymous nodes when they disconnect */
         if (node->name == NULL) {
+                bc_log_info("Anonymous node disconnected");
                 manager_remove_node(manager, node);
         } else {
-                /* Remove all jobs associated with the registered node that got
-                   disconnected. */
+                bc_log_infof("Node '%s' disconnected", node->name);
+                /* Remove all jobs associated with the registered node that got disconnected. */
                 if (!LIST_IS_EMPTY(manager->jobs)) {
                         Job *job = NULL;
                         Job *next_job = NULL;
@@ -963,12 +964,6 @@ static int node_disconnected(UNUSED sd_bus_message *message, void *userdata, UNU
                         }
                 }
                 node_unset_agent_bus(node);
-        }
-
-        if (node->name) {
-                bc_log_infof("Node '%s' disconnected", node->name);
-        } else {
-                bc_log_info("Anonymous node disconnected");
         }
 
         return 0;


### PR DESCRIPTION
Fixes: https://github.com/containers/bluechi/issues/591

When an anonymous node has been disconnected in the controller and the cleanup has been done, a log statement was made afterwards. This statement differed based on the node name. Since the node instance has been cleaned up (freed), but not set to NULL, valgrind reported this as an invalid read. Moved the log statements accordingly.