### PR TITLE
Force python-rich installation for podman-py

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Mark source directory as safe
-        run: | 
+        run: |
           git config --global --add safe.directory $(pwd)
 
       - name: Perform build
@@ -66,6 +66,8 @@ jobs:
       - name: Install unpackaged python libraries from PyPi
         run: |
           pip install "tmt[provision]" "tmt[report-junit]" podman pytest pytest-timeout
+          # Mitigate https://github.com/containers/podman-py/issues/350
+          pip install rich
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -77,7 +79,7 @@ jobs:
         with:
           name: rpm-artifacts
           path: 'tests/bluechi-rpms'
-      
+
       - name: Check integration test IDs
         run: |
           cd tests

--- a/tests/scripts/tests-setup.sh
+++ b/tests/scripts/tests-setup.sh
@@ -12,6 +12,8 @@ if [ "$INSTALL_DEPS" == "yes" ]; then
         python3-pytest \
         python3-pytest-timeout \
         -y
+    # Mitigate https://github.com/containers/podman-py/issues/350
+    dnf install python3-rich -y
 fi
 
 BUILD_ARG=""


### PR DESCRIPTION
Fixes https://github.com/containers/podman-py/issues/350 by forcing
installation of python-rich dependency, which is missing in
podman-py 4.8.0.post1

Signed-off-by: Martin Perina <mperina@redhat.com>
