### PR TITLE
Introduce clang/LLVM support

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,6 +19,15 @@ jobs:
         with:
           submodules: 'true'
 
+      - name: Building BlueChi (with clang/LLVM)
+        run: |
+          export CC=clang
+          export CXX=clang++
+          meson setup builddir
+          meson configure builddir
+          meson compile -C builddir
+          rm -rf builddir
+
       - name: Building BlueChi
         run: |
           meson setup builddir

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@ project(
   ]
 )
 
-test_cflags = [ '-Wno-cast-function-type' ]
+test_cflags = [ '-Wno-cast-function-type', '-Wno-unknown-warning-option' ]
 
 cc = meson.get_compiler('c')
 common_cflags = cc.get_supported_arguments(test_cflags)

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -1384,7 +1384,7 @@ static char *get_dep_unit(const char *unit_name) {
 }
 
 static int start_dep_callback(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
-        _cleanup_systemd_request_ SystemdRequest *req = userdata;
+        UNUSED _cleanup_systemd_request_ SystemdRequest *req = userdata;
 
         if (sd_bus_message_is_method_error(m, NULL)) {
                 bc_log_errorf("Error starting dep service: %s", sd_bus_message_get_error(m)->message);
@@ -1438,7 +1438,7 @@ static int agent_method_start_dep(sd_bus_message *m, void *userdata, UNUSED sd_b
  *************************************************************************/
 
 static int stop_dep_callback(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
-        _cleanup_systemd_request_ SystemdRequest *req = userdata;
+        UNUSED _cleanup_systemd_request_ SystemdRequest *req = userdata;
 
         if (sd_bus_message_is_method_error(m, NULL)) {
                 bc_log_errorf("Error stopping dep service: %s", sd_bus_message_get_error(m)->message);
@@ -2497,7 +2497,7 @@ static bool agent_reconnect(Agent *agent) {
 }
 
 static int stop_proxy_callback(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
-        _cleanup_systemd_request_ SystemdRequest *req = userdata;
+        UNUSED _cleanup_systemd_request_ SystemdRequest *req = userdata;
 
         if (sd_bus_message_is_method_error(m, NULL)) {
                 bc_log_errorf("Error stopping proxy service: %s", sd_bus_message_get_error(m)->message);

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -556,7 +556,7 @@ static int manager_method_list_units_encode_reply(ListUnitsRequest *req, sd_bus_
 
 static void manager_method_list_units_done(ListUnitsRequest *req) {
         /* All sub_req-requests are done, collect results and free when done */
-        _cleanup_list_unit_request_ ListUnitsRequest *free_me = req;
+        UNUSED _cleanup_list_unit_request_ ListUnitsRequest *free_me = req;
 
         _cleanup_sd_bus_message_ sd_bus_message *reply = NULL;
         int r = sd_bus_message_new_method_return(req->request_message, &reply);

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -1759,8 +1759,6 @@ int node_add_proxy_dependency(Node *node, const char *unit_name) {
 
 int node_remove_proxy_dependency(Node *node, const char *unit_name) {
         ProxyDependency *dep = NULL;
-        _cleanup_free_ char *unit_name_copy = NULL;
-
         dep = node_find_proxy_dependency(node, unit_name);
         if (!dep) {
                 return -ENOENT;

--- a/src/manager/proxy_monitor.c
+++ b/src/manager/proxy_monitor.c
@@ -202,7 +202,6 @@ static int proxy_monitor_send_state_changed_callback(
 int proxy_monitor_send_state_changed(
                 ProxyMonitor *monitor, const char *active_state, const char *substate, const char *reason) {
         _cleanup_sd_bus_error_ sd_bus_error error = SD_BUS_ERROR_NULL;
-        _cleanup_sd_bus_message_ sd_bus_message *message = NULL;
         int r = sd_bus_call_method_async(
                         monitor->node->agent_bus,
                         NULL,
@@ -239,7 +238,6 @@ static int proxy_monitor_send_new_callback(sd_bus_message *m, void *userdata, UN
 
 int proxy_monitor_send_new(ProxyMonitor *monitor, const char *reason) {
         _cleanup_sd_bus_error_ sd_bus_error error = SD_BUS_ERROR_NULL;
-        _cleanup_sd_bus_message_ sd_bus_message *message = NULL;
         int r = sd_bus_call_method_async(
                         monitor->node->agent_bus,
                         NULL,
@@ -274,7 +272,6 @@ static int proxy_monitor_send_removed_callback(sd_bus_message *m, void *userdata
 
 int proxy_monitor_send_removed(ProxyMonitor *monitor, const char *reason) {
         _cleanup_sd_bus_error_ sd_bus_error error = SD_BUS_ERROR_NULL;
-        _cleanup_sd_bus_message_ sd_bus_message *message = NULL;
         int r = sd_bus_call_method_async(
                         monitor->node->agent_bus,
                         NULL,


### PR DESCRIPTION
Some changes were made to account for unused variables the LLVM toolchain found, it also did not recognize the gcc-specific warnings turned off by the pragma statements, so tell clang to just ignore those.