### PR TITLE
Remove integration tests specific network setup

### DIFF
--- a/tests/bluechi_test/fixtures.py
+++ b/tests/bluechi_test/fixtures.py
@@ -40,13 +40,6 @@ def bluechi_ctrl_svc_port() -> str:
 
 
 @pytest.fixture(scope='session')
-def bluechi_network_name() -> str:
-    """Returns the name of the network used for testing containers"""
-
-    return _get_env_value('BLUECHI_NETWORK_NAME', 'bluechi-test')
-
-
-@pytest.fixture(scope='session')
 def run_with_valgrind() -> bool:
     """Returns 1 if bluechi should be run with valgrind for memory management testing"""
 
@@ -106,7 +99,6 @@ def bluechi_node_default_config(bluechi_ctrl_svc_port: str):
 def bluechi_test(
         podman_client: PodmanClient,
         bluechi_image_id: str,
-        bluechi_network_name: str,
         bluechi_ctrl_host_port: str,
         bluechi_ctrl_svc_port: str,
         tmt_test_data_dir: str,
@@ -116,7 +108,6 @@ def bluechi_test(
     return BluechiTest(
         podman_client,
         bluechi_image_id,
-        bluechi_network_name,
         bluechi_ctrl_host_port,
         bluechi_ctrl_svc_port,
         tmt_test_data_dir,

--- a/tests/bluechi_test/test.py
+++ b/tests/bluechi_test/test.py
@@ -23,7 +23,6 @@ class BluechiTest():
             self,
             podman_client: PodmanClient,
             bluechi_image_id: str,
-            bluechi_network_name: str,
             bluechi_ctrl_host_port: str,
             bluechi_ctrl_svc_port: str,
             tmt_test_data_dir: str,
@@ -32,7 +31,6 @@ class BluechiTest():
 
         self.podman_client = podman_client
         self.bluechi_image_id = bluechi_image_id
-        self.bluechi_network_name = bluechi_network_name
         self.bluechi_ctrl_host_port = bluechi_ctrl_host_port
         self.bluechi_ctrl_svc_port = bluechi_ctrl_svc_port
         self.tmt_test_data_dir = tmt_test_data_dir
@@ -66,7 +64,6 @@ class BluechiTest():
                 image=self.bluechi_image_id,
                 detach=True,
                 ports={self.bluechi_ctrl_svc_port: self.bluechi_ctrl_host_port},
-                networks={self.bluechi_network_name: {}},
             )
             c.wait(condition="running")
 
@@ -83,7 +80,6 @@ class BluechiTest():
                     name=cfg.node_name,
                     image=self.bluechi_image_id,
                     detach=True,
-                    networks={self.bluechi_network_name: {}},
                 )
                 c.wait(condition="running")
 

--- a/tests/plans/tier0.fmf
+++ b/tests/plans/tier0.fmf
@@ -9,7 +9,6 @@ environment:
     CONTAINER_USED: integration-test-snapshot
     LOG_LEVEL: INFO
     MGR_PORT: 8420
-    TEST_NET_RANGE: 10.10.0.0/24
 prepare:
   - name: Set containers setup
     how: shell

--- a/tests/scripts/tests-setup.sh
+++ b/tests/scripts/tests-setup.sh
@@ -18,11 +18,6 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
-podman network exists bluechi-test
-if [[ $? -ne 0 ]]; then
-    podman network create --subnet $TEST_NET_RANGE bluechi-test
-fi
-
 if [ "$(systemctl --user is-active podman.socket)" != "active" ]; then
     echo "Integration tests requires access to podman using user socket"
     systemctl --user enable podman.socket


### PR DESCRIPTION
We were setting up specific network range for integration tests, but we
were not using it directly within any test. So we can remove that
specific network setup and rely on the default.

Signed-off-by: Martin Perina <mperina@redhat.com>
