### PR TITLE
add a comment for each PR about test coverage

### DIFF
--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -1,0 +1,42 @@
+name: Comment on the pull request
+
+on:
+  workflow_run:
+    workflows: ["Integration tests"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download coverage-artifacts-info
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "coverage-artifacts-info"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/coverage-artifacts-info.zip', Buffer.from(download.data));
+      - run: unzip coverage-artifacts-info.zip
+
+      - name: Create comment with code coverage on PR
+        uses: romeovs/lcov-reporter-action@v0.2.16
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          lcov-file: merged.info

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Perform build
         run: |
-          ./build-scripts/build-rpm.sh $ARTIFACTS_DIR
+          WITH_COVERAGE=1 ./build-scripts/build-rpm.sh $ARTIFACTS_DIR
 
       - name: Create DNF repository
         run: |
@@ -55,6 +55,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install \
                   genisoimage \
+                  lcov \
                   libkrb5-dev \
                   libvirt-daemon-system \
                   libvirt-dev \
@@ -89,17 +90,45 @@ jobs:
       - name: Run integration tests
         run: |
           cd tests
-          tmt run -v -eCONTAINER_USED=integration-test-local
+          tmt run -v -eCONTAINER_USED=integration-test-local -eWITH_COVERAGE=1
 
       - name: Show tmt log output in case of failure
         if: ${{ failure() }}
         run: |
           cat /var/tmp/tmt/run-001/log.txt
 
-      - name: Gather tests artifacts
+      # Extract the collected coverage results if they exist and remove them from
+      # the tmt directory to avoid duplication in artifacts
+      - name: Extract coverage results
+        if: always()
+        run: |
+          MERGE_FILE="/var/tmp/tmt/run-001/plans/tier0/report/default-0/merged.info"
+          COVERAGE_DIR="/var/tmp/tmt/run-001/plans/tier0/report/default-0/report/"
+          if [ -d "$COVERAGE_DIR" ]; then
+            cp -r $COVERAGE_DIR /var/tmp
+            cp $MERGE_FILE /var/tmp
+            rm -rf $COVERAGE_DIR
+            rm -rf $MERGE_FILE
+          fi
+      
+      - name: Upload tmt artifacts
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: test-artifacts
+          name: tmt-artifacts
           path: '/var/tmp/tmt'
 
+      - name: Upload coverage HTML report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-artifacts-html
+          path: '/var/tmp/report'
+      
+      - name: Upload coverage file
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-artifacts-info
+          path: '/var/tmp/merged.info'
+      


### PR DESCRIPTION
This PR extends the integration test workflow in GH to add a comment about the test coverage to a PR. For this, it uses https://github.com/romeovs/lcov-reporter-action. It also splits the results of tmt into tmt logs and coverage results (html report and info file). 

**Note 1:**
This can later be further extended to 
- create and use a badge (e.g. on the README) to display coverage
- define coverage thresholds

**Note 2:**
The comment won't appear in this PR since it first needs to be merged and the comment workflow be part of this repository. 