### PR TITLE
enable -fanalyzers malloc leak detection

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,6 @@ endif
 
 if get_option('with_analyzer')
   add_project_arguments('-fanalyzer', language : 'c')
-  add_project_arguments('-Wno-analyzer-malloc-leak', language : 'c')
 endif
 
 # Set option to get coverage collection


### PR DESCRIPTION
Previously, the malloc leak detection of the `-fanalyzer` option has been disabled. This PR enables it since we no longer use that option in RPM builds (which raised multiple potentially found leaks). #618 