### PR TITLE
switch to hashmap.c in eclipse-bluechi organization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "subprojects/hashmap.c"]
 	path = subprojects/hashmap.c
-	url = https://github.com/engelmi/hashmap.c.git
+	url = https://github.com/eclipse-bluechi/hashmap.c.git
 [submodule "subprojects/inih"]
 	path = subprojects/inih
 	url = https://github.com/benhoyt/inih.git

--- a/subprojects/README.md
+++ b/subprojects/README.md
@@ -5,8 +5,8 @@ project using mesons [subproject feature](https://mesonbuild.com/Subprojects.htm
 
 Currently BlueChi uses the following external projects:
 
-- [hashmap.c](https://github.com/engelmi/hashmap.c.git)
-- [inih](https://github.com/benhoyt/inih.git)
+- [hashmap.c](https://github.com/eclipse-bluechi/hashmap.c)
+- [inih](https://github.com/benhoyt/inih)
 
 Unfortunately, `hashmap.c` doesn't provide a `meson.build` file and patching on the fly would result in uncommitted
 changes. Because of that a fork has been created containing the necessary `meson.build` and is used for now.


### PR DESCRIPTION
After setting up [hashmap.c](https://github.com/eclipse-bluechi/hashmap.c) in the `eclipse-bluechi` organization as a mirror of [tidwall/hashmap.c](https://github.com/tidwall/hashmap.c), we can switch from using a private fork to using the organization repo. 