### PR TITLE
changed Conflicts= to be not supported in documentation

### DIFF
--- a/doc/docs/cross_node_dependencies/proxy_services.md
+++ b/doc/docs/cross_node_dependencies/proxy_services.md
@@ -63,7 +63,7 @@ Based on systemd's mapping table for [properties to their inverses](https://www.
 | `PartOf=`  | no |
 | `BindsTo=`  | yes |
 | `Requisite=`  | yes |
-| `Conflicts=`  | yes |
+| `Conflicts=`  | no |
 | `PropagatesReloadTo=`  | no |
 | `ReloadPropagatedFrom=`  | no |
 


### PR DESCRIPTION
[Conflicts=](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Conflicts=) is also not supported by Proxy Services. This PR updates the documentation accordingly. 