### PR TITLE
enable quicker tcp error notification

### DIFF
--- a/config/agent/agent.conf
+++ b/config/agent/agent.conf
@@ -40,3 +40,8 @@
 #
 # If this flag is set to true, no logs are written by bluechi.
 #LogIsQuiet=false
+
+# Enables or disables extended, reliable error message passing for the peer connection with the
+# controller. For example, if set to true, the peer connection will be dropped instantly on
+# Host unreachable errors.
+#IPReceiveErrors=true

--- a/config/controller/controller.conf
+++ b/config/controller/controller.conf
@@ -27,3 +27,8 @@
 #
 # If this flag is set to true, no logs are written by bluechi.
 #LogIsQuiet=false
+
+# Enables or disables extended, reliable error message passing for the peer connection with
+# the agent. For example, if set to true, the peer connection will be dropped instantly on
+# Host unreachable errors.
+#IPReceiveErrors=true

--- a/doc/man/bluechi-agent.conf.5.md
+++ b/doc/man/bluechi-agent.conf.5.md
@@ -66,6 +66,14 @@ By default `journald` is used as the target.
 
 If this flag is set to `true`, no logs are written by bluechi. By default the flag is set to `false`.
 
+#### **IPReceiveErrors** (string)
+
+If this flag is set to `true`, it enables extended, reliable error message passing for
+the peer connection with the controller. This results in BlueChi receiving errors such as
+host unreachable ICMP packets instantly and possibly dropping the connection. This is
+useful to detect disconnects faster, but should be used with care as this might cause
+unnecessary disconnects in less robut networks. Default: true.
+
 ## Example
 
 Using `ManagerHost` and `ManagerPort` options:

--- a/doc/man/bluechi-controller.conf.5.md
+++ b/doc/man/bluechi-controller.conf.5.md
@@ -52,6 +52,15 @@ By default `journald` is used as the target.
 
 If this flag is set to `true`, no logs are written by bluechi. By default the flag is set to `false`.
 
+#### **IPReceiveErrors** (string)
+
+If this flag is set to `true`, it enables extended, reliable error message passing for
+the peer connection with all agents. This results in BlueChi receiving errors such as
+host unreachable ICMP packets instantly and possibly dropping the connection. This is
+useful to detect disconnects faster, but should be used with care as this might cause
+unnecessary disconnects in less robut networks. Default: true.
+
+
 ## Example
 
 A basic example of a configuration file for `bluechi`:

--- a/src/agent/agent.h
+++ b/src/agent/agent.h
@@ -65,6 +65,8 @@ struct Agent {
 
         bool metrics_enabled;
 
+        bool ip_receive_errors;
+
         sd_event *event;
 
         sd_bus *api_bus;

--- a/src/libbluechi/bus/utils.c
+++ b/src/libbluechi/bus/utils.c
@@ -336,8 +336,21 @@ int bus_socket_set_keepalive(sd_bus *bus) {
                 return -errno;
         }
 
-        int enable = 1;
-        r = setsockopt(fd, IPPROTO_IP, IP_RECVERR, &enable, sizeof(int));
+        return 0;
+}
+
+int bus_socket_enable_recv_err(sd_bus *bus) {
+        int fd = sd_bus_get_fd(bus);
+        if (fd < 0) {
+                return fd;
+        }
+
+        if (!is_socket_tcp(fd)) {
+                return -EINVAL;
+        }
+
+        int flag = 1;
+        int r = setsockopt(fd, IPPROTO_IP, IP_RECVERR, &flag, sizeof(int));
         if (r < 0) {
                 return -errno;
         }

--- a/src/libbluechi/bus/utils.c
+++ b/src/libbluechi/bus/utils.c
@@ -336,6 +336,12 @@ int bus_socket_set_keepalive(sd_bus *bus) {
                 return -errno;
         }
 
+        int enable = 1;
+        r = setsockopt(fd, IPPROTO_IP, IP_RECVERR, &enable, sizeof(int));
+        if (r < 0) {
+                return -errno;
+        }
+
         return 0;
 }
 

--- a/src/libbluechi/bus/utils.h
+++ b/src/libbluechi/bus/utils.h
@@ -42,6 +42,7 @@ int bus_parse_unit_on_node_info(sd_bus_message *message, UnitInfo *u);
 
 int bus_socket_set_no_delay(sd_bus *bus);
 int bus_socket_set_keepalive(sd_bus *bus);
+int bus_socket_enable_recv_err(sd_bus *bus);
 
 bool bus_id_is_valid(const char *name);
 

--- a/src/libbluechi/common/cfg.c
+++ b/src/libbluechi/common/cfg.c
@@ -398,9 +398,35 @@ const char *cfg_dump(struct config *config) {
         return cfg_info;
 }
 
