### PR TITLE
extended monitor API by adding and removing peers

### DIFF
--- a/data/org.eclipse.bluechi.Monitor.xml
+++ b/data/org.eclipse.bluechi.Monitor.xml
@@ -58,6 +58,30 @@
       <arg name="id" type="u" direction="out" />
     </method>
 
+    <!-- 
+      AddPeer:
+      @name: The name of the peer to add as listener to all monitor events. Needs to be unique name on the bus.
+      @id: The id of the created peer
+
+      Add a new peer to the monitor. A peer will receive all events that the monitor subscribes to.
+    -->
+    <method name="AddPeer">
+      <arg name="name" type="s" direction="in" />
+      <arg name="id" type="u" direction="out" />
+    </method>
+
+    <!-- 
+      RemovePeer:
+      @id: The id of the peer to remove
+      @reason: The reason for removing the peer
+
+      Remove a previously added peer from the monitor. The reason will be part of the PeerRemoved signal, which is only sent to the respective peer.
+    -->
+    <method name="RemovePeer">
+      <arg name="id" type="u" direction="in" />
+      <arg name="reason" type="s" direction="in" />
+    </method>
+
 
     <!-- 
       UnitPropertiesChanged:
@@ -120,6 +144,16 @@
     <signal name="UnitRemoved">
       <arg name="node" type="s" />
       <arg name="unit" type="s" />
+      <arg name="reason" type="s" />
+    </signal>
+
+    <!-- 
+      PeerRemoved:
+      @reason: The reason the peer got removed from the monitor.
+
+      Emitted when a peer is removed from the monitor, e.g. when the monitor has been closed, and only sent to the respective peer.
+    -->
+    <signal name="PeerRemoved">
       <arg name="reason" type="s" />
     </signal>
   </interface>

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -154,6 +154,31 @@ class Monitor(ApiBase):
             units,
         )
 
