### PR TITLE
fix CI check for apispec changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ jobs:
       clang: ${{ steps.filter.outputs.clang }}
       md: ${{ steps.filter.outputs.md }}
       python: ${{ steps.filter.outputs.python }}
+      apispec: ${{ steps.filter.outputs.apispec }}
     steps:
       - name: Detect changed files
         uses: dorny/paths-filter@v2
@@ -141,10 +142,13 @@ jobs:
         run: | 
           python3 -m ensurepip --default-pip
           python3 -m pip install -r src/bindings/generator/requirements.txt
+          pip install wheel
+          dnf install -y python3-gobject
       
-      - name: Generate python bindings
+      - name: Generate and build python bindings
         run: |
           ./build-scripts/generate-bindings.sh python
+          ./build-scripts/build-bindings.sh python
 
       - name: Check for changes in generated python code
         run: |

--- a/build-scripts/build-bindings.sh
+++ b/build-scripts/build-bindings.sh
@@ -4,9 +4,7 @@
 # Important note: 
 # Run from root directory
 
-# Parse package version from the project
-meson setup builddir
-VERSION="$(meson introspect --projectinfo builddir | jq -r '.version')"
+VERSION=$($(dirname "$(readlink -f "$0")")/version.sh)
 
 function python() {
     # Package python bindings

--- a/src/bindings/generator/requirements.txt
+++ b/src/bindings/generator/requirements.txt
@@ -1,2 +1,3 @@
 Jinja2 >= 3.1.2
 black >= 23.3.0
+dasbus >= 1.7


### PR DESCRIPTION
This PR enables the check for any API changes and the re-generation of relevant python binding files (e.g. `setup.py` with the proper version). 