### PR TITLE
Simplify installation of bluechi-coverage package in tests

### DIFF
--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -35,6 +35,10 @@ Summary:  BlueChi service controller
 Requires: systemd
 Recommends: bluechi-selinux
 
+%if 0%{?with_coverage}
+Requires: bluechi-coverage = %{version}-%{release}
+%endif
+
 Obsoletes: hirte < 0.6.0
 Provides: hirte = %{version}-%{release}
 Obsoletes: bluechi < 0.7.0
@@ -80,6 +84,10 @@ This package contains the controller service.
 Summary:  BlueChi service controller agent
 Requires: systemd
 Recommends: bluechi-selinux
+
+%if 0%{?with_coverage}
+Requires: bluechi-coverage = %{version}-%{release}
+%endif
 
 Obsoletes: hirte-agent < 0.6.0
 Provides: hirte-agent = %{version}-%{release}
@@ -175,6 +183,10 @@ semanage port -a -t bluechi_port_t -p tcp 842 2>/dev/null || semanage port -m -t
 %package ctl
 Summary:  BlueChi service controller command line tool
 Requires: %{name} = %{version}-%{release}
+
+%if 0%{?with_coverage}
+Requires: bluechi-coverage = %{version}-%{release}
+%endif
 
 Obsoletes: hirte-ctl < 0.6.0
 Provides: hirte-ctl = %{version}-%{release}

--- a/tests/containers/integration-test-local
+++ b/tests/containers/integration-test-local
@@ -1,7 +1,5 @@
 FROM quay.io/bluechi/integration-test-base:latest
 
-ARG with_coverage
-
 RUN mkdir -p /tmp/bluechi-rpms
 
 COPY ./bluechi-rpms /tmp/bluechi-rpms
@@ -19,14 +17,6 @@ RUN dnf install --repo bluechi-rpms \
         bluechi-selinux \
         python3-bluechi \
         -y
-
-RUN if [ "$with_coverage" = "1" ]; then \
-        dnf install -y --repo bluechi-rpms \
-        --repofrompath bluechi-rpms,file:///tmp/bluechi-rpms/ \
-        --nogpgcheck \
-        --nodocs \
-        bluechi-coverage; \
-    fi
 
 RUN dnf -y clean all
 

--- a/tests/containers/integration-test-snapshot
+++ b/tests/containers/integration-test-snapshot
@@ -2,8 +2,6 @@ FROM quay.io/bluechi/integration-test-base:latest
 
 RUN dnf install -y dnf-plugin-config-manager
 
-ARG with_coverage
-
 RUN dnf copr enable -y @centos-automotive-sig/bluechi-snapshot
 
 RUN dnf install \
@@ -18,13 +16,6 @@ RUN dnf install \
         bluechi-selinux \
         python3-bluechi \
         -y
-
-RUN if [ "$with_coverage" = "1" ]; then \
-        dnf install \
-        --nogpgcheck \
-        --nodocs \
-        bluechi-coverage;  \
-    fi
 
 RUN dnf -y clean all
 

--- a/tests/scripts/tests-setup.sh
+++ b/tests/scripts/tests-setup.sh
@@ -7,12 +7,7 @@ if [ "$CONTAINER_USED" = "integration-test-snapshot" ]; then
    export ARCH="--arch=$(uname -m)"
 fi
 
-BUILD_ARG=""
-if [ "$WITH_COVERAGE" == "1" ]; then
-    BUILD_ARG="--build-arg with_coverage=1"
-fi
-
-podman build $ARCH $BUILD_ARG -f ./containers/$CONTAINER_USED -t $BLUECHI_IMAGE_NAME .
+podman build $ARCH -f ./containers/$CONTAINER_USED -t $BLUECHI_IMAGE_NAME .
 
 if [[ $? -ne 0 ]]; then
     exit 1


### PR DESCRIPTION
When we build RPMs with coverage support (which we do only when we want
to generate code coverage report), it's easier to add bluechi-coverage
RPM as a dependency to other RPMs than passing coverage support to the
container file and installing bluechi-coverage RPM according to the
coverage support enablement.

Signed-off-by: Martin Perina <mperina@redhat.com>
