### PR TITLE
send monitor signals only to peer

### DIFF
--- a/src/manager/monitor.c
+++ b/src/manager/monitor.c
@@ -342,6 +342,7 @@ static Subscription *monitor_find_subscription(Monitor *monitor, uint32_t sub_id
                         return sub;
                 }
         }
+        bc_log_debugf("Subscription ID '%d' for monitor '%s' not found", sub_id, monitor->object_path);
 
         return NULL;
 }
@@ -382,26 +383,41 @@ int monitor_on_unit_property_changed(
         int r = sd_bus_message_new_signal(
                         manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "UnitPropertiesChanged");
         if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to create UnitPropertiesChanged signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
                 return r;
         }
 
         r = sd_bus_message_append(sig, "sss", node, unit, interface);
         if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to append data to UnitPropertiesChanged signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
                 return r;
         }
 
         r = sd_bus_message_skip(m, "ss"); // Skip unit & iface
         if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to skip unit and interface for UnitPropertiesChanged signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
                 return r;
         }
 
         r = sd_bus_message_copy(sig, m, false);
         if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to copy properties for UnitPropertiesChanged signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
                 return r;
         }
 
         r = sd_bus_send_to(manager->api_bus, sig, monitor->client, NULL);
         if (r < 0) {
+                bc_log_errorf("Monitor: %s, ailed to create UnitPropertiesChanged signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
                 return r;
         }
 
@@ -416,11 +432,17 @@ int monitor_on_unit_new(void *userdata, const char *node, const char *unit, cons
         int r = sd_bus_message_new_signal(
                         manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "UnitNew");
         if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to create UnitNew signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
                 return r;
         }
 
         r = sd_bus_message_append(sig, "sss", node, unit, reason);
         if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to append data to UnitNew signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
                 return r;
         }
 
@@ -441,11 +463,17 @@ int monitor_on_unit_state_changed(
         int r = sd_bus_message_new_signal(
                         manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "UnitStateChanged");
         if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to create UnitStateChanged signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
                 return r;
         }
 
         r = sd_bus_message_append(sig, "sssss", node, unit, active_state, substate, reason);
         if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to append data to UnitStateChanged signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
                 return r;
         }
 
@@ -460,11 +488,17 @@ int monitor_on_unit_removed(void *userdata, const char *node, const char *unit, 
         int r = sd_bus_message_new_signal(
                         manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "UnitRemoved");
         if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to create UnitRemoved signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
                 return r;
         }
 
         r = sd_bus_message_append(sig, "sss", node, unit, reason);
         if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to append data to UnitRemoved signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
                 return r;
         }
 

--- a/src/manager/monitor.c
+++ b/src/manager/monitor.c
@@ -412,15 +412,19 @@ int monitor_on_unit_new(void *userdata, const char *node, const char *unit, cons
         Monitor *monitor = (Monitor *) userdata;
         Manager *manager = monitor->manager;
 
-        return sd_bus_emit_signal(
-                        manager->api_bus,
-                        monitor->object_path,
-                        MONITOR_INTERFACE,
-                        "UnitNew",
-                        "sss",
-                        node,
-                        unit,
-                        reason);
+        _cleanup_sd_bus_message_ sd_bus_message *sig = NULL;
+        int r = sd_bus_message_new_signal(
+                        manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "UnitNew");
+        if (r < 0) {
+                return r;
+        }
+
+        r = sd_bus_message_append(sig, "sss", node, unit, reason);
+        if (r < 0) {
+                return r;
+        }
+
+        return sd_bus_send_to(manager->api_bus, sig, monitor->client, NULL);
 }
 
 int monitor_on_unit_state_changed(
@@ -433,30 +437,36 @@ int monitor_on_unit_state_changed(
         Monitor *monitor = (Monitor *) userdata;
         Manager *manager = monitor->manager;
 
-        return sd_bus_emit_signal(
-                        manager->api_bus,
-                        monitor->object_path,
-                        MONITOR_INTERFACE,
-                        "UnitStateChanged",
-                        "sssss",
-                        node,
-                        unit,
-                        active_state,
-                        substate,
-                        reason);
+        _cleanup_sd_bus_message_ sd_bus_message *sig = NULL;
+        int r = sd_bus_message_new_signal(
+                        manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "UnitStateChanged");
+        if (r < 0) {
+                return r;
+        }
+
+        r = sd_bus_message_append(sig, "sssss", node, unit, active_state, substate, reason);
+        if (r < 0) {
+                return r;
+        }
+
+        return sd_bus_send_to(manager->api_bus, sig, monitor->client, NULL);
 }
 
 int monitor_on_unit_removed(void *userdata, const char *node, const char *unit, const char *reason) {
         Monitor *monitor = (Monitor *) userdata;
         Manager *manager = monitor->manager;
 
-        return sd_bus_emit_signal(
-                        manager->api_bus,
-                        monitor->object_path,
-                        MONITOR_INTERFACE,
-                        "UnitRemoved",
-                        "sss",
-                        node,
-                        unit,
-                        reason);
+        _cleanup_sd_bus_message_ sd_bus_message *sig = NULL;
+        int r = sd_bus_message_new_signal(
+                        manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "UnitRemoved");
+        if (r < 0) {
+                return r;
+        }
+
+        r = sd_bus_message_append(sig, "sss", node, unit, reason);
+        if (r < 0) {
+                return r;
+        }
+
+        return sd_bus_send_to(manager->api_bus, sig, monitor->client, NULL);
 }


### PR DESCRIPTION
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/187

When a peer creates a monitor, events matching its subscriptions should be sent only to that peer. Currently, this is only implemented for the unit properties changed signal - the other events are broadcasted so that others receive those signals as well. This commit changes the events for `UnitNew`, `UnitRemoved` and `UnitStateChanged` to be only sent to the peer that created the monitor.

[This gist](https://gist.github.com/engelmi/04c0cbc43f536a4c5e0c5bef10b19283) can be used to verify that no signals are sent to other listeners anymore. 