### PR TITLE
Update maintainer readme

### DIFF
--- a/README.maintainer.md
+++ b/README.maintainer.md
@@ -12,19 +12,18 @@ Following actions need to be taken to release a new stable version of BlueChi:
 
 Following files need to be updated to create a new stable release commit:
 
-* `RELEASE` variable needs to be updated in `build-scripts/build-srpm.sh` to contain a number instead of date and git
-  hash, which are used for snapshot builds. The number should contain `1` for the first build of the release, but it
-  may be increased if we need additional package rebuilds.
-* A new `%changelog` section in `bluechi.spec.in` should be added and it should contain information about the new package
-  release
+* In [build-scripts/version.sh](./build-scripts/version.sh) set `IS_RELEASE=true`. For the first release of that version
+`RELEASE=1` is used. This may be increased if additional package releases are needed.
+* A new `%changelog` section in [bluechi.spec.in](./bluechi.spec.in) should be added and it should contain information
+about the new package release
 
 Here is the example of the release commit for version
-[0.1.0](https://github.com/containers/bluechi/pull/214).
+[0.6.0](https://github.com/eclipse-bluechi/bluechi/pull/637).
 
 ### Tagging a release commit
 
 When the release commit is merged, we need to tag the release commit to be able to create an official release visible
-on the GitHub [project pages](https://github.com/containers/bluechi/releases).
+on the GitHub [project pages](https://github.com/eclipse-bluechi/bluechi/releases).
 
 The tag should use `v<VERSION>` format, where `<VERSION>` is the version of the release we want to create (for example
 the tag should be `v0.1.0` for the 0.1.0 version). There are 2 ways to create a release tag:
@@ -49,21 +48,21 @@ the tag should be `v0.1.0` for the 0.1.0 version). There are 2 ways to create a 
 **WARNING**: If a release tag has a different format, source archive for the release will have a different structure,
 which would cause RPM build for Fedora to fail.
 
-Pushing the new tag to the repository will trigger a GitHub workflow which automatically creates a new release. It will
-be listed on the [release page](https://github.com/containers/bluechi/releases) of BlueChi. Assets such as the .src.rpm
-are generated and added to that release by the workflow. In addition to the generated release notes, its good to
-manually add a **Highlights** section describing the most important changes.
+Pushing the new tag to the repository will trigger a [GitHub workflow](./.github/workflows/publish.yml) which
+automatically creates a new release. It will be listed on the
+[release page](https://github.com/eclipse-bluechi/bluechi/releases) of BlueChi. Assets such as the .src.rpm are
+generated and added to that release by the workflow. In addition to the generated release notes, its good to manually
+add a **Highlights** section describing the most important changes.
 
 ### Creating and merging a post release commit
 
-Following files need to be updated to switch the build from release build back to snapshot build:
+Following files need to be updated to switch the build from release build back to snapshot build. In [build-scripts/version.sh](./build-scripts/version.sh)
 
-* `RELEASE` variable needs to be updated in `build-scripts/create-spec.sh` to contain a date and git hash instead of
-  a number.
-* Project version needs to be increased in `meson.build`
+* set `IS_RELEASE=false`
+* increase the project version `VERSION`
 
 Here is the example of the post release commit for version
-[0.1.0](https://github.com/containers/bluechi/pull/215).
+[0.6.0](https://github.com/eclipse-bluechi/bluechi/pull/639).
 
 **WARNING:** There should not be merged any commits to the project between the release commit and the post release
 commit to make things clear.

--- a/build-scripts/version.sh
+++ b/build-scripts/version.sh
@@ -1,8 +1,12 @@
 #!/bin/bash -e
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+# Current version of BlueChi
 VERSION=0.7.0
+# Specify if build is a official release or a snapshot build
 IS_RELEASE=false
+# Used for official releases. Increment if necessary
+RELEASE="1"
 
 function short(){
     echo ${VERSION}
@@ -15,10 +19,7 @@ function long(){
 function release(){
     # Package release
 
-    if [ $IS_RELEASE = true ]; then
-        # Used for official releases. Increment if necessary
-        RELEASE="1"
-    else
+    if [ $IS_RELEASE = false ]; then
         # Used for nightly builds
         RELEASE="0.$(date +%04Y%02m%02d%02H%02M).git$(git rev-parse --short ${GITHUB_SHA:-HEAD})"
     fi


### PR DESCRIPTION
This PR 
- moves the `RELEASE` variable in `version.sh` outside of the release function (to be more visible when releasing)
- updates the README.maintainer.md with the latest changes in the release process