### PR TITLE
Add metrics start unit test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,6 +73,12 @@ jobs:
         with:
           name: rpm-artifacts
           path: 'tests/bluechi-rpms'
+      
+      - name: Check integration test IDs
+        run: |
+          cd tests
+          tmt test id --dry | grep "New id" && echo "Found integration tests with missing ID. Please generate Test-IDs." && exit 1
+          cd ..
 
       - name: Run integration tests
         run: |

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -44,6 +44,7 @@ BC_DEFAULT_HOST = "127.0.0.1"
 BC_DBUS_INTERFACE = "org.eclipse.bluechi"
 BC_OBJECT_PATH = "/org/eclipse/bluechi"
 BC_AGENT_DBUS_INTERFACE = "org.eclipse.bluechi.Agent"
+BC_METRICS_OBJECT_PATH = "/org/eclipse/bluechi/metrics"
 
 DBUS_PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
 
@@ -254,12 +255,8 @@ class Metrics(ApiBase):
     This interface is only available if the metrics have been enabled before via the Manager interface.
     """
 
-    def __init__(
-        self, metrics_path: ObjPath, bus: MessageBus = None, use_systembus=True
-    ) -> None:
-        super().__init__(BC_DBUS_INTERFACE, metrics_path, bus, use_systembus)
-
-        self.metrics_path = metrics_path
+    def __init__(self, bus: MessageBus = None, use_systembus=True) -> None:
+        super().__init__(BC_DBUS_INTERFACE, BC_METRICS_OBJECT_PATH, bus, use_systembus)
 
     def on_start_unit_job_metrics(
         self,

--- a/src/bindings/python/templates/consts.tmpl
+++ b/src/bindings/python/templates/consts.tmpl
@@ -5,5 +5,6 @@ BC_DEFAULT_HOST = "127.0.0.1"
 BC_DBUS_INTERFACE = "org.eclipse.bluechi"
 BC_OBJECT_PATH = "/org/eclipse/bluechi"
 BC_AGENT_DBUS_INTERFACE = "org.eclipse.bluechi.Agent"
+BC_METRICS_OBJECT_PATH = "/org/eclipse/bluechi/metrics"
 
 DBUS_PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"

--- a/src/bindings/python/templates/metrics.tmpl
+++ b/src/bindings/python/templates/metrics.tmpl
@@ -4,10 +4,8 @@ class Metrics(ApiBase):
     {{ iface_doc }}
     """
     
-    def __init__(self, metrics_path: ObjPath, bus: MessageBus = None, use_systembus=True) -> None:
-        super().__init__(BC_DBUS_INTERFACE, metrics_path, bus, use_systembus)
-
-        self.metrics_path = metrics_path
+    def __init__(self, bus: MessageBus = None, use_systembus=True) -> None:
+        super().__init__(BC_DBUS_INTERFACE, BC_METRICS_OBJECT_PATH, bus, use_systembus)
 
     {%- include 'skeleton_method.tmpl' %}
     {%- include 'skeleton_signal.tmpl' %}

--- a/tests/tests/tier0/metrics-start-unit/main.fmf
+++ b/tests/tests/tier0/metrics-start-unit/main.fmf
@@ -1,0 +1,3 @@
+summary: Test if start unit metric signals are emitted when metrics are enabled and
+    a unit is started
+id: dd1d3f60-b313-41a0-b9cf-2ba223ee792f

--- a/tests/tests/tier0/metrics-start-unit/python/start_unit_job_metrics.py
+++ b/tests/tests/tier0/metrics-start-unit/python/start_unit_job_metrics.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from bluechi.api import Manager, Metrics, Node, UInt64
+from dasbus.loop import EventLoop
+
+
+class TestStartUnitJobMetrics(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.loop = EventLoop()
+
+        self.mgr = Manager()
+        self.mgr.enable_metrics()
+
+        self.metrics = Metrics()
+
+        self.received_node_name = ""
+        self.received_job_id = ""
+        self.received_unit_name = ""
+        self.received_job_time = -1
+        self.received_start_time = -1
+
+    def test_start_unit_job_metrics(self):
+        def on_start_metrics(node_name: str,
+                             job_id: str,
+                             unit: str,
+                             job_time_micros: UInt64,
+                             start_time: UInt64) -> None:
+            self.received_node_name = node_name
+            self.received_job_id = job_id
+            self.received_unit_name = unit
+            self.received_job_time = job_time_micros
+            self.received_start_time = start_time
+
+            self.loop.quit()
+
+        self.metrics.on_start_unit_job_metrics(on_start_metrics)
+
+        n = Node("node-foo")
+        assert n.start_unit("simple.service", "replace") != ""
+
+        self.loop.run()
+
+        assert self.received_node_name == "node-foo"
+        assert self.received_job_id != ""
+        assert self.received_unit_name == "simple.service"
+        assert self.received_job_time >= 0
+        assert self.received_start_time >= 0
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/metrics-start-unit/systemd/simple.service
+++ b/tests/tests/tier0/metrics-start-unit/systemd/simple.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Just sleeping
+
+[Service]
+Type=simple
+ExecStart=/bin/true
+RemainAfterExit=yes

--- a/tests/tests/tier0/metrics-start-unit/test_metrics_start_unit.py
+++ b/tests/tests/tier0/metrics-start-unit/test_metrics_start_unit.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+from typing import Dict
+
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.test import BluechiTest
+
+
+node_foo_name = "node-foo"
+simple_service = "simple.service"
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+    foo = nodes[node_foo_name]
+
+    source_dir = "systemd"
+    target_dir = os.path.join("/", "etc", "systemd", "system")
+    foo.copy_systemd_service(simple_service, source_dir, target_dir)
+    assert foo.wait_for_unit_state_to_be(simple_service, "inactive")
+
+    result, output = ctrl.run_python(os.path.join("python", "start_unit_job_metrics.py"))
+    if result != 0:
+        raise Exception(output)
+
+
+def test_metrics_start_unit(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiNodeConfig):
+
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = node_foo_name
+
+    bluechi_ctrl_default_config.allowed_node_names = [node_foo_name]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_node_config(node_foo_cfg)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Fixes: https://github.com/containers/bluechi/issues/415
Added an integration test to validate that collecting metrics for the start time of a unit works as expected.

In addition, this PR adds a step for checking integration test IDs so that every integration test is guaranteed to have an ID linked to it. 