### PR TITLE
remove warnings from hashmap lib

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -79,7 +79,6 @@ inih_dep = inih.get_variable('inih_dep')
 
 hashmapc = subproject('hashmap.c', default_options: [
   'default_library=static', # include it as static library
-  'werror=false'            # don't treat warnings as errors since it
 ])
 hashmapc_dep = hashmapc.get_variable('hashmapc_dep')
 

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -632,8 +632,8 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
 static void agent_update_unit_infos_for(Agent *agent, AgentUnitInfo *info) {
         if (!info->subscribed && !info->loaded) {
                 AgentUnitInfoKey key = { info->object_path };
-                AgentUnitInfo *info = hashmap_delete(agent->unit_infos, &key);
-                if (info) {
+                AgentUnitInfo *info = (AgentUnitInfo *) hashmap_delete(agent->unit_infos, &key);
+                if (info != NULL) {
                         unit_info_clear(info);
                 }
         }
@@ -642,7 +642,7 @@ static void agent_update_unit_infos_for(Agent *agent, AgentUnitInfo *info) {
 static AgentUnitInfo *agent_get_unit_info(Agent *agent, const char *unit_path) {
         AgentUnitInfoKey key = { (char *) unit_path };
 
-        return hashmap_get(agent->unit_infos, &key);
+        return (AgentUnitInfo *) hashmap_get(agent->unit_infos, &key);
 }
 
 static AgentUnitInfo *agent_ensure_unit_info(Agent *agent, const char *unit) {
@@ -659,7 +659,7 @@ static AgentUnitInfo *agent_ensure_unit_info(Agent *agent, const char *unit) {
 
         AgentUnitInfo v = { unit_path, unit_copy, false, false, -1, NULL };
 
-        AgentUnitInfo *replaced = hashmap_set(agent->unit_infos, &v);
+        AgentUnitInfo *replaced = (AgentUnitInfo *) hashmap_set(agent->unit_infos, &v);
         if (replaced == NULL && hashmap_oom(agent->unit_infos)) {
                 return NULL;
         }

--- a/src/libbluechi/common/cfg.c
+++ b/src/libbluechi/common/cfg.c
@@ -326,7 +326,7 @@ int cfg_s_set_value(
                         return -ENOMEM;
                 }
         }
-        struct config_option *replaced = hashmap_set(
+        struct config_option *replaced = (struct config_option *) hashmap_set(
                         config->cfg_store,
                         &(struct config_option){
                                         .section = section_copy, .name = name_copy, .value = value_copy });


### PR DESCRIPTION
Fixes: #459

Remove warning messages from hashmap.c  by casting raw pointers to each original object