### PR TITLE
Get gcda and gcno files from containers.

### DIFF
--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -224,6 +224,7 @@ will be used during integration tests when creating code coverage report.
 %files coverage
 %license LICENSE
 %{_datadir}/bluechi-coverage/*.gcno
+%dir %{_localstatedir}/tmp/bluechi-coverage/
 %endif
 
 %prep
@@ -241,6 +242,10 @@ popd
 
 %install
 %meson_install
+
+%if 0%{?with_coverage}
+mkdir -p %{buildroot}/%{_localstatedir}/tmp/bluechi-coverage/
+%endif
 
 %if %{with_python}
 pushd src/bindings/python

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,9 @@ endif
 with_coverage = get_option('with_coverage')
 if with_coverage == 'true'
    add_project_arguments('-coverage', language : 'c')
+    add_project_arguments(
+    '-fprofile-dir=' + join_paths(get_option('prefix'), get_option('localstatedir'), 'tmp', 'bluechi-coverage'), 
+    language : 'c')
    add_project_link_arguments('-lgcov', language : 'c')
    # Coverage source code mapping files `*.gcno` are created as a part of the build for each `*.c` file, but it's
    # very hard to tell meson to install files, which are created as a side effect from the build, so it's easier

--- a/tests/bluechi_test/container.py
+++ b/tests/bluechi_test/container.py
@@ -63,6 +63,13 @@ class BluechiContainer():
 
         self.get_file(log_file, data_dir)
 
+    def gather_coverage(self, data_coverage_dir: str) -> None:
+        gcno_file_location = "/usr/share/bluechi-coverage/"
+        gcda_file_location = "/var/tmp/bluechi-coverage"
+
+        self.get_file(gcda_file_location, data_coverage_dir)
+        self.get_file(gcno_file_location, data_coverage_dir)
+
     def cleanup(self):
         if self.container.status == 'running':
             kw_params = {'timeout': 0}

--- a/tests/bluechi_test/fixtures.py
+++ b/tests/bluechi_test/fixtures.py
@@ -111,7 +111,7 @@ def bluechi_test(
         bluechi_ctrl_svc_port: str,
         tmt_test_data_dir: str,
         run_with_valgrind: bool,
-        run_with_coverage:bool):
+        run_with_coverage: bool):
 
     return BluechiTest(
         podman_client,
@@ -122,4 +122,4 @@ def bluechi_test(
         tmt_test_data_dir,
         run_with_valgrind,
         run_with_coverage,
-    )
+        )

--- a/tests/bluechi_test/fixtures.py
+++ b/tests/bluechi_test/fixtures.py
@@ -53,6 +53,13 @@ def run_with_valgrind() -> bool:
     return _get_env_value('WITH_VALGRIND', 0) == '1'
 
 
+@pytest.fixture(scope='session')
+def run_with_coverage() -> bool:
+    """Returns 1 if code coverage should be collected"""
+
+    return _get_env_value('WITH_COVERAGE', 0) == '1'
+
+
 def _get_env_value(env_var: str, default_value: str) -> str:
     value = os.getenv(env_var)
     if value is None:
@@ -103,7 +110,8 @@ def bluechi_test(
         bluechi_ctrl_host_port: str,
         bluechi_ctrl_svc_port: str,
         tmt_test_data_dir: str,
-        run_with_valgrind: bool):
+        run_with_valgrind: bool,
+        run_with_coverage:bool):
 
     return BluechiTest(
         podman_client,
@@ -113,4 +121,5 @@ def bluechi_test(
         bluechi_ctrl_svc_port,
         tmt_test_data_dir,
         run_with_valgrind,
+        run_with_coverage,
     )

--- a/tests/bluechi_test/test.py
+++ b/tests/bluechi_test/test.py
@@ -121,8 +121,9 @@ class BluechiTest():
                 node.gather_valgrind_logs(self.tmt_test_data_dir)
 
         self.gather_test_executor_logs()
+
     def gather_coverage(self, ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
-        logger.debug("Collecting coverage from all containers...")
+        LOGGER.debug("Collecting coverage from all containers...")
 
         data_coverage_dir = f"{self.tmt_test_data_dir}/bluechi-coverage/"
 

--- a/tests/containers/integration-test-local
+++ b/tests/containers/integration-test-local
@@ -1,6 +1,9 @@
 FROM quay.io/bluechi/integration-test-base:latest
 
+ARG with_coverage
+
 RUN mkdir -p /tmp/bluechi-rpms
+
 COPY ./bluechi-rpms /tmp/bluechi-rpms
 
 RUN dnf install --repo bluechi-rpms \
@@ -16,6 +19,14 @@ RUN dnf install --repo bluechi-rpms \
         bluechi-selinux \
         python3-bluechi \
         -y
+
+RUN if [ "$with_coverage" = "1" ]; then \
+        dnf install -y --repo bluechi-rpms \
+        --repofrompath bluechi-rpms,file:///tmp/bluechi-rpms/ \
+        --nogpgcheck \
+        --nodocs \
+        bluechi-coverage; \
+    fi
 
 RUN dnf -y clean all
 

--- a/tests/containers/integration-test-snapshot
+++ b/tests/containers/integration-test-snapshot
@@ -2,6 +2,8 @@ FROM quay.io/bluechi/integration-test-base:latest
 
 RUN dnf install -y dnf-plugin-config-manager
 
+ARG with_coverage
+
 RUN dnf copr enable -y @centos-automotive-sig/bluechi-snapshot
 
 RUN dnf install \
@@ -16,6 +18,13 @@ RUN dnf install \
         bluechi-selinux \
         python3-bluechi \
         -y
+
+RUN if [ "$with_coverage" = "1" ]; then \
+        dnf install \
+        --nogpgcheck \
+        --nodocs \
+        bluechi-coverage;  \
+    fi
 
 RUN dnf -y clean all
 

--- a/tests/scripts/tests-setup.sh
+++ b/tests/scripts/tests-setup.sh
@@ -7,7 +7,12 @@ if [ "$CONTAINER_USED" = "integration-test-snapshot" ]; then
    export ARCH="--arch=$(uname -m)"
 fi
 
-podman build $ARCH -f ./containers/$CONTAINER_USED -t $BLUECHI_IMAGE_NAME .
+BUILD_ARG=""
+if [ "$WITH_COVERAGE" == "1" ]; then
+    BUILD_ARG="--build-arg with_coverage=1"
+fi
+
+podman build $ARCH $BUILD_ARG -f ./containers/$CONTAINER_USED -t $BLUECHI_IMAGE_NAME .
 
 if [[ $? -ne 0 ]]; then
     exit 1


### PR DESCRIPTION
When running tmt gcda and gcno files are created. This files are necessary for later code coverage report creation. So before the container destroyed we need to extract this files to the local machine.

Related: https://github.com/containers/bluechi/issues/397