### PR TITLE
disable llvm-include-order rule for clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@
 Checks: >
     *,
     -llvm-header-guard,
+    -llvm-include-order,
     -llvmlibc-restrict-system-libc-headers,
     -cert-err33-c,
     -cert-dcl37-c,


### PR DESCRIPTION
clang-format and clang-tidy seem to both evaluate the include order, but with a different set of rules. For example, clang-format would apply
   #include method-unit-actions.h
   #include client.h
while clang-tidy would sort them in reverse - and error on the other. Since this is a formatting task, lets disable the include order rule in clang-tidy.