### PR TITLE
Test for cmd -c option for agent and controller

### DIFF
--- a/tests/bluechi_test/container.py
+++ b/tests/bluechi_test/container.py
@@ -205,6 +205,13 @@ class BluechiContainer():
         self.extract_valgrind_logs(valgrind_log_path_controller, bluechi_valgrind_log_target_path, data_dir)
         self.extract_valgrind_logs(valgrind_log_path_agent, bluechi_agent_valgrind_log_target_path, data_dir)
 
+    def restart_with_config_file(self, config_file_location, service):
+        self.exec_run(f"sed -i '/ExecStart=/c\\ExecStart=/usr/libexec/{service} -c "
+                      f"{config_file_location}' "
+                      f"/usr/lib/systemd/system/{service}.service")
+        self.exec_run("systemctl daemon-reload")
+        self.exec_run(f"systemctl restart {service}.service")
+
 
 class BluechiNodeContainer(BluechiContainer):
 

--- a/tests/tests/tier0/bluechi-agent-cmd-line-c-invalid-config/config-files/invalid.conf
+++ b/tests/tests/tier0/bluechi-agent-cmd-line-c-invalid-config/config-files/invalid.conf
@@ -1,0 +1,2 @@
+[bluechi-agent]
+ManagerPort8420

--- a/tests/tests/tier0/bluechi-agent-cmd-line-c-invalid-config/main.fmf
+++ b/tests/tests/tier0/bluechi-agent-cmd-line-c-invalid-config/main.fmf
@@ -1,0 +1,2 @@
+summary: Test agent cmd -c option with invalid config file
+id: bb9d4394-bd53-4d36-b8ba-ee91697c4850

--- a/tests/tests/tier0/bluechi-agent-cmd-line-c-invalid-config/test_bluechi_agent_cmd_line_c_invalid_config.py
+++ b/tests/tests/tier0/bluechi-agent-cmd-line-c-invalid-config/test_bluechi_agent_cmd_line_c_invalid_config.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import logging
+
+from typing import Dict
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+from bluechi_test.util import read_file
+
+LOGGER = logging.getLogger(__name__)
+
+NODE_FOO = "node-foo"
+failed_status = "failed"
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+
+    node_foo = nodes[NODE_FOO]
+    config_file_location = "/var/tmp"
+    bluechi_agent_str = "bluechi-agent"
+    invalid_conf_str = "config-files/invalid.conf"
+
+    # Copying relevant config files into node container
+    content = read_file(invalid_conf_str)
+    node_foo.create_file(config_file_location, invalid_conf_str, content)
+
+    LOGGER.debug("Setting invalid.conf as conf file for foo and checking if failed")
+    node_foo.restart_with_config_file(os.path.join(config_file_location, invalid_conf_str), bluechi_agent_str)
+    assert node_foo.wait_for_unit_state_to_be(bluechi_agent_str, failed_status)
+
+
+def test_agent_config_c_option(
+        bluechi_test: BluechiTest,
+        bluechi_node_default_config: BluechiNodeConfig, bluechi_ctrl_default_config: BluechiControllerConfig):
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = NODE_FOO
+
+    bluechi_test.add_bluechi_node_config(node_foo_cfg)
+
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO]
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(exec)

--- a/tests/tests/tier0/bluechi-controller-cmd-line-c-invalid-config/config-files/invalid.conf
+++ b/tests/tests/tier0/bluechi-controller-cmd-line-c-invalid-config/config-files/invalid.conf
@@ -1,0 +1,2 @@
+[bluechi-controller]
+ManagerPort8420

--- a/tests/tests/tier0/bluechi-controller-cmd-line-c-invalid-config/main.fmf
+++ b/tests/tests/tier0/bluechi-controller-cmd-line-c-invalid-config/main.fmf
@@ -1,0 +1,2 @@
+summary: Test controller cmd -c option with invalid config file
+id: bb9d4394-bd53-4d36-b8ba-ee91697c4850

--- a/tests/tests/tier0/bluechi-controller-cmd-line-c-invalid-config/test_bluechi_controller_cmd_line_c_invalid_config.py
+++ b/tests/tests/tier0/bluechi-controller-cmd-line-c-invalid-config/test_bluechi_controller_cmd_line_c_invalid_config.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import logging
+
+from typing import Dict
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig
+from bluechi_test.util import read_file
+
+LOGGER = logging.getLogger(__name__)
+
+failed_status = "failed"
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+    config_file_location = "/var/tmp"
+    bluechi_controller_str = "bluechi-controller"
+    invalid_conf_str = "config-files/invalid.conf"
+
+    # Copying relevant config files into the container
+    content = read_file(invalid_conf_str)
+    ctrl.create_file(config_file_location, invalid_conf_str, content)
+
+    LOGGER.debug("Setting invalid.conf as conf file for ctrl and checking if failed")
+    ctrl.restart_with_config_file(os.path.join(config_file_location, invalid_conf_str), bluechi_controller_str)
+    assert ctrl.wait_for_unit_state_to_be(bluechi_controller_str, failed_status)
+
+
+def test_agent_config_c_option(
+        bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Test for cmd -c option for agent and controller

Test if cmd -c option with invalid conf will
set the status of the agent and controller to failed status.

Related-to: https://github.com/eclipse-bluechi/bluechi/issues/668
Signed-off-by: Artiom Divak <adivak@redhat.com>