### PR TITLE
Move snapshot COPR repo under centos-sig-automotive group

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BlueChi
 
-[![Copr build status](https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/package/hirte/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/package/hirte/)
+[![Copr build status](https://copr.fedorainfracloud.org/coprs/g/centos-automotive-sig/bluechi-snapshot/package/bluechi/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/g/centos-automotive-sig/bluechi-snapshot/package/bluechi/)
 
 BlueChi (formerly know as hirte) is a systemd service controller intended for
 multi-node environments with a predefined number of nodes and with a focus on
@@ -22,11 +22,11 @@ to generate systemd service configuration to run a container via
 ### Testing
 
 RPM packages for the BlueChi project are available on
-[hirte-snapshot](https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/)
+[bluechi-snapshot](https://copr.fedorainfracloud.org/coprs/g/centos-automotive-sig/bluechi-snapshot/)
 COPR repo. To install BlueChi packages on your system please add that repo using:
 
 ```bash
-dnf copr enable mperina/hirte-snapshot
+dnf copr enable @centos-automotive-sig/bluechi-snapshot
 ```
 
 When done you can install relevant BlueChi packages using:

--- a/tests/README.md
+++ b/tests/README.md
@@ -74,7 +74,7 @@ tmt run
 ```
 
 This will use latest BlueChi packages from
-[hirte-snapshot](https://copr.fedorainfracloud.org/coprs/mperina/hirte-snapshot/) repository.
+[bluechi-snapshot](https://copr.fedorainfracloud.org/coprs/g/centos-automotive-sig/bluechi-snapshot/) repository.
 
 ## Running integration tests with memory leak detection
 

--- a/tests/containers/integration-test-snapshot
+++ b/tests/containers/integration-test-snapshot
@@ -2,7 +2,7 @@ FROM quay.io/bluechi/integration-test-base:latest
 
 RUN dnf install -y dnf-plugin-config-manager
 
-RUN dnf copr enable -y mperina/hirte-snapshot
+RUN dnf copr enable -y @centos-automotive-sig/bluechi-snapshot
 
 RUN dnf install \
         --nogpgcheck \


### PR DESCRIPTION
Moves bluechi snapshot builds from mperina/hirte-snapshot repo to
@centos-sig-automotive/bluechi-snapshot repo.

Signed-off-by: Martin Perina <mperina@redhat.com>
