### PR TITLE
Add integration test unsubscribe

### DIFF
--- a/src/manager/monitor.c
+++ b/src/manager/monitor.c
@@ -7,7 +7,7 @@
 #include "node.h"
 
 Subscription *subscription_new(const char *node) {
-        static uint32_t next_id = 0;
+        static uint32_t next_id = 1;
 
         _cleanup_subscription_ Subscription *subscription = malloc0(sizeof(Subscription));
         if (subscription == NULL) {
@@ -349,7 +349,7 @@ static Subscription *monitor_find_subscription(Monitor *monitor, uint32_t sub_id
 static int monitor_method_unsubscribe(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
         Monitor *monitor = userdata;
         Manager *manager = monitor->manager;
-        const uint32_t sub_id = 0;
+        uint32_t sub_id = 0;
 
         int r = sd_bus_message_read(m, "u", &sub_id);
         if (r < 0) {
@@ -363,7 +363,7 @@ static int monitor_method_unsubscribe(sd_bus_message *m, void *userdata, UNUSED 
         Subscription *sub = monitor_find_subscription(monitor, sub_id);
         if (sub == NULL) {
                 return sd_bus_reply_method_errorf(
-                                m, SD_BUS_ERROR_FAILED, "Subscription is not found: %s", strerror(-r));
+                                m, SD_BUS_ERROR_FAILED, "Subscription '%d' is not found", sub_id);
         }
 
         manager_remove_subscription(manager, sub);

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -1561,7 +1561,7 @@ static void node_send_agent_unsubscribe(Node *node, const char *unit) {
 
         int r = send_agent_simple_message(node, "Unsubscribe", unit);
         if (r < 0) {
-                bc_log_error("Failed to subscribe w/ agent");
+                bc_log_error("Failed to unsubscribe w/ agent");
         }
 }
 

--- a/tests/bluechi_test/util.py
+++ b/tests/bluechi_test/util.py
@@ -43,4 +43,4 @@ def assemble_bluechi_proxy_service_name(node_name: str, unit_name: str) -> str:
 def get_random_name(name_length: int) -> str:
     # choose from all lowercase letter
     letters = string.ascii_lowercase
-    return ''.join(random.choice(letters) for i in range(name_length))
+    return ''.join(random.choice(letters) for _ in range(name_length))

--- a/tests/tests/tier0/monitor-unsubscribe/main.fmf
+++ b/tests/tests/tier0/monitor-unsubscribe/main.fmf
@@ -1,0 +1,2 @@
+summary: Test if a subscription on a monitor can be created and closed successfully
+id: 219ae7cf-7be1-4f93-bd1f-6844e464e273

--- a/tests/tests/tier0/monitor-unsubscribe/python/unsubscribe-automatically.py
+++ b/tests/tests/tier0/monitor-unsubscribe/python/unsubscribe-automatically.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from dasbus.loop import EventLoop
+
+from bluechi.api import Manager, Monitor, Node
+
+
+node_name_foo = "node-foo"
+service_simple = "simple.service"
+
+
+class TestUnsubscribe(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.loop = EventLoop()
+        self.mgr = Manager()
+        monitor_path = self.mgr.create_monitor()
+        self.monitor = Monitor(monitor_path=monitor_path)
+
+        self.sub_id = -1
+        self.unsubscribe_ex = None
+
+        def on_unit_removed(node: str, unit: str, reason: str) -> None:
+            # catch exception if raised, otherwise it'll prevent the loop quit
+            # and result in a timeout. assert on the exception later.
+            try:
+                self.monitor.unsubscribe(self.sub_id)
+            except Exception as ex:
+                self.unsubscribe_ex = Exception(f"Failed to unsubscribe '{self.sub_id}', got exception: {ex}")
+            self.loop.quit()
+
+        self.monitor.on_unit_removed(on_unit_removed)
+
+    def test_unsubscribe(self):
+
+        node_foo = Node(node_name_foo)
+
+        # create subscription, start unit and run event loop till removed signal is received
+        self.sub_id = self.monitor.subscribe(node_name_foo, service_simple)
+        assert node_foo.start_unit(service_simple, "replace") != ""
+        self.loop.run()
+
+        assert self.unsubscribe_ex is None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/monitor-unsubscribe/systemd/simple.service
+++ b/tests/tests/tier0/monitor-unsubscribe/systemd/simple.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Just being true once
+
+[Service]
+Type=simple
+ExecStart=/bin/true

--- a/tests/tests/tier0/monitor-unsubscribe/test_monitor_unsubscribe.py
+++ b/tests/tests/tier0/monitor-unsubscribe/test_monitor_unsubscribe.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+
+
+node_name_foo = "node-foo"
+service_simple = "simple.service"
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+
+    nodes[node_name_foo].copy_systemd_service(
+        service_simple, "systemd", os.path.join("/", "etc", "systemd", "system"))
+    assert nodes[node_name_foo].wait_for_unit_state_to_be(service_simple, "inactive")
+
+    result, output = ctrl.run_python(os.path.join("python", "unsubscribe-automatically.py"))
+    if result != 0:
+        raise Exception(output)
+
+
+def test_monitor_unsubscribe(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiNodeConfig):
+
+    bluechi_node_default_config.node_name = node_name_foo
+    bluechi_ctrl_default_config.allowed_node_names = [bluechi_node_default_config.node_name]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_node_config(bluechi_node_default_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Fixes: #413 

This PR introduces an integration test for removing an existing subscription. It also fixes a bug in the `unsubscribe` method where the subscription ID variable wasn't set when reading the value from the message due to a `const` qualifier. 