### PR TITLE
mark current directory as safe when creating archive

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -4,5 +4,6 @@ installdeps:
 	dnf -y install gcc gcc-c++ git jq meson systemd-devel rpm-build
 
 srpm: installdeps
+	git config --global --add safe.directory "$(shell pwd)"
 	./build-scripts/build-srpm.sh
 	cp rpmbuild/SRPMS/*.src.rpm $(outdir)

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,6 +23,10 @@ jobs:
           # Use githash of a tested commit instead of merge commit
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Mark source directory as safe
+        run: | 
+          git config --global --add safe.directory $(pwd)
+
       - name: Perform build
         run: |
           ./build-scripts/build-rpm.sh $ARTIFACTS_DIR

--- a/.packit.yml
+++ b/.packit.yml
@@ -19,6 +19,7 @@ srpm_build_deps:
 
 actions:
   post-upstream-clone:
+    - bash -c 'git config --global --add safe.directory $(pwd)'
     - bash -c './build-scripts/create-spec.sh'
 
   get-current-version:

--- a/build-scripts/version.sh
+++ b/build-scripts/version.sh
@@ -19,9 +19,6 @@ function release(){
         # Used for official releases. Increment if necessary
         RELEASE="1"
     else
-        # Mark current directory as safe for git to be able to parse git hash
-        git config --global --add safe.directory $(pwd)
-
         # Used for nightly builds
         RELEASE="0.$(date +%04Y%02m%02d%02H%02M).git$(git rev-parse --short ${GITHUB_SHA:-HEAD})"
     fi


### PR DESCRIPTION
After moving the version script in #635, marking the current directory as safe needs to be added in case of releases. 