### PR TITLE
added option for building with static analysis

### DIFF
--- a/README.developer.md
+++ b/README.developer.md
@@ -5,15 +5,18 @@
   - [Environment Setup](#environment-setup)
     - [Prerequisites](#prerequisites)
     - [Dependencies Installation](#dependencies-installation)
+  - [Busctl](#busctl)
   - [Code Style](#code-style)
   - [Linting](#linting)
   - [Build](#build)
+    - [Build options](#build-options)
+    - [Bindings](#bindings)
   - [Debug](#debug)
-  - [Busctl](#busctl)
   - [Unit Tests](#unit-tests)
   - [Integration Tests](#integration-tests)
   - [Running](#running)
-    - [bluechi](#bluechi)
+    - [Assumed setup](#assumed-setup)
+    - [bluechi](#bluechi-controller)
     - [bluechi-agent](#bluechi-agent)
     - [bluechictl](#bluechictl)
 - [Documentation](#documentation)
@@ -182,6 +185,21 @@ After building, the following binaries are available:
 - `bluechi-proxy`: an internally used application to resolve cross-node dependencies
 - `bluechictl`: a helper (CLI) program to send an commands to the controller
 
+#### Build options
+
+BlueChi can be built with configurable options as listed in [meson_options.txt](./meson_options.txt). The value for
+those settings can either be changed directly in the file or via
+
+```bash
+# assuming an initial "meson setup builddir"
+meson configure -D<option-name>=<option-value>
+```
+
+Current options include:
+
+- `with_coverage`: This option ensures that BlueChi is built to collect coverage when running a BlueChi binary
+- `with_analyzer`: This option enables the [gcc option for static analysis](https://gcc.gnu.org/onlinedocs/gcc-13.2.0/gcc/Static-Analyzer-Options.html)
+
 #### Bindings
 
 Bindings for the D-Bus API of `BlueChi` are located in [src/bindings](./src/bindings/). Please refer to the
@@ -205,7 +223,7 @@ Rebuild the BlueChi project with debug symbols included:
 ```bash
 bluechi> make clean
 bluechi> meson install -C builddir --dest=bin
-bluechi> gdb --args ./builddir/bin/usr/local/bin/bluechi-controller -c /etc/bluechi/controller.conf
+bluechi> gdb --args ./builddir/bin/usr/local/libexec/bluechi-controller -c /etc/bluechi/controller.conf
 ```
 
 ### Unit tests

--- a/meson.build
+++ b/meson.build
@@ -24,21 +24,25 @@ systemd_dep = dependency('libsystemd')
 # Set option to use either the session or system D-Bus
 api_bus = get_option('api_bus')
 if api_bus == 'user'
-   common_cflags += '-DUSE_USER_API_BUS'
+  common_cflags += '-DUSE_USER_API_BUS'
+endif
+
+if get_option('with_analyzer')
+  add_project_arguments('-fanalyzer', language : 'c')
 endif
 
 # Set option to get coverage collection
 with_coverage = get_option('with_coverage')
 if with_coverage == 'true'
-   add_project_arguments('-coverage', language : 'c')
-    add_project_arguments(
+  add_project_arguments('-coverage', language : 'c')
+  add_project_arguments(
     '-fprofile-dir=' + join_paths(get_option('prefix'), get_option('localstatedir'), 'tmp', 'bluechi-coverage'), 
     language : 'c')
-   add_project_link_arguments('-lgcov', language : 'c')
-   # Coverage source code mapping files `*.gcno` are created as a part of the build for each `*.c` file, but it's
-   # very hard to tell meson to install files, which are created as a side effect from the build, so it's easier
-   # to use custom install script
-   meson.add_install_script('build-scripts/install-coverage.sh')
+  add_project_link_arguments('-lgcov', language : 'c')
+  # Coverage source code mapping files `*.gcno` are created as a part of the build for each `*.c` file, but it's
+  # very hard to tell meson to install files, which are created as a side effect from the build, so it's easier
+  # to use custom install script
+  meson.add_install_script('build-scripts/install-coverage.sh')
 endif
 
 # Build time configuration header file

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,4 +10,7 @@ option('with_coverage', type : 'combo',
     choices : ['true', 'false'], value : 'false',
     description : 'Add coverage collection')
 
+option('with_analyzer', type : 'boolean', value : 'false',
+    description : 'Add the gcc option -fanalyzer for static analysis')
+
 option('dbus-srv-user', type: 'string', description: 'The (existing) user which runs bluechi')


### PR DESCRIPTION
Related to: https://github.com/containers/bluechi/issues/604

Added the gcc option -fanalyzer as configurable meson option (default: false) to ensure higher code quality. Default is set to false and no integration into CI is done since it can also result in false-positives. Therefore, the developer has to decide which issue to tackle.