+    def add_peer(self, name: str) -> UInt32:
+        """
+          AddPeer:
+        @name: The name of the peer to add as listener to all monitor events. Needs to be unique name on the bus.
+        @id: The id of the created peer
+
+        Add a new peer to the monitor. A peer will receive all events that the monitor subscribes to.
+        """
+        return self.get_proxy().AddPeer(
+            name,
+        )
+
+    def remove_peer(self, id: UInt32, reason: str) -> None:
+        """
+          RemovePeer:
+        @id: The id of the peer to remove
+        @reason: The reason for removing the peer
+
+        Remove a previously added peer from the monitor. The reason will be part of the PeerRemoved signal, which is only sent to the respective peer.
+        """
+        self.get_proxy().RemovePeer(
+            id,
+            reason,
+        )
+
     def on_unit_properties_changed(
         self,
         callback: Callable[
@@ -245,6 +270,23 @@ class Monitor(ApiBase):
         (reason=virtual).
         """
         self.get_proxy().UnitRemoved.connect(callback)
+
+    def on_peer_removed(
+        self,
+        callback: Callable[
+            [
+                str,
+            ],
+            None,
+        ],
+    ) -> None:
+        """
+          PeerRemoved:
+        @reason: The reason the peer got removed from the monitor.
+
+        Emitted when a peer is removed from the monitor, e.g. when the monitor has been closed, and only sent to the respective peer.
+        """
+        self.get_proxy().PeerRemoved.connect(callback)
 
 
 class Metrics(ApiBase):

--- a/src/libbluechi/bus/utils.h
+++ b/src/libbluechi/bus/utils.h
@@ -43,6 +43,8 @@ int bus_parse_unit_on_node_info(sd_bus_message *message, UnitInfo *u);
 int bus_socket_set_no_delay(sd_bus *bus);
 int bus_socket_set_keepalive(sd_bus *bus);
 
+bool bus_id_is_valid(const char *name);
+
 int assemble_object_path_string(const char *prefix, const char *name, char **res);
 
 DEFINE_CLEANUP_FUNC(UnitInfo, unit_unref)

--- a/src/libbluechi/test/bus/meson.build
+++ b/src/libbluechi/test/bus/meson.build
@@ -1,5 +1,3 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-subdir('bus')
-subdir('common')
-subdir('log')
+subdir('utils')

--- a/src/libbluechi/test/bus/utils/bus_id_is_valid_test.c
+++ b/src/libbluechi/test/bus/utils/bus_id_is_valid_test.c
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libbluechi/bus/utils.h"
+#include "libbluechi/common/string-util.h"
+
+bool test_bus_id_is_valid(const char *name, bool expected_is_valid) {
+        bool got_is_valid = bus_id_is_valid(name);
+        if (got_is_valid != expected_is_valid) {
+                fprintf(stderr,
+                        "FAILED: expected bus name '%s' to be %s, but got %s\n",
+                        name,
+                        bool_to_str(expected_is_valid),
+                        bool_to_str(got_is_valid));
+                return false;
+        }
+        return true;
+}
+
+int main() {
+        bool result = true;
+
+        result = result && test_bus_id_is_valid(NULL, false);
+        result = result && test_bus_id_is_valid("", false);
+        result = result && test_bus_id_is_valid(":", false);
+        result = result && test_bus_id_is_valid(":.", false);
+        result = result && test_bus_id_is_valid(":1.", false);
+        result = result && test_bus_id_is_valid(":1.3.", false);
+        result = result && test_bus_id_is_valid("1", false);
+        result = result && test_bus_id_is_valid("1.", false);
+        result = result && test_bus_id_is_valid("1.3", false);
+        result = result && test_bus_id_is_valid(":1..3", false);
+        result = result && test_bus_id_is_valid("org.eclipse.bluechi", false);
+        result = result &&
+                        test_bus_id_is_valid(
+                                        ":1.1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+                                        false);
+
+        result = result && test_bus_id_is_valid(":1.1", true);
+        result = result && test_bus_id_is_valid(":1.12345", true);
+        result = result && test_bus_id_is_valid(":1.123.45", true);
+
+        if (result) {
+                return EXIT_SUCCESS;
+        }
+        return EXIT_FAILURE;
+}

--- a/src/libbluechi/test/bus/utils/meson.build
+++ b/src/libbluechi/test/bus/utils/meson.build
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+bus_src = [
+  'bus_id_is_valid_test',
+]
+
+foreach src : bus_src
+  exec_test = executable(src, src + '.c',
+    link_with: [
+      bluechi_lib,
+    ],
+    include_directories: include_directories('../../../..'),
+  )
+  test(src, exec_test)
+endforeach

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -925,7 +925,7 @@ static void manager_client_disconnected(Manager *manager, const char *client_id)
         Monitor *monitor = NULL;
         Monitor *next_monitor = NULL;
         LIST_FOREACH_SAFE(monitors, monitor, next_monitor, manager->monitors) {
-                if (streq(monitor->client, client_id)) {
+                if (streq(monitor->owner, client_id)) {
                         monitor_close(monitor);
                         manager_remove_monitor(manager, monitor);
                 }

--- a/src/manager/monitor.c
+++ b/src/manager/monitor.c
@@ -6,6 +6,12 @@
 #include "monitor.h"
 #include "node.h"
 
+#include "libbluechi/bus/utils.h"
+
+/****************************************
+ ********** Subscription ****************
+ ****************************************/
+
 Subscription *subscription_new(const char *node) {
         static uint32_t next_id = 1;
 
@@ -102,12 +108,18 @@ static int monitor_method_close(sd_bus_message *m, void *userdata, sd_bus_error 
 static int monitor_method_subscribe(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
 static int monitor_method_subscribe_list(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
 static int monitor_method_unsubscribe(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
+static int monitor_method_add_peer(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
+static int monitor_method_remove_peer(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
+
+static void monitor_emit_peer_removed(void *userdata, MonitorPeer *peer, const char *reason);
 
 static const sd_bus_vtable monitor_vtable[] = {
         SD_BUS_VTABLE_START(0),
         SD_BUS_METHOD("Subscribe", "ss", "u", monitor_method_subscribe, 0),
         SD_BUS_METHOD("SubscribeList", "sas", "u", monitor_method_subscribe_list, 0),
         SD_BUS_METHOD("Unsubscribe", "u", "", monitor_method_unsubscribe, 0),
+        SD_BUS_METHOD("AddPeer", "s", "u", monitor_method_add_peer, 0),
+        SD_BUS_METHOD("RemovePeer", "us", "", monitor_method_remove_peer, 0),
         SD_BUS_METHOD("Close", "", "", monitor_method_close, 0),
         SD_BUS_SIGNAL_WITH_NAMES(
                         "UnitPropertiesChanged",
@@ -122,10 +134,11 @@ static const sd_bus_vtable monitor_vtable[] = {
                                         SD_BUS_PARAM(substate) SD_BUS_PARAM(reason),
                         0),
         SD_BUS_SIGNAL_WITH_NAMES("UnitRemoved", "ss", SD_BUS_PARAM(node) SD_BUS_PARAM(unit), 0),
+        SD_BUS_SIGNAL_WITH_NAMES("PeerRemoved", "s", SD_BUS_PARAM(reason), 0),
         SD_BUS_VTABLE_END
 };
 
-Monitor *monitor_new(Manager *manager, const char *client) {
+Monitor *monitor_new(Manager *manager, const char *owner) {
         static uint32_t next_id = 0;
         _cleanup_monitor_ Monitor *monitor = malloc0(sizeof(Monitor));
         if (monitor == NULL) {
@@ -133,13 +146,14 @@ Monitor *monitor_new(Manager *manager, const char *client) {
         }
 
         monitor->ref_count = 1;
+        monitor->id = ++next_id;
         monitor->manager = manager;
         LIST_INIT(monitors, monitor);
-        monitor->id = ++next_id;
         LIST_HEAD_INIT(monitor->subscriptions);
+        LIST_HEAD_INIT(monitor->peers);
 
-        monitor->client = strdup(client);
-        if (monitor->client == NULL) {
+        monitor->owner = strdup(owner);
+        if (monitor->owner == NULL) {
                 return NULL;
         }
 
@@ -164,7 +178,7 @@ void monitor_unref(Monitor *monitor) {
 
         sd_bus_slot_unrefp(&monitor->export_slot);
         free_and_null(monitor->object_path);
-        free_and_null(monitor->client);
+        free_and_null(monitor->owner);
         free_and_null(monitor);
 }
 
@@ -197,13 +211,22 @@ void monitor_close(Monitor *monitor) {
                 subscription_unref(sub);
         }
 
+        MonitorPeer *peer = NULL;
+        MonitorPeer *next_peer = NULL;
+        LIST_FOREACH_SAFE(peers, peer, next_peer, monitor->peers) {
+                monitor_emit_peer_removed(monitor, peer, "closed");
+                LIST_REMOVE(peers, monitor->peers, peer);
+                free_and_null(peer->name);
+                free_and_null(peer);
+        }
+
         sd_bus_slot_unrefp(&monitor->export_slot);
         monitor->export_slot = NULL;
 }
 
-/*************************************************************************
+/***********************************************************
  *** org.eclipse.bluechi.Monitor.Close *********************
- *************************************************************************/
+ ***********************************************************/
 
 static int monitor_method_close(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
         _cleanup_monitor_ Monitor *monitor = monitor_ref(userdata);
@@ -220,9 +243,9 @@ static int monitor_method_close(sd_bus_message *m, void *userdata, UNUSED sd_bus
         return sd_bus_reply_method_return(m, "");
 }
 
-/*************************************************************************
+/***********************************************************
  *** org.eclipse.bluechi.Monitor.Subscribe *****************
- *************************************************************************/
+ ***********************************************************/
 
 static int monitor_method_subscribe(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
         Monitor *monitor = userdata;
@@ -259,9 +282,9 @@ static int monitor_method_subscribe(sd_bus_message *m, void *userdata, UNUSED sd
         return sd_bus_reply_method_return(m, "u", sub->id);
 }
 
-/*************************************************************************
+/***********************************************************
  ***** org.eclipse.bluechi.Monitor.SubscribeList ***********
- *************************************************************************/
+ ***********************************************************/
 
 static int monitor_method_subscribe_list(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
         Monitor *monitor = userdata;
@@ -330,9 +353,9 @@ static int monitor_method_subscribe_list(sd_bus_message *m, void *userdata, UNUS
         return sd_bus_reply_method_return(m, "u", sub->id);
 }
 
-/*************************************************************************
+/***********************************************************
  ********* org.eclipse.bluechi.Monitor.Unsubscribe *********
- *************************************************************************/
+ ***********************************************************/
 
 static Subscription *monitor_find_subscription(Monitor *monitor, uint32_t sub_id) {
         Subscription *sub = NULL;
@@ -364,7 +387,7 @@ static int monitor_method_unsubscribe(sd_bus_message *m, void *userdata, UNUSED 
         Subscription *sub = monitor_find_subscription(monitor, sub_id);
         if (sub == NULL) {
                 return sd_bus_reply_method_errorf(
-                                m, SD_BUS_ERROR_FAILED, "Subscription '%d' is not found", sub_id);
+                                m, SD_BUS_ERROR_FAILED, "Subscription '%d' not found", sub_id);
         }
 
         manager_remove_subscription(manager, sub);
@@ -374,79 +397,196 @@ static int monitor_method_unsubscribe(sd_bus_message *m, void *userdata, UNUSED 
         return sd_bus_reply_method_return(m, "");
 }
 
+/*******************************************************
+ ********* org.eclipse.bluechi.Monitor.AddPeer *********
+ *******************************************************/
+
+static MonitorPeer *monitor_add_peer(Monitor *monitor, const char *peer_name) {
+        static uint32_t next_peer_id = 0;
+
+        MonitorPeer *peer = malloc0(sizeof(MonitorPeer));
+        if (peer == NULL) {
+                return NULL;
+        }
+        peer->name = strdup(peer_name);
+        if (peer->name == NULL) {
+                free(peer);
+                return NULL;
+        }
+        peer->id = ++next_peer_id;
+
+        LIST_APPEND(peers, monitor->peers, peer);
+
+        bc_log_debugf("Added monitor peer '%s' to monitor '%s'", peer_name, monitor->object_path);
+        return peer;
+}
+
+static int monitor_method_add_peer(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
+        Monitor *monitor = userdata;
+
+        const char *peer_name = NULL;
+
+        int r = sd_bus_message_read(m, "s", &peer_name);
+        if (r < 0) {
+                return sd_bus_reply_method_errorf(
+                                m,
+                                SD_BUS_ERROR_INVALID_ARGS,
+                                "Invalid argument for the peer name: %s",
+                                strerror(-r));
+        }
+
+        if (!bus_id_is_valid(peer_name)) {
+                return sd_bus_reply_method_errorf(
+                                m,
+                                SD_BUS_ERROR_INVALID_ARGS,
+                                "Peer name '%s' is not a valid bus name",
+                                peer_name);
+        }
+
+        MonitorPeer *peer = monitor_add_peer(monitor, peer_name);
+        if (peer == NULL) {
+                return sd_bus_reply_method_errorf(
+                                m, SD_BUS_ERROR_NO_MEMORY, "Failed to add peer '%s': OOM", peer_name);
+        }
+
+        return sd_bus_reply_method_return(m, "u", peer->id);
+}
+
+/*******************************************************
+ ********* org.eclipse.bluechi.Monitor.RemovePeer *********
+ *******************************************************/
+
+static MonitorPeer *monitor_find_peer(Monitor *monitor, uint32_t peer_id) {
+        MonitorPeer *peer = NULL;
+        MonitorPeer *next_peer = NULL;
+        LIST_FOREACH_SAFE(peers, peer, next_peer, monitor->peers) {
+                if (peer->id == peer_id) {
+                        return peer;
+                }
+        }
+        bc_log_debugf("Peer with ID '%d' for monitor '%s' not found", peer_id, monitor->object_path);
+
+        return NULL;
+}
+
+static int monitor_method_remove_peer(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
+        Monitor *monitor = userdata;
+
+        uint32_t peer_id = 0;
+        const char *reason = NULL;
+
+        int r = sd_bus_message_read(m, "us", &peer_id, &reason);
+        if (r < 0) {
+                return sd_bus_reply_method_errorf(
+                                m,
+                                SD_BUS_ERROR_INVALID_ARGS,
+                                "Invalid argument for the peer name: %s",
+                                strerror(-r));
+        }
+
+        MonitorPeer *peer = monitor_find_peer(monitor, peer_id);
+        if (peer == NULL) {
+                return sd_bus_reply_method_errorf(
+                                m, SD_BUS_ERROR_FAILED, "Peer with ID '%d' not found.", peer_id);
+        }
+
+        monitor_emit_peer_removed(monitor, peer, reason);
+        LIST_REMOVE(peers, monitor->peers, peer);
+        free_and_null(peer->name);
+        free_and_null(peer);
+
+        bc_log_debugf("Removed monitor peer '%d' to monitor '%s'", peer_id, monitor->object_path);
+        return sd_bus_reply_method_return(m, "");
+}
+
+
+/**********************************
+ ********* Monitor events *********
+ **********************************/
+
+static sd_bus_message *assemble_unit_new_signal(
+                Monitor *monitor, const char *node, const char *unit, const char *reason);
+static sd_bus_message *assemble_unit_removed_signal(
+                Monitor *monitor, const char *node, const char *unit, const char *reason);
+static sd_bus_message *assemble_unit_property_changed_signal(
+                Monitor *monitor, const char *node, const char *unit, const char *interface, sd_bus_message *m);
+static sd_bus_message *assemble_unit_state_changed_signal(
+                Monitor *monitor,
+                const char *node,
+                const char *unit,
+                const char *active_state,
+                const char *substate,
+                const char *reason);
+
 int monitor_on_unit_property_changed(
                 void *userdata, const char *node, const char *unit, const char *interface, sd_bus_message *m) {
         Monitor *monitor = (Monitor *) userdata;
         Manager *manager = monitor->manager;
 
+        int r = 0;
         _cleanup_sd_bus_message_ sd_bus_message *sig = NULL;
-        int r = sd_bus_message_new_signal(
-                        manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "UnitPropertiesChanged");
-        if (r < 0) {
-                bc_log_errorf("Monitor: %s, failed to create UnitPropertiesChanged signal: %s",
-                              monitor->object_path,
-                              strerror(-r));
-                return r;
+
+        sig = assemble_unit_property_changed_signal(monitor, node, unit, interface, m);
+        if (sig != NULL) {
+                r = sd_bus_send_to(manager->api_bus, sig, monitor->owner, NULL);
+                if (r < 0) {
+                        bc_log_errorf("Monitor: %s, failed to send UnitPropertyChanged signal to monitor owner: %s",
+                                      monitor->object_path,
+                                      strerror(-r));
+                }
         }
 
-        r = sd_bus_message_append(sig, "sss", node, unit, interface);
-        if (r < 0) {
-                bc_log_errorf("Monitor: %s, failed to append data to UnitPropertiesChanged signal: %s",
-                              monitor->object_path,
-                              strerror(-r));
-                return r;
+        MonitorPeer *peer = NULL;
+        MonitorPeer *next_peer = NULL;
+        LIST_FOREACH_SAFE(peers, peer, next_peer, monitor->peers) {
+                sig = assemble_unit_property_changed_signal(monitor, node, unit, interface, m);
+                if (sig != NULL) {
+                        r = sd_bus_send_to(manager->api_bus, sig, peer->name, NULL);
+                        if (r < 0) {
+                                bc_log_errorf("Monitor: %s, failed to send UnitPropertyChanged signal to peer '%s': %s",
+                                              monitor->object_path,
+                                              peer->name,
+                                              strerror(-r));
+                        }
+                }
         }
 
-        r = sd_bus_message_skip(m, "ss"); // Skip unit & iface
-        if (r < 0) {
-                bc_log_errorf("Monitor: %s, failed to skip unit and interface for UnitPropertiesChanged signal: %s",
-                              monitor->object_path,
-                              strerror(-r));
-                return r;
-        }
-
-        r = sd_bus_message_copy(sig, m, false);
-        if (r < 0) {
-                bc_log_errorf("Monitor: %s, failed to copy properties for UnitPropertiesChanged signal: %s",
-                              monitor->object_path,
-                              strerror(-r));
-                return r;
-        }
-
-        r = sd_bus_send_to(manager->api_bus, sig, monitor->client, NULL);
-        if (r < 0) {
-                bc_log_errorf("Monitor: %s, ailed to create UnitPropertiesChanged signal: %s",
-                              monitor->object_path,
-                              strerror(-r));
-                return r;
-        }
-
-        return sd_bus_message_rewind(m, false);
+        return 0;
 }
 
 int monitor_on_unit_new(void *userdata, const char *node, const char *unit, const char *reason) {
         Monitor *monitor = (Monitor *) userdata;
         Manager *manager = monitor->manager;
 
+        int r = 0;
         _cleanup_sd_bus_message_ sd_bus_message *sig = NULL;
-        int r = sd_bus_message_new_signal(
-                        manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "UnitNew");
-        if (r < 0) {
-                bc_log_errorf("Monitor: %s, failed to create UnitNew signal: %s",
-                              monitor->object_path,
-                              strerror(-r));
-                return r;
+
+        sig = assemble_unit_new_signal(monitor, node, unit, reason);
+        if (sig != NULL) {
+                r = sd_bus_send_to(manager->api_bus, sig, monitor->owner, NULL);
+                if (r < 0) {
+                        bc_log_errorf("Monitor: %s, failed to send UnitNew signal to monitor owner: %s",
+                                      monitor->object_path,
+                                      strerror(-r));
+                }
         }
 
-        r = sd_bus_message_append(sig, "sss", node, unit, reason);
-        if (r < 0) {
-                bc_log_errorf("Monitor: %s, failed to append data to UnitNew signal: %s",
-                              monitor->object_path,
-                              strerror(-r));
-                return r;
+        MonitorPeer *peer = NULL;
+        MonitorPeer *next_peer = NULL;
+        LIST_FOREACH_SAFE(peers, peer, next_peer, monitor->peers) {
+                sig = assemble_unit_new_signal(monitor, node, unit, reason);
+                if (sig != NULL) {
+                        r = sd_bus_send_to(manager->api_bus, sig, peer->name, NULL);
+                        if (r < 0) {
+                                bc_log_errorf("Monitor: %s, failed to send signal to peer '%s': %s",
+                                              monitor->object_path,
+                                              peer->name,
+                                              strerror(-r));
+                        }
+                }
         }
 
-        return sd_bus_send_to(manager->api_bus, sig, monitor->client, NULL);
+        return 0;
 }
 
 int monitor_on_unit_state_changed(
@@ -459,29 +599,100 @@ int monitor_on_unit_state_changed(
         Monitor *monitor = (Monitor *) userdata;
         Manager *manager = monitor->manager;
 
+        int r = 0;
         _cleanup_sd_bus_message_ sd_bus_message *sig = NULL;
-        int r = sd_bus_message_new_signal(
-                        manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "UnitStateChanged");
-        if (r < 0) {
-                bc_log_errorf("Monitor: %s, failed to create UnitStateChanged signal: %s",
-                              monitor->object_path,
-                              strerror(-r));
-                return r;
+
+        sig = assemble_unit_state_changed_signal(monitor, node, unit, active_state, substate, reason);
+        if (sig != NULL) {
+                r = sd_bus_send_to(manager->api_bus, sig, monitor->owner, NULL);
+                if (r < 0) {
+                        bc_log_errorf("Monitor: %s, failed to send signal to monitor owner: %s",
+                                      monitor->object_path,
+                                      strerror(-r));
+                }
         }
 
-        r = sd_bus_message_append(sig, "sssss", node, unit, active_state, substate, reason);
-        if (r < 0) {
-                bc_log_errorf("Monitor: %s, failed to append data to UnitStateChanged signal: %s",
-                              monitor->object_path,
-                              strerror(-r));
-                return r;
+        MonitorPeer *peer = NULL;
+        MonitorPeer *next_peer = NULL;
+        LIST_FOREACH_SAFE(peers, peer, next_peer, monitor->peers) {
+                sig = assemble_unit_state_changed_signal(monitor, node, unit, active_state, substate, reason);
+                if (sig != NULL) {
+                        r = sd_bus_send_to(manager->api_bus, sig, peer->name, NULL);
+                        if (r < 0) {
+                                bc_log_errorf("Monitor: %s, failed to send UnitStateChanged signal to peer '%s': %s",
+                                              monitor->object_path,
+                                              peer->name,
+                                              strerror(-r));
+                        }
+                }
         }
 
-        return sd_bus_send_to(manager->api_bus, sig, monitor->client, NULL);
+        return 0;
 }
 
 int monitor_on_unit_removed(void *userdata, const char *node, const char *unit, const char *reason) {
         Monitor *monitor = (Monitor *) userdata;
+        Manager *manager = monitor->manager;
+
+        int r = 0;
+        _cleanup_sd_bus_message_ sd_bus_message *sig = NULL;
+
+        sig = assemble_unit_removed_signal(monitor, node, unit, reason);
+        if (sig != NULL) {
+                r = sd_bus_send_to(manager->api_bus, sig, monitor->owner, NULL);
+                if (r < 0) {
+                        bc_log_errorf("Monitor: %s, failed to send signal to monitor owner: %s",
+                                      monitor->object_path,
+                                      strerror(-r));
+                }
+        }
+
+        MonitorPeer *peer = NULL;
+        MonitorPeer *next_peer = NULL;
+        LIST_FOREACH_SAFE(peers, peer, next_peer, monitor->peers) {
+                sig = assemble_unit_removed_signal(monitor, node, unit, reason);
+                if (sig != NULL) {
+                        r = sd_bus_send_to(manager->api_bus, sig, peer->name, NULL);
+                        if (r < 0) {
+                                bc_log_errorf("Monitor: %s, failed to send UnitRemoved signal to peer '%s': %s",
+                                              monitor->object_path,
+                                              peer->name,
+                                              strerror(-r));
+                        }
+                }
+        }
+
+        return 0;
+}
+
+
+static sd_bus_message *assemble_unit_new_signal(
+                Monitor *monitor, const char *node, const char *unit, const char *reason) {
+        Manager *manager = monitor->manager;
+
+        _cleanup_sd_bus_message_ sd_bus_message *sig = NULL;
+        int r = sd_bus_message_new_signal(
+                        manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "UnitNew");
+        if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to create UnitNew signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
+                return NULL;
+        }
+
+        r = sd_bus_message_append(sig, "sss", node, unit, reason);
+        if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to append data to UnitNew signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
+                return NULL;
+        }
+
+        return steal_pointer(&sig);
+}
+
+static sd_bus_message *assemble_unit_removed_signal(
+                Monitor *monitor, const char *node, const char *unit, const char *reason) {
         Manager *manager = monitor->manager;
 
         _cleanup_sd_bus_message_ sd_bus_message *sig = NULL;
@@ -491,7 +702,7 @@ int monitor_on_unit_removed(void *userdata, const char *node, const char *unit, 
                 bc_log_errorf("Monitor: %s, failed to create UnitRemoved signal: %s",
                               monitor->object_path,
                               strerror(-r));
-                return r;
+                return NULL;
         }
 
         r = sd_bus_message_append(sig, "sss", node, unit, reason);
@@ -499,8 +710,118 @@ int monitor_on_unit_removed(void *userdata, const char *node, const char *unit, 
                 bc_log_errorf("Monitor: %s, failed to append data to UnitRemoved signal: %s",
                               monitor->object_path,
                               strerror(-r));
-                return r;
+                return NULL;
         }
 
-        return sd_bus_send_to(manager->api_bus, sig, monitor->client, NULL);
+        return steal_pointer(&sig);
+}
+
+static sd_bus_message *assemble_unit_property_changed_signal(
+                Monitor *monitor, const char *node, const char *unit, const char *interface, sd_bus_message *m) {
+        Manager *manager = monitor->manager;
+
+        _cleanup_sd_bus_message_ sd_bus_message *sig = NULL;
+        int r = sd_bus_message_new_signal(
+                        manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "UnitPropertiesChanged");
+        if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to create UnitPropertiesChanged signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
+                return NULL;
+        }
+
+        r = sd_bus_message_append(sig, "sss", node, unit, interface);
+        if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to append data to UnitPropertiesChanged signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
+                return NULL;
+        }
+
+        r = sd_bus_message_skip(m, "ss"); // Skip unit & iface
+        if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to skip unit and interface for UnitPropertiesChanged signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
+                return NULL;
+        }
+
+        r = sd_bus_message_copy(sig, m, false);
+        if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to copy properties for UnitPropertiesChanged signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
+                return NULL;
+        }
+
+        r = sd_bus_message_rewind(m, false);
+        if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to rewind original UnitPropertiesChanged signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
+                return NULL;
+        }
+
+        return steal_pointer(&sig);
+}
+
+static sd_bus_message *assemble_unit_state_changed_signal(
+                Monitor *monitor,
+                const char *node,
+                const char *unit,
+                const char *active_state,
+                const char *substate,
+                const char *reason) {
+        Manager *manager = monitor->manager;
+
+        _cleanup_sd_bus_message_ sd_bus_message *sig = NULL;
+        int r = sd_bus_message_new_signal(
+                        manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "UnitStateChanged");
+        if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to create UnitStateChanged signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
+                return NULL;
+        }
+
+        r = sd_bus_message_append(sig, "sssss", node, unit, active_state, substate, reason);
+        if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to append data to UnitStateChanged signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
+                return NULL;
+        }
+
+        return steal_pointer(&sig);
+}
+
+static void monitor_emit_peer_removed(void *userdata, MonitorPeer *peer, const char *reason) {
+        Monitor *monitor = (Monitor *) userdata;
+        Manager *manager = monitor->manager;
+
+        _cleanup_sd_bus_message_ sd_bus_message *sig = NULL;
+        int r = sd_bus_message_new_signal(
+                        manager->api_bus, &sig, monitor->object_path, MONITOR_INTERFACE, "PeerRemoved");
+        if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to create PeerRemoved signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
+                return;
+        }
+
+        r = sd_bus_message_append(sig, "s", reason);
+        if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to append data to PeerRemoved signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
+                return;
+        }
+
+        r = sd_bus_send_to(manager->api_bus, sig, peer->name, NULL);
+        if (r < 0) {
+                bc_log_errorf("Monitor: %s, failed to send PeerRemoved signal: %s",
+                              monitor->object_path,
+                              strerror(-r));
+                return;
+        }
 }

--- a/src/manager/monitor.h
+++ b/src/manager/monitor.h
@@ -54,10 +54,18 @@ void subscription_unref(Subscription *subscription);
 DEFINE_CLEANUP_FUNC(Subscription, subscription_unref)
 #define _cleanup_subscription_ _cleanup_(subscription_unrefp)
 
+struct MonitorPeer {
+        uint32_t id;
+        char *name;
+        LIST_FIELDS(MonitorPeer, peers);
+};
+
 struct Monitor {
         int ref_count;
         uint32_t id;
-        char *client;
+
+        char *owner;
+        LIST_HEAD(MonitorPeer, peers);
 
         Manager *manager; /* weak ref */
 
@@ -69,7 +77,7 @@ struct Monitor {
         LIST_FIELDS(Monitor, monitors);
 };
 
-Monitor *monitor_new(Manager *manager, const char *client);
+Monitor *monitor_new(Manager *manager, const char *owner);
 Monitor *monitor_ref(Monitor *monitor);
 void monitor_unref(Monitor *monitor);
 

--- a/src/manager/types.h
+++ b/src/manager/types.h
@@ -9,4 +9,5 @@ typedef struct Monitor Monitor;
 typedef struct ProxyMonitor ProxyMonitor;
 typedef struct Subscription Subscription;
 typedef struct SubscribedUnit SubscribedUnit;
+typedef struct MonitorPeer MonitorPeer;
 typedef struct ProxyDependency ProxyDependency;


### PR DESCRIPTION
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/187

Monitor signals are only sent to the creator of the monitor. The new Peer API enables to add and remove additional listener on the same monitor with its subscriptions.
A user with sufficient priviledges to make methods calls to BlueChi's API can add and remove peers. The processes for the peers can be run by a different user with no access to BlueChi's API, but will still be able to receive events if added by a privileged process.
