### PR TITLE
Add lcov to integration-test-base container

### DIFF
--- a/tests/containers/integration-test-base
+++ b/tests/containers/integration-test-base
@@ -1,12 +1,14 @@
 FROM quay.io/centos/centos:stream9
 
-RUN dnf upgrade --refresh -y --nodocs && \
+RUN dnf upgrade --refresh --nodocs -y && \
+    dnf install --nodocs epel-release -y && \
     dnf install --nodocs \
-        policycoreutils-python-utils \
-        python3-dasbus \
-        selinux-policy \
-        systemd \
-        systemd-devel \
-        valgrind \
-    -y && \
+            lcov \
+            policycoreutils-python-utils \
+            python3-dasbus \
+            selinux-policy \
+            systemd \
+            systemd-devel \
+            valgrind \
+        -y && \
     dnf -y clean all


### PR DESCRIPTION
Adds lcov to integration-test-base container, because lcov will be
required to generate code coverage report from integration tests run.

Related-to: https://github.com/eclipse-bluechi/bluechi/issues/397
Signed-off-by: Martin Perina <mperina@redhat.com>
