### PR TITLE
Introduced shutdown hook running before exiting event loop

### DIFF
--- a/src/agent/agent.h
+++ b/src/agent/agent.h
@@ -109,7 +109,7 @@ void agent_set_systemd_user(Agent *agent, bool systemd_user);
 bool agent_parse_config(Agent *agent, const char *configfile);
 
 bool agent_start(Agent *agent);
-bool agent_stop(Agent *agent);
+void agent_stop(Agent *agent);
 
 bool agent_is_connected(Agent *agent);
 char *agent_is_online(Agent *agent);

--- a/src/agent/main.c
+++ b/src/agent/main.c
@@ -161,10 +161,8 @@ int main(int argc, char *argv[]) {
                 return EXIT_FAILURE;
         }
 
-        if (!agent_start(agent)) {
-                return EXIT_FAILURE;
+        if (agent_start(agent)) {
+                return EXIT_SUCCESS;
         }
-
-        agent_stop(agent);
-        return EXIT_SUCCESS;
+        return EXIT_FAILURE;
 }

--- a/src/client/method-metrics.c
+++ b/src/client/method-metrics.c
@@ -121,7 +121,7 @@ static int method_metrics_listen(Client *client) {
                 return r;
         }
 
-        r = event_loop_add_shutdown_signals(event);
+        r = event_loop_add_shutdown_signals(event, NULL);
         if (r < 0) {
                 fprintf(stderr, "Failed to add signals to agent event loop: %s", strerror(-r));
                 return r;

--- a/src/client/method-monitor.c
+++ b/src/client/method-monitor.c
@@ -21,7 +21,7 @@ static int start_event_loop(sd_bus *api_bus) {
                 return r;
         }
 
-        r = event_loop_add_shutdown_signals(event);
+        r = event_loop_add_shutdown_signals(event, NULL);
         if (r < 0) {
                 fprintf(stderr, "Failed to add signals to agent event loop: %s", strerror(-r));
                 return r;

--- a/src/client/method-status.c
+++ b/src/client/method-status.c
@@ -26,7 +26,7 @@ static const struct bus_properties_map property_map[] = {
         { "FreezerState", offsetof(unit_info_t, freezer_state) },
         { "SubState", offsetof(unit_info_t, sub_state) },
         { "UnitFileState", offsetof(unit_info_t, unit_file_state) },
-        {}
+        { NULL, 0 },
 };
 
 static int get_property_map(sd_bus_message *m, const struct bus_properties_map **prop) {

--- a/src/libbluechi/service/shutdown.c
+++ b/src/libbluechi/service/shutdown.c
@@ -1,32 +1,27 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #include <errno.h>
-#include <systemd/sd-bus-vtable.h>
 
 #include "libbluechi/common/common.h"
 #include "libbluechi/log/log.h"
 
-#include "service.h"
 #include "shutdown.h"
 
-int shutdown_event_loop(sd_event *event) {
-        if (event == NULL) {
-                return -EINVAL;
-        }
-
-        return sd_event_exit(event, 0);
-}
-
 static int event_loop_signal_handler(
-                sd_event_source *event_source, UNUSED const struct signalfd_siginfo *si, UNUSED void *userdata) {
+                sd_event_source *event_source, UNUSED const struct signalfd_siginfo *si, void *userdata) {
         if (event_source == NULL) {
                 return -EINVAL;
         }
 
+        ShutdownHook *hook = (ShutdownHook *) userdata;
+        if (hook != NULL && hook->shutdown != NULL) {
+                hook->shutdown(hook->userdata);
+        }
+
         sd_event *event = sd_event_source_get_event(event_source);
-        return shutdown_event_loop(event);
+        return sd_event_exit(event, 0);
 }
 
-int event_loop_add_shutdown_signals(sd_event *event) {
+int event_loop_add_shutdown_signals(sd_event *event, ShutdownHook *hook) {
         sigset_t sigset;
         int r = 0;
 
@@ -58,12 +53,12 @@ int event_loop_add_shutdown_signals(sd_event *event) {
         }
 
         // Add SIGTERM and SIGINT as event sources in the event loop.
-        r = sd_event_add_signal(event, NULL, SIGTERM, event_loop_signal_handler, NULL);
+        r = sd_event_add_signal(event, NULL, SIGTERM, event_loop_signal_handler, hook);
         if (r < 0) {
                 bc_log_errorf("sd_event_add_signal() failed: %s", strerror(-r));
                 return -1;
         }
-        r = sd_event_add_signal(event, NULL, SIGINT, event_loop_signal_handler, NULL);
+        r = sd_event_add_signal(event, NULL, SIGINT, event_loop_signal_handler, hook);
         if (r < 0) {
                 bc_log_errorf("sd_event_add_signal() failed: %s", strerror(-r));
                 return -1;

--- a/src/libbluechi/service/shutdown.h
+++ b/src/libbluechi/service/shutdown.h
@@ -4,5 +4,12 @@
 #include <stdbool.h>
 #include <systemd/sd-bus.h>
 
+typedef void (*ShutdownHookFn)(void *userdata);
+
+typedef struct ShutdownHook {
+        ShutdownHookFn shutdown;
+        void *userdata;
+} ShutdownHook;
+
 int shutdown_event_loop(sd_event *event_loop);
-int event_loop_add_shutdown_signals(sd_event *event);
+int event_loop_add_shutdown_signals(sd_event *event, ShutdownHook *hook);

--- a/src/manager/manager.h
+++ b/src/manager/manager.h
@@ -48,6 +48,7 @@ bool manager_set_port(Manager *manager, const char *port);
 bool manager_parse_config(Manager *manager, const char *configfile);
 
 bool manager_start(Manager *manager);
+void manager_stop(Manager *manager);
 
 Node *manager_find_node(Manager *manager, const char *name);
 Node *manager_find_node_by_path(Manager *manager, const char *path);

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -198,9 +198,10 @@ void node_unref(Node *node) {
                 proxy_dependency_free(dep);
         }
 
-        sd_bus_slot_unrefp(&node->export_slot);
 
         node_unset_agent_bus(node);
+        sd_bus_slot_unrefp(&node->export_slot);
+
         hashmap_free(node->unit_subscriptions);
 
         free_and_null(node->name);


### PR DESCRIPTION
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/686
Relates to: https://github.com/eclipse-bluechi/bluechi/pull/681

A shutdown hook function has been introduced that is executed right before exiting the event loop. By doing so, the agent and controller are able to perform final shutdown actions such as emitting signals.
It uses the agent_stop and manager_stop functions for both applications to perform these tasks and applies asserts in the unref functions to cross-check that all lists, e.g. for nodes or jobs, have been cleared.

One way to test this is by the [monitor agent connection on the managed node](https://bluechi.readthedocs.io/en/latest/api/examples/#monitor-the-connection-on-the-managed-node) script. 

*Note:*
In the integration tests, e.g. for the proxy service tests, there might still be errors in the logs such as:
```bash
systemd[1]: bluechi-agent.service: Failed to kill control group /system.slice/bluechi-agent.service, ignoring: Input/output error
```
This is due to the order of shutting down. Since we don't know the dependencies in the generic test setup, this might happen. 
