### PR TITLE
removed D-Bus method Shutdown

### DIFF
--- a/README.developer.md
+++ b/README.developer.md
@@ -83,8 +83,6 @@ org.eclipse.bluechi.Manager         interface -         -              -
 .SetLogLevel                        method    s         -              -
 .JobNew                             signal    uo        -              -
 .JobRemoved                         signal    uosss     -              -
-org.eclipse.bluechi.Shutdown        interface -         -              -
-.Shutdown                           method    -         -              -
 org.freedesktop.DBus.Introspectable interface -         -              -
 .Introspect                         method    -         s              -
 org.freedesktop.DBus.Peer           interface -         -              -

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -2378,12 +2378,6 @@ bool agent_start(Agent *agent) {
                 sd_bus_add_filter(agent->systemd_dbus, NULL, debug_systemd_message_handler, agent);
         }
 
-        r = shutdown_service_register(agent->api_bus, agent->event);
-        if (r < 0) {
-                bc_log_errorf("Failed to register shutdown service: %s", strerror(-r));
-                return false;
-        }
-
         r = event_loop_add_shutdown_signals(agent->event);
         if (r < 0) {
                 bc_log_errorf("Failed to add signals to agent event loop: %s", strerror(-r));

--- a/src/libbluechi/service/shutdown.c
+++ b/src/libbluechi/service/shutdown.c
@@ -16,66 +16,6 @@ int shutdown_event_loop(sd_event *event) {
         return sd_event_exit(event, 0);
 }
 
-static int method_shutdown(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
-        if (userdata == NULL) {
-                return -EINVAL;
-        }
-
-        sd_event *event = (sd_event *) userdata;
-
-        int r = shutdown_event_loop(event);
-        if (r < 0) {
-                return sd_bus_reply_method_errnof(m, -r, "Failed to shutown event loop: %m");
-        }
-        return sd_bus_reply_method_return(m, "");
-}
-
-#define method_name_shutdown "Shutdown"
-
-static const sd_bus_vtable vtable_shutdown[] = {
-        SD_BUS_VTABLE_START(0), SD_BUS_METHOD(method_name_shutdown, "", "", method_shutdown, 0), SD_BUS_VTABLE_END
-};
-
-int shutdown_service_register(sd_bus *target_bus, sd_event *event) {
-        if (target_bus == NULL || event == NULL) {
-                return -EINVAL;
-        }
-
-        _cleanup_free_ char *interface_name = assemble_interface_name(method_name_shutdown);
-        return sd_bus_add_object_vtable(
-                        target_bus, NULL, BC_OBJECT_PATH, interface_name, vtable_shutdown, event);
-}
-
-
-int service_call_shutdown(sd_bus *target_bus, const char *service_name) {
-        if (target_bus == NULL || service_name == NULL) {
-                return -EINVAL;
-        }
-
-        _cleanup_free_ char *interface_name = assemble_interface_name(method_name_shutdown);
-        if (interface_name == NULL) {
-                return -1;
-        }
-
-        _cleanup_sd_bus_error_ sd_bus_error error = SD_BUS_ERROR_NULL;
-        _cleanup_sd_bus_message_ sd_bus_message *reply = NULL;
-
-        int r = sd_bus_call_method(
-                        target_bus,
-                        service_name,
-                        BC_OBJECT_PATH,
-                        interface_name,
-                        method_name_shutdown,
-                        &error,
-                        &reply,
-                        "");
-        if (r < 0) {
-                bc_log_errorf("Failed to call '%s': %s", method_name_shutdown, error.message);
-                return r;
-        }
-        return 0;
-}
-
 static int event_loop_signal_handler(
                 sd_event_source *event_source, UNUSED const struct signalfd_siginfo *si, UNUSED void *userdata) {
         if (event_source == NULL) {

--- a/src/libbluechi/service/shutdown.h
+++ b/src/libbluechi/service/shutdown.h
@@ -5,6 +5,4 @@
 #include <systemd/sd-bus.h>
 
 int shutdown_event_loop(sd_event *event_loop);
-int shutdown_service_register(sd_bus *target_bus, sd_event *event);
-int service_call_shutdown(sd_bus *target_bus, const char *service_name);
 int event_loop_add_shutdown_signals(sd_event *event);

--- a/src/manager/manager.c
+++ b/src/manager/manager.c
@@ -1047,12 +1047,6 @@ bool manager_start(Manager *manager) {
                 return false;
         }
 
-        r = shutdown_service_register(manager->api_bus, manager->event);
-        if (r < 0) {
-                bc_log_errorf("Failed to register shutdown service: %s", strerror(-r));
-                return false;
-        }
-
         r = event_loop_add_shutdown_signals(manager->event);
         if (r < 0) {
                 bc_log_errorf("Failed to add signals to manager event loop: %s", strerror(-r));


### PR DESCRIPTION
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/682

The D-Bus method Shutdown was added in the early days of the project and has never been used to this day. The use case of this method is also not clear. So in order to keep the API of BlueChi as lean as possible, lets remove the Shutdown method.

Note: The `Shutdown` interface was actually never documented - so the chances of it being used are even smaller. 