### PR TITLE
Small fixes in agent shutdown

### DIFF
--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -485,7 +485,7 @@ void agent_unref(Agent *agent) {
         bc_log_debug("Finalizing agent");
 
         /* These are removed in agent_stop */
-        assert(agent->proxy_services == NULL);
+        assert(LIST_IS_EMPTY(agent->proxy_services));
 
         hashmap_free(agent->unit_infos);
 

--- a/src/agent/main.c
+++ b/src/agent/main.c
@@ -159,8 +159,8 @@ int main(int argc, char *argv[]) {
                 return EXIT_FAILURE;
         }
 
-        if (agent_start(agent)) {
-                return EXIT_SUCCESS;
+        if (!agent_start(agent)) {
+                return EXIT_FAILURE;
         }
 
         agent_stop(agent);


### PR DESCRIPTION
This PR fixes two small bugs:

### Asserting that the proxy service list on `agent_unref`

Currently, this assertion fails:
```
bluechi-agent: ../src/agent/agent.c:488: agent_unref: Assertion `agent->proxy_services == NULL' failed.
```
We are only stopping and removing them from the list and not setting it `NULL`. It doesn't make sense to set the list pointer to `NULL`. So lets assert `LIST_IS_EMPTY` instead.

### Wrong return value check for `agent_start`

This bug leads to exiting successful while not cleaning up the proxy services since `agent_stop` isn't called. This, however, reveals another issue we currently have: 
After exiting the event loop, we can't emit signals or call methods. In case of `agent_stop`, this means that the call to stop proxy services is actually failing
```
bluechi-agent[25]: Failed to call async: Transport endpoint is not connected
bluechi-agent[25]: Failed to stop proxy service: Input/output error
```
I'll tackle this issue in a separate PR to keep this one small. 