### PR TITLE
integration test reconnect: wait a bit after controller has stopped

### DIFF
--- a/tests/tests/tier0/monitor-node-reconnect/test_monitor_node_reconnect.py
+++ b/tests/tests/tier0/monitor-node-reconnect/test_monitor_node_reconnect.py
@@ -20,6 +20,9 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     ctrl.exec_run("systemctl stop bluechi-controller")
     ctrl.wait_for_unit_state_to_be('bluechi-controller', 'inactive')
 
+    # lets wait a bit so the agent has at least one failing reconnect attempt
+    time.sleep(1)
+
     ctrl.exec_run("systemctl start bluechi-controller")
     ctrl.wait_for_bluechi()
     # since the heartbeat (incl. a try to reconnect) is going to happen


### PR DESCRIPTION
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/668

By waiting a bit, e.g. 1s, after the controller has stopped the agent will fail to reconnect at least one time - testing the perpetual retry to connect to the controller again.