### PR TITLE
Add label to basic integration test packit job

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -45,6 +45,8 @@ jobs:
     trigger: pull_request
     identifier: integration-tests
     fmf_path: tests
+    labels:
+      - standard
     env:
       INSTALL_DEPS: "yes"
     targets:


### PR DESCRIPTION
New label to the regular packit test job, in addition to the existing `valgrind` one. 
The labels allow triggering a single job or a group of jobs manually. In our case:
`/packit test --labels standard` - runs only the regular test job 
`/packit test --labels valgrind` - runs only the valgrind test job 
`/packit test` - runs both (all the) tests