+static int cfg_def_conf(struct config *config) {
+        int result = 0;
+
+        if ((result = cfg_set_value(config, CFG_LOG_LEVEL, log_level_to_string(LOG_LEVEL_INFO))) != 0) {
+                return result;
+        }
+
+        if ((result = cfg_set_value(config, CFG_LOG_TARGET, BC_LOG_TARGET_JOURNALD)) != 0) {
+                return result;
+        }
+
+        if ((result = cfg_set_value(config, CFG_LOG_IS_QUIET, NULL)) != 0) {
+                return result;
+        }
+
+        if ((result = cfg_set_value(config, CFG_IP_RECEIVE_ERRORS, BC_DEFAULT_IP_RECEIVE_ERROR)) != 0) {
+                return result;
+        }
+
+        return 0;
+}
+
 int cfg_agent_def_conf(struct config *config) {
         int result = cfg_set_default_section(config, CFG_SECT_AGENT);
         if (result != 0) {
+                return result;
+        }
+
+        if ((result = cfg_def_conf(config)) != 0) {
                 return result;
         }
 
@@ -421,19 +447,6 @@ int cfg_agent_def_conf(struct config *config) {
                 return result;
         }
 
-        const char *LOG_LEVEL_INFO = "INFO";
-        if ((result = cfg_set_value(config, CFG_LOG_LEVEL, LOG_LEVEL_INFO)) != 0) {
-                return result;
-        }
-
-        if ((result = cfg_set_value(config, CFG_LOG_TARGET, BC_LOG_TARGET_JOURNALD)) != 0) {
-                return result;
-        }
-
-        if ((result = cfg_set_value(config, CFG_LOG_IS_QUIET, NULL)) != 0) {
-                return result;
-        }
-
         return 0;
 }
 
@@ -445,23 +458,15 @@ int cfg_manager_def_conf(struct config *config) {
                 return result;
         }
 
+        if ((result = cfg_def_conf(config)) != 0) {
+                return result;
+        }
+
         if ((result = cfg_set_value(config, CFG_MANAGER_PORT, BC_DEFAULT_PORT)) != 0) {
                 return result;
         }
 
         if ((result = cfg_set_value(config, CFG_ALLOWED_NODE_NAMES, "")) != 0) {
-                return result;
-        }
-
-        if ((result = cfg_set_value(config, CFG_LOG_LEVEL, log_level_to_string(LOG_LEVEL_INFO))) != 0) {
-                return result;
-        }
-
-        if ((result = cfg_set_value(config, CFG_LOG_TARGET, BC_LOG_TARGET_JOURNALD)) != 0) {
-                return result;
-        }
-
-        if ((result = cfg_set_value(config, CFG_LOG_IS_QUIET, NULL)) != 0) {
                 return result;
         }
 

--- a/src/libbluechi/common/cfg.h
+++ b/src/libbluechi/common/cfg.h
@@ -17,6 +17,7 @@
 #define CFG_NODE_NAME "NodeName"
 #define CFG_ALLOWED_NODE_NAMES "AllowedNodeNames"
 #define CFG_HEARTBEAT_INTERVAL "HeartbeatInterval"
+#define CFG_IP_RECEIVE_ERRORS "IPReceiveErrors"
 
 /*
  * Global section - this is used, when configuration options are specified in the configuration file

--- a/src/libbluechi/common/protocol.h
+++ b/src/libbluechi/common/protocol.h
@@ -5,6 +5,8 @@
 
 #define BC_DEFAULT_PORT "842"
 #define BC_DEFAULT_HOST "127.0.0.1"
+/* Enable extended reliable error message passing */
+#define BC_DEFAULT_IP_RECEIVE_ERROR "true"
 
 #define BC_DBUS_NAME "org.eclipse.bluechi"
 #define BC_AGENT_DBUS_NAME "org.eclipse.bluechi.Agent"

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -371,11 +371,11 @@ static int manager_accept_node_connection(
 
         int r = bus_socket_set_no_delay(dbus_server);
         if (r < 0) {
-                bc_log_warn("Failed to set NO_DELAY on socket");
+                bc_log_warnf("Failed to set NO_DELAY on socket: %s", strerror(-r));
         }
         r = bus_socket_set_keepalive(dbus_server);
         if (r < 0) {
-                bc_log_warn("Failed to set KEEPALIVE on socket");
+                bc_log_warnf("Failed to set KEEPALIVE on socket: %s", strerror(-r));
         }
 
         /* Add anonymous node */

--- a/src/manager/manager.h
+++ b/src/manager/manager.h
@@ -26,6 +26,8 @@ struct Manager {
 
         bool metrics_enabled;
 
+        bool ip_receive_errors;
+
         int n_nodes;
         LIST_HEAD(Node, nodes);
         LIST_HEAD(Node, anonymous_nodes);


### PR DESCRIPTION
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/652
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/648

When a connection between controller and agent is esablished and is dropped later, e.g. removing the cable from the agent, the disconnect is properly detected by the keepalive mechanism. However, the keepalive takes a while to detect this (based on the KEEPCNT of the system). If any command is issued during that time frame, tcp will try to retransmit the data. Eventually, retransmitting will be stopped and ICMP packets for host not reachable emitted. The keepalive is not used then, which results in the connection between agent and controller to be broken but not closed - a disconnect is not detected.
By setting the IP_RECVERR socket option, errors such as the ICMP host not reachable error will be delivered to the upper layer (systemd event loop in our case) so that it can handle it.

A detailed explanation can be found in this comment: https://github.com/eclipse-bluechi/bluechi/issues/652#issuecomment-1859772124
