### PR TITLE
Introduce clang/LLVM to build-base

### DIFF
--- a/tests/containers/build-base
+++ b/tests/containers/build-base
@@ -8,6 +8,7 @@ RUN dnf install -y dnf-plugin-config-manager && \
     dnf update --refresh --nodocs -y && \
     dnf install --nodocs \
         bzip2 \
+        clang \
         clang-tools-extra \
         codespell \
         createrepo_c \


### PR DESCRIPTION
clang/LLVM is an alternate C compiler that is commonly used in Linux and other operating systems. It has useful tooling and helps keep the code portable. Other projects that use this toolchain include Chromium, Linux kernel and virtually all Rust projects use LLVM backend.