### PR TITLE
re-enable proxy service fails on execstart integration test

### DIFF
--- a/systemd-units/bluechi-dep@.service
+++ b/systemd-units/bluechi-dep@.service
@@ -9,6 +9,13 @@ BindsTo=%i.service
 After=%i.service
 
 [Service]
-ExecStart=true
 Type=oneshot
+
+# Use of ExecStop= here instead of ExecStart= since there is a  
+# potential race condition for ExecStart= that results in the
+# bluechi-dep@.service to transition in a failed state. 
+# This can happen when the target service transitioned to a failed 
+# state and the command in ExecStart= is still running. Then 
+# systemd will send a SIGTERM, failing the dep service as well.
+ExecStop=true
 RemainAfterExit=yes

--- a/tests/bluechi_test/container.py
+++ b/tests/bluechi_test/container.py
@@ -125,7 +125,7 @@ class BluechiContainer():
 
     def _is_unit_in_state(self, unit_name: str, expected_state: str) -> bool:
         latest_state = self.get_unit_state(unit_name)
-        LOGGER.debug(f"Got state '{latest_state}' for unit {unit_name}")
+        LOGGER.info(f"Got state '{latest_state}' for unit {unit_name}")
         return latest_state == expected_state
 
     def wait_for_unit_state_to_be(
@@ -134,7 +134,6 @@ class BluechiContainer():
             expected_state: str,
             timeout: float = 5.0,
             delay: float = 0.5) -> bool:
-        latest_state = ""
 
         if self._is_unit_in_state(unit_name, expected_state):
             return True
@@ -145,8 +144,7 @@ class BluechiContainer():
             if self._is_unit_in_state(unit_name, expected_state):
                 return True
 
-        LOGGER.error(f"Timeout while waiting for '{unit_name}' to reach state '{expected_state}'. \
-              Latest state: '{latest_state}'")
+        LOGGER.error(f"Timeout while waiting for '{unit_name}' to reach state '{expected_state}'.")
         return False
 
     def enable_valgrind(self) -> None:

--- a/tests/tests/tier0/proxy-service-fails-on-execstart/systemd/simple.service
+++ b/tests/tests/tier0/proxy-service-fails-on-execstart/systemd/simple.service
@@ -3,5 +3,5 @@ Description=Attempting to just sleep, but fail
 
 [Service]
 Type=simple
-ExecStart=exit 1
+ExecStart=/bin/false
 RemainAfterExit=yes

--- a/tests/tests/tier0/proxy-service-fails-on-execstart/test_proxy_service_fails_on_execstart.py
+++ b/tests/tests/tier0/proxy-service-fails-on-execstart/test_proxy_service_fails_on_execstart.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
-import pytest
 from typing import Dict
 
 from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
@@ -41,7 +40,6 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     verify_proxy_start_failed(foo, bar)
 
 
-@pytest.mark.skip(reason="Currently flaky. Tracked in https://github.com/containers/bluechi/issues/320. ")
 def test_proxy_service_fails_on_execstart(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,


### PR DESCRIPTION
Fixes: #320 

This PR re-enables the - currently - skipped integration test for the proxy service where the `ExecStart` returns exit code 1. 
Running it locally a few times it works fine, so lets enable it again and see if the flakiness is gone. 