### PR TITLE
Containerize RPM build to ensure CentOS-Stream9 RPMs

### DIFF
--- a/Containerfile.bluechi-rpm-build
+++ b/Containerfile.bluechi-rpm-build
@@ -1,0 +1,4 @@
+FROM quay.io/bluechi/build-base:latest
+
+RUN dnf install --nodocs -y python3-devel && \
+    dnf -y clean all

--- a/Makefile.skipper
+++ b/Makefile.skipper
@@ -1,0 +1,5 @@
+rpm:
+	SKIP_GIT_CONFIG=yes SKIP_BUILDDEP=yes ARTIFACTS_DIR=./tests/bluechi-rpms/ ./build-scripts/build-rpm.sh
+
+clean-rpm:
+	rm -rf ./tests/bluechi-rpms/

--- a/build-scripts/build-srpm.sh
+++ b/build-scripts/build-srpm.sh
@@ -6,7 +6,9 @@ meson setup builddir
 VERSION="$(meson introspect --projectinfo builddir | jq -r '.version')"
 
 # Mark current directory as safe for git to be able to parse git hash
-git config --global --add safe.directory $(pwd)
+if [ "${SKIP_GIT_CONFIG}" != "yes" ]; then
+    git config --global --add safe.directory $(pwd)
+fi
 
 # Package release
 #

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -1,0 +1,3 @@
+build_container_image: bluechi-rpm-build
+make:
+  makefile: Makefile.skipper

--- a/tests/README.md
+++ b/tests/README.md
@@ -96,13 +96,16 @@ section.
 
 In the following steps BlueChi source codes are located in `~/bluechi` directory.
 
-Integration tests are expecting, that local BlueChi RPMs are located in `tests/bluechi-rpms` top level subdirectory, so BlueChi
-packages should be built using following commands:
+The integration tests expect that local BlueChi RPMs are located in `tests/bluechi-rpms` top level subdirectory.
+In addition, since the tests run in CentOS-Stream9 based containers the RPMs must also be built for CentOS-Stream9.
+To this end, a containerized build infrastructure is available.
+
+The containerized build infrastructure depends on [skipper](https://github.com/Stratoscale/skipper),
+installed via the [requirements.txt](./requirements.txt) file
 
 ```shell
-mkdir ~/bluechi/tests/bluechi-rpms
 cd ~/bluechi
-sudo ARTIFACTS_DIR=~/bluechi/tests/bluechi-rpms ./build-scripts/build-rpm.sh
+skipper make rpm
 ```
 
 When done it's required to create DNF repository from those RPMs:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,4 @@ pytest >= 7.3.1
 pytest-timeout >= 2.1.0
 podman >= 4.5.0
 flake8 >= 6.0.0
+strato-skipper >= 2.0.2


### PR DESCRIPTION
Add skipper environment configuration
Skip git config operation when running the containerized build
Add strato-skipper to the requirements.txt file
Update the tests README

Resolves: #535 