### PR TITLE
Move version to dedicated script

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -22,9 +22,10 @@ actions:
     - bash -c './build-scripts/create-spec.sh'
 
   get-current-version:
-    - bash -c './build-scripts/get-version.sh'
+    - bash -c './build-scripts/version.sh'
 
   create-archive:
+    - bash -c 'meson setup builddir 1>&2'
     - bash -c './build-scripts/create-archive.sh'
     - bash -c 'echo bluechi-$PACKIT_PROJECT_VERSION.tar.gz'
 

--- a/build-scripts/create-spec.sh
+++ b/build-scripts/create-spec.sh
@@ -1,18 +1,10 @@
 #!/bin/bash -xe
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-VERSION="$($(dirname "$(readlink -f "$0")")/get-version.sh)"
+VERSION_SCRIPT=$(dirname "$(readlink -f "$0")")/version.sh
 
-# Mark current directory as safe for git to be able to parse git hash
-git config --global --add safe.directory $(pwd)
-
-# Package release
-#
-# Use following for official releases
-#RELEASE="1"
-# Use following for nightly builds
-RELEASE="0.$(date +%04Y%02m%02d%02H%02M).git$(git rev-parse --short ${GITHUB_SHA:-HEAD})"
-
+VERSION="$(${VERSION_SCRIPT} short)"
+RELEASE="$(${VERSION_SCRIPT} release)"
 
 # Set version and release
 sed \

--- a/build-scripts/get-version.sh
+++ b/build-scripts/get-version.sh
@@ -1,8 +1,0 @@
-#!/bin/bash -e
-# SPDX-License-Identifier: LGPL-2.1-or-later
-
-# Parse package version from the project
-meson setup builddir 1>&2
-VERSION="$(meson introspect --projectinfo builddir | jq -r '.version')"
-
-echo ${VERSION}

--- a/build-scripts/version.sh
+++ b/build-scripts/version.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+VERSION=0.6.0
+IS_RELEASE=false
+
+function short(){
+    echo ${VERSION}
+}
+
+function long(){
+    echo "$(short)-$(release)"
+}
+
+function release(){
+    # Package release
+
+    if [ $IS_RELEASE = true ]; then
+        # Used for official releases. Increment if necessary
+        RELEASE="1"
+    else
+        # Mark current directory as safe for git to be able to parse git hash
+        git config --global --add safe.directory $(pwd)
+
+        # Used for nightly builds
+        RELEASE="0.$(date +%04Y%02m%02d%02H%02M).git$(git rev-parse --short ${GITHUB_SHA:-HEAD})"
+    fi
+    echo $RELEASE
+}
+
+[ -z $1 ] && short || $1

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@
 project(
   'bluechi',
   'c',
-  version: '0.6.0',
+  version: run_command(join_paths(meson.current_source_dir(), 'build-scripts', 'version.sh'), ' short', check: true).stdout().strip(),
   license: 'LGPL-2.1-or-later',
   default_options: [
     'c_std=gnu17',     # Adds "-std=gnu17".  Includes GNU 17 extensions.
@@ -55,7 +55,10 @@ prefixdir = get_option('prefix')
 
 conf.set_quoted('CONFIG_H_SYSCONFDIR', join_paths(prefixdir, get_option('sysconfdir')))
 conf.set_quoted('CONFIG_H_DATADIR', join_paths(prefixdir, get_option('datadir')))
-conf.set_quoted('CONFIG_H_BC_VERSION', meson.project_version())
+conf.set_quoted('CONFIG_H_BC_VERSION', run_command(
+    join_paths(meson.current_source_dir(), 'build-scripts', 'version.sh'), ' long', check: true
+  ).stdout().strip()
+)
 
 config_h = configure_file(
         output : 'config.h',

--- a/src/agent/main.c
+++ b/src/agent/main.c
@@ -77,7 +77,7 @@ static int get_opts(int argc, char *argv[]) {
                         return 1;
 
                 case ARG_VERSION_SHORT:
-                        printf("%s\n", CONFIG_H_BC_VERSION);
+                        printf("bluechi-agent version %s\n", CONFIG_H_BC_VERSION);
                         return 1;
 
                 case ARG_NAME_SHORT:

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -751,7 +751,7 @@ int client_call_manager(Client *client) {
                         return -EINVAL;
                 }
         } else if (streq(client->op, "version")) {
-                printf("%s\n", CONFIG_H_BC_VERSION);
+                printf("bluechictl version %s\n", CONFIG_H_BC_VERSION);
         } else {
                 return -EINVAL;
         }

--- a/src/manager/main.c
+++ b/src/manager/main.c
@@ -49,7 +49,7 @@ static int get_opts(int argc, char *argv[]) {
                         return 1;
 
                 case ARG_VERSION_SHORT:
-                        printf("%s\n", CONFIG_H_BC_VERSION);
+                        printf("bluechi-controller version %s\n", CONFIG_H_BC_VERSION);
                         return 1;
 
                 case ARG_PORT_SHORT:

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -936,7 +936,7 @@ static int manager_name_owner_changed(sd_bus_message *m, void *userdata, UNUSED 
 }
 
 bool manager_start(Manager *manager) {
-        bc_log_infof("Starting bluechi %s", CONFIG_H_BC_VERSION);
+        bc_log_infof("Starting bluechi-controller %s", CONFIG_H_BC_VERSION);
         if (manager == NULL) {
                 return false;
         }

--- a/src/proxy/main.c
+++ b/src/proxy/main.c
@@ -76,7 +76,7 @@ static int get_opts(int argc, char *argv[]) {
                         return 1;
 
                 case ARG_VERSION_SHORT:
-                        printf("%s\n", CONFIG_H_BC_VERSION);
+                        printf("bluechi-proxy version %s\n", CONFIG_H_BC_VERSION);
                         return 1;
 
                 case ARG_USER_SHORT:


### PR DESCRIPTION
This PR moves the version and release to a dedicated script, which can then be used by meson to fetch the short version (e.g. `0.6.0-1` for releases) or the long one (e.g. `0.6.0-0.202310261526.git3b060db` for dev/nightly builds). This changes the -v CLI option as well:
```bash
$ bluechictl -v
bluechictl version 0.6.0-0.202310261526.git3b060db
```

Fixes: https://github.com/eclipse-bluechi/bluechi/issues/454

/cc @dougsland @mkemel 