### PR TITLE
Fix remaining URLs pointing to containers/bluechi

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dnf install bluechi bluechi-agent bluechi-ctl
 
 Patches are welcome!
 
-Please submit patches to [github.com/containers/bluechi](https://github.com/containers/bluechi).
+Please submit patches to [github.com/eclipse-bluechi/bluechi](https://github.com/eclipse-bluechi/bluechi).
 More information about the development can be found in [README.developer.md](README.developer.md).
 
 You can read [Get started with GitHub](https://docs.github.com/en/get-started)
@@ -47,7 +47,7 @@ if you are not familiar with the development process to learn more about it.
 
 ### Found a bug or documentation issue?
 
-To submit a bug or suggest an enhancement please use [GitHub issues](https://github.com/containers/bluechi/issues).
+To submit a bug or suggest an enhancement please use [GitHub issues](https://github.com/eclipse-bluechi/bluechi/issues).
 
 ## Still need help?
 

--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -13,7 +13,7 @@ Version: @VERSION@
 Release: @RELEASE@%{?dist}
 Summary: A systemd service controller for multi-nodes environments
 License: LGPL-2.1-or-later
-URL:     https://github.com/containers/bluechi
+URL:     https://github.com/eclipse-bluechi/bluechi
 Source0: %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires: gcc
@@ -275,7 +275,7 @@ popd
 - Renamed bluechi to bluechi-controller for binary, rpm and documentation
 - Snapshot builds are now available in the centos-sig-automotive COPR group
 - Moved bluechi binaries to /usr/libexec for auto-completion
-- Introduced packit for builds and running integration tests on testing farm 
+- Introduced packit for builds and running integration tests on testing farm
 - Introduced initial implementation for a tool to test FFI of BlueChi
 - Introduced clang/LLVM support
 - Added properties and signals for connection status and disconnected timestamp to Agent's public API
@@ -283,7 +283,7 @@ popd
 - CLI option for the version (-v) prints version and git commit hash for non-release builds
 - Extended BlueChi's public D-Bus API specification by inline-comments
 - Added EmitsChangedSignal annotation to properties in BlueChi's public D-Bus API specification
-- Enhanced typed python bindings generator to use inline-comments from specification 
+- Enhanced typed python bindings generator to use inline-comments from specification
 - Enhanced typed python bindings generator to provide listener functions for property changed signals
 - Fixes in the D-Bus API description
 - Improved error messages returned by D-Bus API

--- a/doc/api-examples/rust/setup.md
+++ b/doc/api-examples/rust/setup.md
@@ -21,7 +21,7 @@ The snippet chosen to run needs to be copied into the `bluechi` directory. After
 
 ```bash
 # clone the BlueChi project
-$ git clone https://github.com/containers/bluechi.git
+$ git clone https://github.com/eclipse-bluechi/bluechi.git
 
 # navigate into the rust api-examples directory
 $ cd bluechi/doc/api-examples/rust

--- a/doc/docs/api/client_generation.md
+++ b/doc/docs/api/client_generation.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable-file MD013 -->
 # Generating BlueChi clients
 
-BlueChi provides [introspection data](https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format) for its public API. These XML files are located in the [data directory](https://github.com/containers/bluechi/tree/main/data) of the project and can be also be used as input to generate clients.
+BlueChi provides [introspection data](https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format) for its public API. These XML files are located in the [data directory](https://github.com/eclipse-bluechi/bluechi/tree/main/data) of the project and can be also be used as input to generate clients.
 
 There is a variety of code generation tools for various programming languages. There is a list
 
@@ -16,7 +16,7 @@ Using generated code for clients has the advantage of reducing boilerplate code 
 
 For `python`, the dynamically generated proxies (e.g. from [dasbus](https://github.com/rhinstaller/dasbus)) don't require any generation and work well on their own. Because of that there are no larger projects to generate python code from a D-Bus specification. These proxies, however, don't provide (type) hints.
 
-Therefore, the BlueChi project contains its own [generator](https://github.com/containers/bluechi/tree/main/src/bindings/generator) to output typed python bindings based on introspection data.
+Therefore, the BlueChi project contains its own [generator](https://github.com/eclipse-bluechi/bluechi/tree/main/src/bindings/generator) to output typed python bindings based on introspection data.
 
 ### Installation
 
@@ -33,7 +33,7 @@ pip install bluechi
 Or build and install it directly from source:
 
 ```bash
-git clone git@github.com:containers/bluechi.git
+git clone git@github.com:eclipse-bluechi/bluechi.git
 cd bluechi
 pip install -r src/bindings/generator/requirements.txt
 
@@ -63,7 +63,7 @@ The functions from the `ext` subpackage leverage the functions in `api` and comb
 --8<-- "bluechi-examples/StartUnit.py"
 ```
 
-If there is a common task for which `bluechi` can provide a simplifying function, please submit an [new RFE request](https://github.com/containers/bluechi/issues/new/choose).
+If there is a common task for which `bluechi` can provide a simplifying function, please submit an [new RFE request](https://github.com/eclipse-bluechi/bluechi/issues/new/choose).
 
 For more examples, please have a look at the [next section](#more-examples)
 

--- a/doc/docs/api/description.md
+++ b/doc/docs/api/description.md
@@ -3,7 +3,7 @@
 
 The main way to interact with BlueChi is using [D-Bus](https://www.freedesktop.org/wiki/Software/dbus/). It exposes a name on the system bus called `org.eclipse.bluechi` that other programs can use to control the system. It is expected that high-level control planes use this API directly, but there is also debugging tool called [bluechictl](../man/bluechictl.md) which can be used for debugging and testing purposes.
 
-The interfaces described in this sections are referencing the [introspection data](https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format) which is defined in XML files located in the [data directory](https://github.com/containers/bluechi/tree/main/data) of the project.
+The interfaces described in this sections are referencing the [introspection data](https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format) which is defined in XML files located in the [data directory](https://github.com/eclipse-bluechi/bluechi/tree/main/data) of the project.
 
 ## BlueChi public D-Bus API
 

--- a/doc/docs/api/examples.md
+++ b/doc/docs/api/examples.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable-file MD013 -->
 # Using BlueChi's D-Bus API
 
-BlueChi provides [introspection data](https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format) for its public API. These XML files are located in the [data directory](https://github.com/containers/bluechi/tree/main/data) of the BlueChi project and can be used either as reference when writing custom clients or as input to generate them (see [here](./client_generation.md)).
+BlueChi provides [introspection data](https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format) for its public API. These XML files are located in the [data directory](https://github.com/eclipse-bluechi/bluechi/tree/main/data) of the BlueChi project and can be used either as reference when writing custom clients or as input to generate them (see [here](./client_generation.md)).
 
 There are a number of bindings for the D-Bus protocol for a range of programming languages. A (not complete) list of bindings can be found on the [freedesktop D-Bus bindings](https://www.freedesktop.org/wiki/Software/DBusBindings/) website.
 

--- a/doc/docs/getting_started/cross_node_dependencies.md
+++ b/doc/docs/getting_started/cross_node_dependencies.md
@@ -20,7 +20,7 @@ On the raspberry pi, first create a temporary directory and add an example image
 ```bash
 mkdir -p /tmp/bluechi-cdn
 cd /tmp/bluechi-cdn
-wget https://raw.githubusercontent.com/containers/bluechi/main/doc/docs/img/bluechi_architecture.jpg
+wget https://raw.githubusercontent.com/eclipse-bluechi/bluechi/main/doc/docs/img/bluechi_architecture.jpg
 ```
 
 For the sake of simplicity, python's [http.server module](https://docs.python.org/3/library/http.server.html) is used to simulate a CDN. Create a new file `/etc/systemd/system/bluechi-cdn.service` and paste the following systemd unit definition:
@@ -117,7 +117,7 @@ if __name__ == "__main__":
     cdn_host = sys.argv[2]
 
     server = wsgiref.simple_server.make_server(
-        host="localhost", 
+        host="localhost",
         port=port,
         app=service
     )

--- a/doc/man/bluechi-agent.1.md
+++ b/doc/man/bluechi-agent.1.md
@@ -41,7 +41,7 @@ The unique name of this `bluechi-agent` used for registering at `bluechi`. This 
 
 #### **--interval**, **-i**
 
-The interval between two heartbeat signals sent to bluechi in milliseconds. If an agent is not connected, it will retry to connect on each heartbeat. Setting this options to values smaller or equal to 0 disables it. This option will overwrite the heartbeat interval defined in the configuration file. 
+The interval between two heartbeat signals sent to bluechi in milliseconds. If an agent is not connected, it will retry to connect on each heartbeat. Setting this options to values smaller or equal to 0 disables it. This option will overwrite the heartbeat interval defined in the configuration file.
 
 #### **--config**, **-c**
 
@@ -86,4 +86,4 @@ TBD
 
 ## CONFIGURATION FILES
 
-**[bluechi-agent.conf(5)](https://github.com/containers/bluechi/blob/main/doc/man/bluechi-agent.conf.5.md)**
+**[bluechi-agent.conf(5)](https://github.com/eclipse-bluechi/bluechi/blob/main/doc/man/bluechi-agent.conf.5.md)**

--- a/doc/man/bluechi-agent.conf.5.md
+++ b/doc/man/bluechi-agent.conf.5.md
@@ -39,7 +39,7 @@ The port on which `bluechi` is listening for connection request and the `bluechi
 
 #### **HeartbeatInterval** (long)
 
-The interval between two heartbeat signals sent to bluechi in milliseconds. If an agent is not connected, it will retry to connect on each heartbeat. Setting this options to values smaller or equal to 0 disables it. This option will overwrite the heartbeat interval defined in the configuration file. 
+The interval between two heartbeat signals sent to bluechi in milliseconds. If an agent is not connected, it will retry to connect on each heartbeat. Setting this options to values smaller or equal to 0 disables it. This option will overwrite the heartbeat interval defined in the configuration file.
 
 #### **LogLevel** (string)
 
@@ -112,4 +112,4 @@ Administrators can also use a "drop-in" directory __/etc/bluechi/agent.conf.d__ 
 
 ## SEE ALSO
 
-**[bluechi-agent(1)](https://github.com/containers/bluechi/blob/main/doc/man/bluechi-agent.1.md)**
+**[bluechi-agent(1)](https://github.com/eclipse-bluechi/bluechi/blob/main/doc/man/bluechi-agent.1.md)**

--- a/doc/man/bluechi-controller.1.md
+++ b/doc/man/bluechi-controller.1.md
@@ -65,4 +65,4 @@ TBD
 
 ## CONFIGURATION FILES
 
-**[bluechi-controller.conf(5)](https://github.com/containers/bluechi/blob/main/doc/man/bluechi-controller.conf.5.md)**
+**[bluechi-controller.conf(5)](https://github.com/eclipse-bluechi/bluechi/blob/main/doc/man/bluechi-controller.conf.5.md)**

--- a/doc/man/bluechi-controller.conf.5.md
+++ b/doc/man/bluechi-controller.conf.5.md
@@ -88,4 +88,4 @@ Administrators can also use a "drop-in" directory __/etc/bluechi/controller.conf
 
 ## SEE ALSO
 
-**[bluechi-controller(1)](https://github.com/containers/bluechi/blob/main/doc/man/bluechi-controller.1.md)**
+**[bluechi-controller(1)](https://github.com/eclipse-bluechi/bluechi/blob/main/doc/man/bluechi-controller.1.md)**

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: BlueChi Documentation
 
-repo_url: https://github.com/containers/bluechi
+repo_url: https://github.com/eclipse-bluechi/bluechi
 repo_name: bluechi
 edit_uri: blob/main/doc/docs/
 
@@ -8,14 +8,14 @@ copyright: © Red Hat
 nav:
   - Home: index.md
   - Architecture: architecture.md
-  - Getting Started: 
+  - Getting Started:
     - getting_started/index.md
     - Single Node Setup: getting_started/single_node.md
     - Multi-Node Setup: getting_started/multi_node.md
     - Using bluechictl: getting_started/examples_bluechictl.md
     - Cross-node dependencies: getting_started/cross_node_dependencies.md
   - Configuration: configuration.md
-  - Cross-Node Dependencies: 
+  - Cross-Node Dependencies:
     - cross_node_dependencies/index.md
     - Proxy Services: cross_node_dependencies/proxy_services.md
     - Using Proxy Services: cross_node_dependencies/usage.md

--- a/src/bindings/python/setup.py
+++ b/src/bindings/python/setup.py
@@ -14,7 +14,7 @@ setup(
     long_description=readme(),
     long_description_content_type="text/markdown",
     author="BlueChi developers",
-    url="https://github.com/containers/bluechi/",
+    url="https://github.com/eclipse-bluechi/bluechi/",
     license="LGPL-2.1-or-later",
     install_requires=[
         "dasbus",

--- a/src/bindings/python/setup.py.in
+++ b/src/bindings/python/setup.py.in
@@ -14,7 +14,7 @@ setup(
     long_description=readme(),
     long_description_content_type="text/markdown",
     author="BlueChi developers",
-    url="https://github.com/containers/bluechi/",
+    url="https://github.com/eclipse-bluechi/bluechi/",
     license="LGPL-2.1-or-later",
     install_requires=[
         "dasbus",

--- a/tests/README.md
+++ b/tests/README.md
@@ -90,8 +90,8 @@ If `valgrind` detects a memory leak in a test, the test will fail, and the logs 
 
 In order to run integration tests for your local BlueChi build, you need have BlueChi RPM packages built from your source
 code. The details about BlueChi development can be found at
-[README.developer.md](https://github.com/containers/bluechi/blob/main/README.developer.md), the most important part for
-running integration tests is [Packaging](https://github.com/containers/bluechi/blob/main/README.developer.md#packaging)
+[README.developer.md](https://github.com/eclipse-bluechi/bluechi/blob/main/README.developer.md), the most important part for
+running integration tests is [Packaging](https://github.com/eclipse-bluechi/bluechi/blob/main/README.developer.md#packaging)
 section.
 
 In the following steps BlueChi source codes are located in `~/bluechi` directory.


### PR DESCRIPTION
Fix remaining URLs pointing to container/bluechi to point to
eclipse-bluechi/bluechi

Signed-off-by: Martin Perina <mperina@redhat.com>
