### PR TITLE
graceful node shutdown when manager destroyed

### DIFF
--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -83,9 +83,11 @@ void manager_unref(Manager *manager) {
         Node *node = NULL;
         Node *next_node = NULL;
         LIST_FOREACH_SAFE(nodes, node, next_node, manager->nodes) {
+                node_shutdown(node);
                 node_unref(node);
         }
         LIST_FOREACH_SAFE(nodes, node, next_node, manager->anonymous_nodes) {
+                node_shutdown(node);
                 node_unref(node);
         }
 

--- a/src/manager/node.h
+++ b/src/manager/node.h
@@ -21,6 +21,8 @@ struct AgentRequest {
         free_func_t free_userdata;
         agent_request_response_t cb;
 
+        bool is_cancelled;
+
         LIST_FIELDS(AgentRequest, outstanding_requests);
 };
 
@@ -28,6 +30,8 @@ AgentRequest *agent_request_ref(AgentRequest *req);
 void agent_request_unref(AgentRequest *req);
 
 int agent_request_start(AgentRequest *req);
+
+int agent_request_cancel(AgentRequest *r);
 
 struct Node {
         int ref_count;
@@ -54,11 +58,14 @@ struct Node {
 
         struct hashmap *unit_subscriptions;
         time_t last_seen;
+
+        bool is_shutdown;
 };
 
 Node *node_new(Manager *manager, const char *name);
 Node *node_ref(Node *node);
 void node_unref(Node *node);
+void node_shutdown(Node *node);
 
 const char *node_get_status(Node *node);
 

--- a/tests/bluechi_test/container.py
+++ b/tests/bluechi_test/container.py
@@ -148,11 +148,11 @@ class BluechiContainer():
         return False
 
     def enable_valgrind(self) -> None:
-        self.exec_run(f"sed -i '/ExecStart=/c\\ExecStart=/usr/bin/valgrind --leak-check=yes "
+        self.exec_run(f"sed -i '/ExecStart=/c\\ExecStart=/usr/bin/valgrind -s --leak-check=yes "
                       f"--log-file={valgrind_log_path_controller} /usr/libexec/bluechi-controller' "
                       f"/usr/lib/systemd/system/bluechi-controller.service")
-        self.exec_run(f"sed -i '/ExecStart=/c\\ExecStart=/usr/bin/valgrind --leak-check=yes "
-                      f"--log-file={valgrind_log_path_controller} /usr/libexec/bluechi-agent' "
+        self.exec_run(f"sed -i '/ExecStart=/c\\ExecStart=/usr/bin/valgrind -s --leak-check=yes "
+                      f"--log-file={valgrind_log_path_agent} /usr/libexec/bluechi-agent' "
                       f"/usr/lib/systemd/system/bluechi-agent.service")
         self.exec_run("mkdir -p /var/log/valgrind")
         self.exec_run("systemctl daemon-reload")


### PR DESCRIPTION
Added graceful node_shutdown function that is called before node_unref, which goes over outstanding requests and cancels them.

This fixes a memory leak when bluechi-controller service is stopped via bluechi-controller itself

Fixes #578 