### PR TITLE
added integration test shutdown for bluechi

### DIFF
--- a/tests/bluechi_test/container.py
+++ b/tests/bluechi_test/container.py
@@ -186,10 +186,6 @@ class BluechiContainer():
         bluechi_valgrind_log_target_path = f"/tmp/{bluechi_valgrind_filename}"
         bluechi_agent_valgrind_log_target_path = f"/tmp/{bluechi_agent_valgrind_filename}"
 
-        # Stop bluechi process to finalize valgrind report
-        self.exec_run("systemctl stop bluechi-agent")
-        self.exec_run("systemctl stop bluechi-controller")
-
         # Collect valgrind logs to the data directory
         self.extract_valgrind_logs(valgrind_log_path_controller, bluechi_valgrind_log_target_path, data_dir)
         self.extract_valgrind_logs(valgrind_log_path_agent, bluechi_agent_valgrind_log_target_path, data_dir)


### PR DESCRIPTION
In order to finalize all data - journal and valgrind logs and code coverage files - a shutdown step has been introduced that stops the bluechi components in all container.
Also, error logs have been added in the run routine that should help debugging test failures.

/cc @ArtiomDivak 
Without stopping the systemd service(s), the `.gcda` files aren't written so that the coverage collection can't find them and fails. This PR with the shutdown before collecting artifacts should ensure that the `.gcda` files are written and finalized. 

Relates to: https://github.com/eclipse-bluechi/bluechi/issues/397
