### PR TITLE
log error when at least one list units request fails

### DIFF
--- a/src/client/main.c
+++ b/src/client/main.c
@@ -68,7 +68,6 @@ int main(int argc, char *argv[]) {
         _cleanup_client_ Client *client = new_client(op, opargc, opargv, opt_filter_glob);
         r = client_call_manager(client);
         if (r < 0) {
-                fprintf(stderr, "Call to manager failed: %s\n", strerror(-r));
                 return EXIT_FAILURE;
         }
 

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -1129,17 +1129,17 @@ int agent_request_start(AgentRequest *req) {
 AgentRequest *node_request_list_units(
                 Node *node, agent_request_response_t cb, void *userdata, free_func_t free_userdata) {
         if (!node_has_agent(node)) {
-                return false;
+                return NULL;
         }
 
         _cleanup_agent_request_ AgentRequest *req = NULL;
         node_create_request(&req, node, "ListUnits", cb, userdata, free_userdata);
         if (req == NULL) {
-                return false;
+                return NULL;
         }
 
         if (agent_request_start(req) < 0) {
-                return false;
+                return NULL;
         }
 
         return steal_pointer(&req);


### PR DESCRIPTION
Relates to:
https://github.com/eclipse-bluechi/bluechi/issues/567
https://github.com/eclipse-bluechi/bluechi/issues/568

When list units for all nodes is run and the requests are submitted, it might happen that one of those is failing. Previously, this led to a failure when reading the message for the node where the request failed - which got propagated to the caller.
Now, an additional error log in BlueChi is made and the error code is extracted from the sd_bus_message.

One option to reproduce this is by registering a `bluechi-agent`, but not providing the `list units` method. 
Previous error message with `bluechictl`:
```bash
$ bluechictl list-units
Failed to issue method call: Failed to create a reply message: No such device or address
Call to manager failed: Permission denied
```
New message:
```bash
$ bluechictl list-units
Failed to issue method call: Failed to create a reply message: Invalid request descriptor
Call to manager failed: Permission denied
```
Not sure this is better for the client, but `sd_bus_message_get_errno` retrieves error code 53 (Invalid request descriptor). The log in `bluechi-controller` provides more info:
```
msg="Failed to list units for node 'node1': Object does not exist at path “/org/eclipse/bluechi/internal/agent”"
```