### PR TITLE
Rename bluechi RPM to bluechi-controller

### DIFF
--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -24,28 +24,38 @@ BuildRequires: systemd-devel
 BuildRequires: systemd-rpm-macros
 BuildRequires: golang-github-cpuguy83-md2man
 
+%description
+BlueChi is a systemd service controller for multi-nodes environements with a
+predefined number of nodes and with a focus on highly regulated environment
+such as those requiring functional safety (for example in cars).
+
+
+%package controller
+Summary:  BlueChi service controller
 Requires: systemd
 Recommends: bluechi-selinux
 
 Obsoletes: hirte < 0.6.0
 Provides: hirte = %{version}-%{release}
+Obsoletes: bluechi < 0.7.0
+Provides: bluechi = %{version}-%{release}
 
-%description
+%description controller
 BlueChi is a systemd service controller for multi-nodes environements with a
 predefined number of nodes and with a focus on highly regulated environment
 such as those requiring functional safety (for example in cars).
-This package contains the controller and command line tool.
+This package contains the controller service.
 
-%post
+%post controller
 %systemd_post bluechi-controller.service
 
-%preun
+%preun controller
 %systemd_preun bluechi-controller.service
 
-%postun
+%postun controller
 %systemd_postun_with_restart bluechi-controller.service
 
-%files
+%files controller
 %ghost %{_sysconfdir}/bluechi/controller.conf
 %dir %{_sysconfdir}/bluechi
 %dir %{_sysconfdir}/bluechi/controller.conf.d

--- a/tests/containers/integration-test-local
+++ b/tests/containers/integration-test-local
@@ -3,18 +3,20 @@ FROM quay.io/bluechi/integration-test-base:latest
 RUN mkdir -p /tmp/bluechi-rpms
 COPY ./bluechi-rpms /tmp/bluechi-rpms
 
-RUN dnf install -y --repo bluechi-rpms \
+RUN dnf install --repo bluechi-rpms \
         --repofrompath bluechi-rpms,file:///tmp/bluechi-rpms/ \
         --nogpgcheck \
         --nodocs \
-        bluechi \
-        bluechi-debuginfo \
+        bluechi-controller \
+        bluechi-controller-debuginfo \
         bluechi-agent \
         bluechi-agent-debuginfo \
         bluechi-ctl \
         bluechi-ctl-debuginfo \
         bluechi-selinux \
-        python3-bluechi && \
-    dnf -y clean all
+        python3-bluechi \
+        -y
+
+RUN dnf -y clean all
 
 CMD [ "/sbin/init" ]

--- a/tests/containers/integration-test-snapshot
+++ b/tests/containers/integration-test-snapshot
@@ -7,8 +7,8 @@ RUN dnf copr enable -y mperina/hirte-snapshot
 RUN dnf install \
         --nogpgcheck \
         --nodocs \
-        bluechi \
-        bluechi-debuginfo \
+        bluechi-controller \
+        bluechi-controller-debuginfo \
         bluechi-agent \
         bluechi-agent-debuginfo \
         bluechi-ctl \


### PR DESCRIPTION
Renames bluechi RPM to bluechi-controller, which better describes the
content of the package.

Signed-off-by: Martin Perina <mperina@redhat.com>
