### PR TITLE
added tmt serial no. to container name

### DIFF
--- a/tests/bluechi_test/fixtures.py
+++ b/tests/bluechi_test/fixtures.py
@@ -18,10 +18,15 @@ def tmt_test_data_dir() -> str:
     return _get_env_value('TMT_TEST_DATA', os.getcwd())
 
 
+@pytest.fixture(scope='function')
+def tmt_test_serial_number() -> str:
+    """Return serial number of current test"""
+    return _get_env_value('TMT_TEST_SERIAL_NUMBER', 'NA')
+
+
 @pytest.fixture(scope='session')
 def bluechi_image_name() -> str:
     """Returns the name of bluechi testing container images"""
-
     return _get_env_value('BLUECHI_IMAGE_NAME', 'bluechi-image')
 
 
@@ -101,6 +106,7 @@ def bluechi_test(
         bluechi_image_id: str,
         bluechi_ctrl_host_port: str,
         bluechi_ctrl_svc_port: str,
+        tmt_test_serial_number: str,
         tmt_test_data_dir: str,
         run_with_valgrind: bool,
         run_with_coverage: bool):
@@ -110,7 +116,8 @@ def bluechi_test(
         bluechi_image_id,
         bluechi_ctrl_host_port,
         bluechi_ctrl_svc_port,
+        tmt_test_serial_number,
         tmt_test_data_dir,
         run_with_valgrind,
         run_with_coverage,
-        )
+    )

--- a/tests/bluechi_test/test.py
+++ b/tests/bluechi_test/test.py
@@ -25,6 +25,7 @@ class BluechiTest():
             bluechi_image_id: str,
             bluechi_ctrl_host_port: str,
             bluechi_ctrl_svc_port: str,
+            tmt_test_serial_number: str,
             tmt_test_data_dir: str,
             run_with_valgrind: bool,
             run_with_coverage: bool) -> None:
@@ -33,6 +34,7 @@ class BluechiTest():
         self.bluechi_image_id = bluechi_image_id
         self.bluechi_ctrl_host_port = bluechi_ctrl_host_port
         self.bluechi_ctrl_svc_port = bluechi_ctrl_svc_port
+        self.tmt_test_serial_number = tmt_test_serial_number
         self.tmt_test_data_dir = tmt_test_data_dir
         self.run_with_valgrind = run_with_valgrind
         self.run_with_coverage = run_with_coverage
@@ -60,7 +62,7 @@ class BluechiTest():
                 \n{self.bluechi_controller_config.serialize()}")
 
             c = self.podman_client.containers.run(
-                name=self.bluechi_controller_config.name,
+                name=f"{self.bluechi_controller_config.name}-{self.tmt_test_serial_number}",
                 image=self.bluechi_image_id,
                 detach=True,
                 ports={self.bluechi_ctrl_svc_port: self.bluechi_ctrl_host_port},
@@ -77,7 +79,7 @@ class BluechiTest():
                 LOGGER.debug(f"Starting container bluechi-node '{cfg.node_name}' with config:\n{cfg.serialize()}")
 
                 c = self.podman_client.containers.run(
-                    name=cfg.node_name,
+                    name=f"{cfg.node_name}-{self.tmt_test_serial_number}",
                     image=self.bluechi_image_id,
                     detach=True,
                 )


### PR DESCRIPTION
Added TMT serial number to container names in order to prevent cascading failures when containers from previous tests aren't properly cleaned up.