### PR TITLE
fixed api description for register method

### DIFF
--- a/data/org.eclipse.bluechi.internal.Manager.xml
+++ b/data/org.eclipse.bluechi.internal.Manager.xml
@@ -3,7 +3,7 @@
 <node>
   <interface name="org.eclipse.bluechi.internal.Manager">
     <method name="Register">
-      <arg name="name" type="st" direction="in" />
+      <arg name="name" type="s" direction="in" />
     </method>
   </interface>
 </node>


### PR DESCRIPTION
Fixed a small error in the `Register` method of the internal Manager API. 