### PR TITLE
Test for -c option check if port is changed

### DIFF
--- a/tests/bluechi_test/fixtures.py
+++ b/tests/bluechi_test/fixtures.py
@@ -101,6 +101,11 @@ def bluechi_node_default_config(bluechi_ctrl_svc_port: str):
 
 
 @pytest.fixture(scope='function')
+def additional_ports():
+    return None
+
+
+@pytest.fixture(scope='function')
 def bluechi_test(
         podman_client: PodmanClient,
         bluechi_image_id: str,
@@ -109,7 +114,8 @@ def bluechi_test(
         tmt_test_serial_number: str,
         tmt_test_data_dir: str,
         run_with_valgrind: bool,
-        run_with_coverage: bool):
+        run_with_coverage: bool,
+        additional_ports: dict):
 
     return BluechiTest(
         podman_client,
@@ -120,4 +126,5 @@ def bluechi_test(
         tmt_test_data_dir,
         run_with_valgrind,
         run_with_coverage,
+        additional_ports
     )

--- a/tests/bluechi_test/test.py
+++ b/tests/bluechi_test/test.py
@@ -28,7 +28,8 @@ class BluechiTest():
             tmt_test_serial_number: str,
             tmt_test_data_dir: str,
             run_with_valgrind: bool,
-            run_with_coverage: bool) -> None:
+            run_with_coverage: bool,
+            additional_ports: dict) -> None:
 
         self.podman_client = podman_client
         self.bluechi_image_id = bluechi_image_id
@@ -38,6 +39,7 @@ class BluechiTest():
         self.tmt_test_data_dir = tmt_test_data_dir
         self.run_with_valgrind = run_with_valgrind
         self.run_with_coverage = run_with_coverage
+        self.additional_ports = additional_ports
 
         self.bluechi_controller_config: BluechiControllerConfig = None
         self.bluechi_node_configs: List[BluechiNodeConfig] = []
@@ -61,11 +63,14 @@ class BluechiTest():
             LOGGER.debug(f"Starting container for bluechi-controller with config:\
                 \n{self.bluechi_controller_config.serialize()}")
 
+            ports = {self.bluechi_ctrl_svc_port: self.bluechi_ctrl_host_port}
+            if self.additional_ports:
+                ports.update(self.additional_ports)
             c = self.podman_client.containers.run(
                 name=f"{self.bluechi_controller_config.name}-{self.tmt_test_serial_number}",
                 image=self.bluechi_image_id,
                 detach=True,
-                ports={self.bluechi_ctrl_svc_port: self.bluechi_ctrl_host_port},
+                ports=ports,
             )
             c.wait(condition="running")
 

--- a/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/config-files/agent_port_8421.conf
+++ b/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/config-files/agent_port_8421.conf
@@ -1,0 +1,2 @@
+[bluechi-agent]
+ManagerPort=8421

--- a/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/config-files/ctrl_port_8421.conf
+++ b/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/config-files/ctrl_port_8421.conf
@@ -1,0 +1,2 @@
+[bluechi-controller]
+ManagerPort=8421

--- a/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/main.fmf
+++ b/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/main.fmf
@@ -1,0 +1,3 @@
+summary: "Test if bluechi agent/controller accepts changing port using a custom 
+configuration file passed by command line option -c."
+id: 5645dcdf-acaa-4a04-8c0d-d478c8a6f2a3

--- a/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/python/is_node_connected.py
+++ b/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/python/is_node_connected.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from bluechi.api import Node
+
+
+class TestNodeIsConnected(unittest.TestCase):
+
+    def test_node_is_connected(self):
+        n = Node("node-foo")
+        assert n.status == "online"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/test_bluechi_change_port_with_c_cmd_option.py
+++ b/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/test_bluechi_change_port_with_c_cmd_option.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from typing import Dict
+import os
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+from bluechi_test.util import read_file
+
+NODE_FOO = "node-foo"
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+    node_foo = nodes[NODE_FOO]
+    config_file_location = "/var/tmp"
+    bluechi_agent_str = "bluechi-agent"
+    bluechi_controller_str = "bluechi-controller"
+    file_location_ctrl = os.path.join("config-files", "ctrl_port_8421.conf")
+    file_location_agent = os.path.join("config-files", "agent_port_8421.conf")
+
+    # Copying relevant config files into the nodes container
+    content = read_file(file_location_agent)
+    node_foo.create_file(config_file_location, file_location_agent, content)
+    content = read_file(file_location_ctrl)
+    ctrl.create_file(config_file_location, file_location_ctrl, content)
+
+    ctrl.restart_with_config_file(
+        os.path.join(config_file_location, "ctrl_port_8421.conf"), bluechi_controller_str)
+    assert ctrl.wait_for_unit_state_to_be(bluechi_controller_str, "active")
+
+    # Check if port 8421 is listenning and 8420 is disconnected
+    _, output = ctrl.exec_run("lsof -i:8421")
+    assert "bluechi-c" in str(output)
+    _, output = ctrl.exec_run("lsof -i:8420")
+    assert b'' == output
+
+    # Check if node disconnected
+    result, _ = ctrl.run_python(os.path.join("python", "is_node_connected.py"))
+    assert result
+
+    node_foo.restart_with_config_file(
+        os.path.join(config_file_location, "agent_port_8421.conf"), bluechi_agent_str)
+    assert node_foo.wait_for_unit_state_to_be(bluechi_agent_str, "active")
+
+    # Check if node connected
+    _, output = node_foo.exec_run("lsof -i:8421")
+    assert "bluechi-a" in str(output)
+
+    result, _ = ctrl.run_python(os.path.join("python", "is_node_connected.py"))
+    assert not result
+
+
+def test_agent_invalid_port_configuration(
+        bluechi_test: BluechiTest,
+        bluechi_node_default_config: BluechiNodeConfig, bluechi_ctrl_default_config: BluechiControllerConfig):
+
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = NODE_FOO
+
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO]
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.add_bluechi_node_config(node_foo_cfg)
+
+    bluechi_test.additional_ports = {"8421": "8421"}
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Added an option to add open ports for spawned containers. And also added a test to check if conf file change with -c option will change the ports for agent and ctrl.

Related-to: https://github.com/eclipse-bluechi/bluechi/issues/668