### PR TITLE
bluechictl: add flags to enable and disable commands

### DIFF
--- a/src/agent/main.c
+++ b/src/agent/main.c
@@ -23,7 +23,7 @@ const struct option options[] = {
         { NULL,                   0,                 0, '\0'                        }
 };
 
-#define OPTIONS_STR                                                                               \
+#define GETOPT_OPTSTRING                                                                          \
         ARG_PORT_SHORT_S ARG_HOST_SHORT_S ARG_ADDRESS_SHORT_S ARG_HELP_SHORT_S ARG_CONFIG_SHORT_S \
                         ARG_NAME_SHORT_S ARG_USER_SHORT_S ARG_HEARTBEAT_INTERVAL_SHORT_S ARG_VERSION_SHORT_S
 
@@ -72,7 +72,7 @@ static void usage(char *argv[]) {
 static int get_opts(int argc, char *argv[]) {
         int opt = 0;
 
-        while ((opt = getopt_long(argc, argv, OPTIONS_STR, options, NULL)) != -1) {
+        while ((opt = getopt_long(argc, argv, GETOPT_OPTSTRING, options, NULL)) != -1) {
                 switch (opt) {
                 case ARG_HELP_SHORT:
                         usage(argv);

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -18,6 +18,9 @@
 #define OPT_NONE 0u
 #define OPT_HELP 1u << 0u
 #define OPT_FILTER 1u << 1u
+#define OPT_FORCE 1u << 2u
+#define OPT_RUNTIME 1u << 3u
+#define OPT_NO_RELOAD 1u << 4u
 
 int method_version(UNUSED Command *command, UNUSED void *userdata) {
         printf("bluechictl version %s\n", CONFIG_H_BC_VERSION);
@@ -25,35 +28,41 @@ int method_version(UNUSED Command *command, UNUSED void *userdata) {
 }
 
 const Method methods[] = {
-        {"help",           0, 0,       OPT_NONE,   method_help,          usage_bluechi},
-        { "list-units",    0, 1,       OPT_FILTER, method_list_units,    usage_bluechi},
-        { "start",         2, 2,       OPT_NONE,   method_start,         usage_bluechi},
-        { "stop",          2, 2,       OPT_NONE,   method_stop,          usage_bluechi},
-        { "freeze",        2, 2,       OPT_NONE,   method_freeze,        usage_bluechi},
-        { "thaw",          2, 2,       OPT_NONE,   method_thaw,          usage_bluechi},
-        { "restart",       2, 2,       OPT_NONE,   method_restart,       usage_bluechi},
-        { "reload",        2, 2,       OPT_NONE,   method_reload,        usage_bluechi},
-        { "monitor",       0, 2,       OPT_NONE,   method_monitor,       usage_bluechi},
-        { "metrics",       1, 1,       OPT_NONE,   method_metrics,       usage_bluechi},
-        { "enable",        2, ARG_ANY, OPT_NONE,   method_enable,        usage_bluechi},
-        { "disable",       2, ARG_ANY, OPT_NONE,   method_disable,       usage_bluechi},
-        { "daemon-reload", 1, 1,       OPT_NONE,   method_daemon_reload, usage_bluechi},
-        { "status",        2, ARG_ANY, OPT_NONE,   method_status,        usage_bluechi},
-        { "set-loglevel",  1, 2,       OPT_NONE,   method_set_loglevel,  usage_bluechi},
-        { "version",       0, 0,       OPT_NONE,   method_version,       usage_bluechi},
-        { NULL,            0, 0,       0,          NULL,                 NULL         }
+        {"help",           0, 0,       OPT_NONE,                                method_help,          usage_bluechi},
+        { "list-units",    0, 1,       OPT_FILTER,                              method_list_units,    usage_bluechi},
+        { "start",         2, 2,       OPT_NONE,                                method_start,         usage_bluechi},
+        { "stop",          2, 2,       OPT_NONE,                                method_stop,          usage_bluechi},
+        { "freeze",        2, 2,       OPT_NONE,                                method_freeze,        usage_bluechi},
+        { "thaw",          2, 2,       OPT_NONE,                                method_thaw,          usage_bluechi},
+        { "restart",       2, 2,       OPT_NONE,                                method_restart,       usage_bluechi},
+        { "reload",        2, 2,       OPT_NONE,                                method_reload,        usage_bluechi},
+        { "monitor",       0, 2,       OPT_NONE,                                method_monitor,       usage_bluechi},
+        { "metrics",       1, 1,       OPT_NONE,                                method_metrics,       usage_bluechi},
+        { "enable",        2, ARG_ANY, OPT_FORCE | OPT_RUNTIME | OPT_NO_RELOAD, method_enable,        usage_bluechi},
+        { "disable",       2, ARG_ANY, OPT_NONE,                                method_disable,       usage_bluechi},
+        { "daemon-reload", 1, 1,       OPT_NONE,                                method_daemon_reload, usage_bluechi},
+        { "status",        2, ARG_ANY, OPT_NONE,                                method_status,        usage_bluechi},
+        { "set-loglevel",  1, 2,       OPT_NONE,                                method_set_loglevel,  usage_bluechi},
+        { "version",       0, 0,       OPT_NONE,                                method_version,       usage_bluechi},
+        { NULL,            0, 0,       0,                                       NULL,                 NULL         }
 };
 
 const OptionType option_types[] = {
-        {ARG_FILTER_SHORT, ARG_FILTER, OPT_FILTER},
-        { 0,               NULL,       0         }
+        {ARG_FILTER_SHORT,     ARG_FILTER,    OPT_FILTER   },
+        { ARG_FORCE_SHORT,     ARG_FORCE,     OPT_FORCE    },
+        { ARG_RUNTIME_SHORT,   ARG_RUNTIME,   OPT_RUNTIME  },
+        { ARG_NO_RELOAD_SHORT, ARG_NO_RELOAD, OPT_NO_RELOAD},
+        { 0,                   NULL,          0            }
 };
 
-#define OPTIONS_STR ARG_HELP_SHORT_S ARG_FILTER_SHORT_S
+#define GETOPT_OPTSTRING ARG_HELP_SHORT_S ARG_FORCE_SHORT_S
 const struct option getopt_options[] = {
-        {ARG_HELP,    no_argument,       0, ARG_HELP_SHORT  },
-        { ARG_FILTER, required_argument, 0, ARG_FILTER_SHORT},
-        { NULL,       0,                 0, '\0'            }
+        {ARG_HELP,       no_argument,       0, ARG_HELP_SHORT     },
+        { ARG_FILTER,    required_argument, 0, ARG_FILTER_SHORT   },
+        { ARG_FORCE,     no_argument,       0, ARG_FORCE_SHORT    },
+        { ARG_RUNTIME,   no_argument,       0, ARG_RUNTIME_SHORT  },
+        { ARG_NO_RELOAD, no_argument,       0, ARG_NO_RELOAD_SHORT},
+        { NULL,          0,                 0, '\0'               }
 };
 
 static void usage() {
@@ -63,7 +72,7 @@ static void usage() {
 static int parse_cli_opts(int argc, char *argv[], Command *command) {
         int opt = 0;
 
-        while ((opt = getopt_long(argc, argv, OPTIONS_STR, getopt_options, NULL)) != -1) {
+        while ((opt = getopt_long(argc, argv, GETOPT_OPTSTRING, getopt_options, NULL)) != -1) {
                 if (opt == ARG_HELP_SHORT) {
                         command->is_help = true;
                 } else if (opt == GETOPT_UNKNOWN_OPTION) {

--- a/src/libbluechi/common/opt.h
+++ b/src/libbluechi/common/opt.h
@@ -30,8 +30,7 @@
 #define ARG_NAME_SHORT_S "n:"
 
 #define ARG_FILTER "filter"
-#define ARG_FILTER_SHORT 'f'
-#define ARG_FILTER_SHORT_S "f:"
+#define ARG_FILTER_SHORT 1000
 
 #define ARG_HELP "help"
 #define ARG_HELP_SHORT 'h'
@@ -40,5 +39,15 @@
 #define ARG_VERSION "version"
 #define ARG_VERSION_SHORT 'v'
 #define ARG_VERSION_SHORT_S "v"
+
+#define ARG_FORCE "force"
+#define ARG_FORCE_SHORT 'f'
+#define ARG_FORCE_SHORT_S "f"
+
+#define ARG_RUNTIME "runtime"
+#define ARG_RUNTIME_SHORT 1001
+
+#define ARG_NO_RELOAD "no-reload"
+#define ARG_NO_RELOAD_SHORT 1002
 
 #define GETOPT_UNKNOWN_OPTION '?'

--- a/src/manager/main.c
+++ b/src/manager/main.c
@@ -17,7 +17,7 @@ const struct option options[] = {
         { NULL,        0,                 0, '\0'             }
 };
 
-#define OPTIONS_STR ARG_PORT_SHORT_S ARG_HELP_SHORT_S ARG_CONFIG_SHORT_S ARG_VERSION_SHORT_S
+#define GETOPT_OPTSTRING ARG_PORT_SHORT_S ARG_HELP_SHORT_S ARG_CONFIG_SHORT_S ARG_VERSION_SHORT_S
 
 static const char *opt_port = 0;
 static const char *opt_config = NULL;
@@ -44,7 +44,7 @@ static void usage(char *argv[]) {
 static int get_opts(int argc, char *argv[]) {
         int opt = 0;
 
-        while ((opt = getopt_long(argc, argv, OPTIONS_STR, options, NULL)) != -1) {
+        while ((opt = getopt_long(argc, argv, GETOPT_OPTSTRING, options, NULL)) != -1) {
                 switch (opt) {
                 case ARG_HELP_SHORT:
                         usage(argv);

--- a/src/proxy/main.c
+++ b/src/proxy/main.c
@@ -17,7 +17,7 @@ const struct option options[] = {
         { NULL,        0,           0, '\0'             }
 };
 
-#define OPTIONS_STR ARG_HELP_SHORT_S ARG_USER_SHORT_S ARG_VERSION_SHORT_S
+#define GETOPT_OPTSTRING ARG_HELP_SHORT_S ARG_USER_SHORT_S ARG_VERSION_SHORT_S
 
 static const char *opt_node_unit = NULL;
 static const char *opt_operation = NULL;
@@ -71,7 +71,7 @@ int parse_node_unit_opt(const char *opt_node_unit, char **ret_node_name, char **
 
 static int get_opts(int argc, char *argv[]) {
         int opt = 0;
-        while ((opt = getopt_long(argc, argv, OPTIONS_STR, options, NULL)) != -1) {
+        while ((opt = getopt_long(argc, argv, GETOPT_OPTSTRING, options, NULL)) != -1) {
                 switch (opt) {
                 case ARG_HELP_SHORT:
                         usage(argv);


### PR DESCRIPTION
Adding the following flags:

enable: `--force`, `--runtime` and `--no-reload`
disable: `--runtime` and `--no-reload`

Removed the short `-f` option for `--filter` option, since `-f` is more common for `--force` than for `--filter`

Resolves #323 