### PR TITLE
Small integration tests improvements

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -70,7 +70,7 @@ Integration tests are executed with [tmt framework](https://github.com/teemtee/t
 To run integration tests please execute below command of the top level directory of this project:
 
 ```shell
-tmt run
+tmt run -v
 ```
 
 This will use latest BlueChi packages from
@@ -118,7 +118,7 @@ After that step integration tests can be executed using following command:
 
 ```shell
 cd ~/bluechi/tests
-tmt run -eCONTAINER_USED=integration-test-local
+tmt run -v -eCONTAINER_USED=integration-test-local
 ```
 
 ## Developing integration tests
@@ -140,7 +140,7 @@ More detailed information can be displayed by setting log level to `DEBUG`:
 
 ```shell
 cd ~/bluechi/tests
-tmt run -eLOG_LEVEL=DEBUG
+tmt run -v -eLOG_LEVEL=DEBUG
 ```
 
 ### Using python bindings in tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,14 +37,14 @@ dnf install \
 
 All required python packages are listed in the [requirements.txt](./requirements.txt) and can be installed using `pip`:
 
-```bash
+```shell
 pip install -U -r requirements.txt
 ```
 
 Instead of installing the required packages directly, it is recommended to create a virtual environment. For example,
 the following snippet uses the built-in [venv](https://docs.python.org/3/library/venv.html):
 
-```bash
+```shell
 python -m venv ~/bluechi-env
 source ~/bluechi-env/bin/activate
 pip install -U -r requirements.txt
@@ -128,7 +128,7 @@ tmt run -v -eCONTAINER_USED=integration-test-local
 [autopep8](https://pypi.org/project/autopep8/) is used to enforce a unified code style. The applied rules are defined in
 the [.pep8](./.pep8) file. All source files can be formatted via:
 
-```bash
+```shell
 # navigate into bluechi/tests directory
 autopep8 ./
 ```
@@ -188,13 +188,13 @@ The base images [build-base](./containers/build-base) and [integration-test-base
 
 Building for multiple architectures, the following packages are required:
 
-```bash
+```shell
 sudo dnf install -y podman buildah qemu-user-static
 ```
 
 From the root directory of the project run the following commands:
 
-```bash
+```shell
 # In order to build and directly push, login first
 buildah login -u="someuser" -p="topsecret" quay.io
 PUSH_MANIFEST=yes bash build-scripts/build-push-containers.sh build_base

--- a/tests/README.md
+++ b/tests/README.md
@@ -81,7 +81,7 @@ This will use latest BlueChi packages from
 To run integration tests with `valgrind`, set `WITH_VALGRIND` environment variable as follows:
 
 ```shell
-WITH_VALGRIND=1 tmt run -v
+tmt run -v -eWITH_VALGRIND=1
 ```
 
 If `valgrind` detects a memory leak in a test, the test will fail, and the logs will be found in the test `data` directory.

--- a/tests/plans/tier0.fmf
+++ b/tests/plans/tier0.fmf
@@ -5,10 +5,13 @@ discover:
 provision:
     how: local
 environment:
+    BLUECHI_CTRL_HOST_PORT: 8420
+    BLUECHI_CTRL_SVC_PORT: 8420
     BLUECHI_IMAGE_NAME: bluechi-image
     CONTAINER_USED: integration-test-snapshot
     LOG_LEVEL: INFO
-    MGR_PORT: 8420
+    WITH_COVERAGE: 0
+    WITH_VALGRIND: 0
 prepare:
   - name: Set containers setup
     how: shell


### PR DESCRIPTION
- Suggest to use -v option when running integration tests
- Use shell to indicate that code block should use shell syntax
- Fix inconsistencies in env variables for integration tests

Signed-off-by: Martin Perina <mperina@redhat.com>
