### PR TITLE
added status property on manager interface

### DIFF
--- a/data/org.eclipse.bluechi.Manager.xml
+++ b/data/org.eclipse.bluechi.Manager.xml
@@ -122,5 +122,20 @@
       <arg name="unit" type="s" />
       <arg name="result" type="s" />
     </signal>
+
+    <!--
+      Status:
+
+      The status of the overall system. Its value is one of:
+        down:  no node is connected
+        degraded: at least one node is not connected
+        up:   all nodes listed in the AllowedNodeNames config are connected
+      A signal is emitted on the org.freedesktop.DBus.Properties interface each time the system state changes. Therefore, a (dis-)connecting node
+      doesn't necessarily result in a signal to be emitted. For this puprose, the Status property on the org.eclipse.bluechi.Node interface is a
+      better choice.
+    -->
+    <property name="Status" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true" />
+    </property>
   </interface>
 </node>

--- a/doc/api-examples/go/monitor-system-status.go
+++ b/doc/api-examples/go/monitor-system-status.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT-0
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/godbus/dbus/v5"
+)
+
+const (
+	BcDusInterface     = "org.eclipse.bluechi"
+	BcObjectPath       = "/org/eclipse/bluechi"
+	BcManagerInterface = "org.eclipse.bluechi.Manager"
+)
+
+func main() {
+	conn, err := dbus.ConnectSystemBus()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to connect to system bus:", err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	busObject := conn.Object(BcDusInterface, BcObjectPath)
+	err = busObject.AddMatchSignal("org.freedesktop.DBus.Properties", "PropertiesChanged").Err
+	if err != nil {
+		fmt.Println("Failed to add signal to node: ", err)
+		os.Exit(1)
+	}
+
+	c := make(chan *dbus.Signal, 10)
+	conn.Signal(c)
+	for v := range c {
+		ifaceName := v.Body[0]
+		if ifaceName == BcManagerInterface {
+			changedValues, ok := v.Body[1].(map[string]dbus.Variant)
+			if !ok {
+				fmt.Println("Received invalid property changed signal")
+				continue
+			}
+			if val, ok := changedValues["Status"]; ok {
+				fmt.Printf("System status: %s\n", val.String())
+			}
+		}
+	}
+}

--- a/doc/api-examples/python/monitor-system-status.py
+++ b/doc/api-examples/python/monitor-system-status.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT-0
+
+import dasbus.connection
+from dasbus.loop import EventLoop
+from dasbus.typing import Variant
+from typing import Dict
+
+
+loop = EventLoop()
+bus = dasbus.connection.SystemMessageBus()
+
+agent_props_proxy = bus.get_proxy("org.eclipse.bluechi", "/org/eclipse/bluechi",
+                                  "org.freedesktop.DBus.Properties")
+
+
+def on_connection_status_changed(
+    interface: str,
+    changed_props: Dict[str, Variant],
+    invalidated_props: Dict[str, Variant],
+) -> None:
+    con_status = changed_props["Status"].get_string()
+    print(f"System status: {con_status}")
+
+
+agent_props_proxy.PropertiesChanged.connect(on_connection_status_changed)
+
+loop.run()

--- a/doc/api-examples/rust/Cargo.toml
+++ b/doc/api-examples/rust/Cargo.toml
@@ -34,6 +34,10 @@ name = "monitor-node-connections"
 path = "monitor-node-connections.rs"
 
 [[bin]]
+name = "monitor-system-status"
+path = "monitor-system-status.rs"
+
+[[bin]]
 name = "monitor-unit"
 path = "monitor-unit.rs"
 

--- a/doc/api-examples/rust/monitor-system-status.rs
+++ b/doc/api-examples/rust/monitor-system-status.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT-0
+
+use dbus::{
+    arg::Variant,
+    blocking::{stdintf::org_freedesktop_dbus::PropertiesPropertiesChanged, Connection},
+    Message,
+};
+use std::time::Duration;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let conn = Connection::new_system()?;
+
+    let bluechi = conn.with_proxy(
+        "org.eclipse.bluechi",
+        "/org/eclipse/bluechi",
+        Duration::from_millis(5000),
+    );
+    let _id = bluechi.match_signal(
+        |signal: PropertiesPropertiesChanged, _: &Connection, _: &Message| {
+            match signal.changed_properties.get_key_value("Status") {
+                Some((_, Variant(changed_value))) => {
+                    println!("System status: {}", changed_value.as_str().unwrap_or(""))
+                }
+                _ => {}
+            }
+            true
+        },
+    );
+
+    loop {
+        conn.process(Duration::from_millis(1000))?;
+    }
+}

--- a/doc/bluechi-examples/MonitorSystemStatus.py
+++ b/doc/bluechi-examples/MonitorSystemStatus.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT-0
+
+from bluechi.api import Manager
+from dasbus.loop import EventLoop
+from dasbus.typing import Variant
+
+
+def on_system_status_changed(status: Variant):
+    con_status = status.get_string()
+    print(con_status)
+
+
+loop = EventLoop()
+
+mgr = Manager()
+mgr.on_status_changed(on_system_status_changed)
+
+loop.run()

--- a/doc/docs/api/client_generation.md
+++ b/doc/docs/api/client_generation.md
@@ -124,3 +124,9 @@ The following code snippets showcase more examples on how `bluechi` can be used.
 ```python
 --8<-- "bluechi-examples/MonitorAgentConnection.py"
 ```
+
+#### Monitor system status
+
+```python
+--8<-- "bluechi-examples/MonitorSystemStatus.py"
+```

--- a/doc/docs/api/examples.md
+++ b/doc/docs/api/examples.md
@@ -214,3 +214,23 @@ The following sections demonstrate how the D-Bus API of BlueChi can be interacte
     ```rust
     --8<-- "api-examples/rust/monitor-unit.rs"
     ```
+
+### Monitor system status
+
+=== "Go"
+
+    ```go
+    --8<-- "api-examples/go/monitor-system-status.go"
+    ```
+
+=== "Python"
+
+    ```python
+    --8<-- "api-examples/python/monitor-system-status.py"
+    ```
+
+=== "Rust"
+
+    ```rust
+    --8<-- "api-examples/rust/monitor-system-status.rs"
+    ```

--- a/doc/docs/getting_started/securing_multi_node.md
+++ b/doc/docs/getting_started/securing_multi_node.md
@@ -16,13 +16,13 @@ more relevant to our case, the off-loading of mTLS.
 
 In its simplest form, bluechi-agent connects to the bluechi-controller’s port directly over TCP.
 
-![simple connection](../img/bluechi_secure_simple_connection.png "")
+![simple connection](../assets/img/bluechi_secure_simple_connection.png "")
 
 With the double proxy approach, instances of bluechi-agent connect to a local forward proxy over a Unix socket.
 The forward proxy connects over TCP to the remote reverse proxy for mTLS.
 Finally, the reverse proxy connects to bluechi-controller locally over a Unix socket.
 
-![double proxy connection](../img/bluechi_secure_proxy_connection.png "")
+![double proxy connection](../assets/img/bluechi_secure_proxy_connection.png "")
 
 NOTE: The bluechi-controller and bluechi-agent are not aware of the existence of the proxies.
 They just listen (bluechi-controller) and connect (bluechi-agent) to a local Unix socket.

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -579,6 +579,45 @@ class Manager(ApiBase):
         """
         self.get_proxy().JobRemoved.connect(callback)
 
+    @property
+    def status(self) -> str:
+        """
+          Status:
+
+        The status of the overall system. Its value is one of:
+          down:  no node is connected
+          degraded: at least one node is not connected
+          up:   all nodes listed in the AllowedNodeNames config are connected
+        A signal is emitted on the org.freedesktop.DBus.Properties interface each time the system state changes. Therefore, a (dis-)connecting node
+        doesn't necessarily result in a signal to be emitted. For this puprose, the Status property on the org.eclipse.bluechi.Node interface is a
+        better choice.
+        """
+        return self.get_proxy().Status
+
+    def on_status_changed(self, callback: Callable[[Variant], None]):
+        """
+          Status:
+
+        The status of the overall system. Its value is one of:
+          down:  no node is connected
+          degraded: at least one node is not connected
+          up:   all nodes listed in the AllowedNodeNames config are connected
+        A signal is emitted on the org.freedesktop.DBus.Properties interface each time the system state changes. Therefore, a (dis-)connecting node
+        doesn't necessarily result in a signal to be emitted. For this puprose, the Status property on the org.eclipse.bluechi.Node interface is a
+        better choice.
+        """
+
+        def on_properties_changed(
+            interface: str,
+            changed_props: Dict[str, Variant],
+            invalidated_props: Dict[str, Variant],
+        ) -> None:
+            value = changed_props.get("Status")
+            if value is not None:
+                callback(value)
+
+        self.get_properties_proxy().PropertiesChanged.connect(on_properties_changed)
+
 
 class Node(ApiBase):
     """

--- a/src/manager/manager.h
+++ b/src/manager/manager.h
@@ -29,7 +29,8 @@ struct Manager {
 
         SocketOptions *peer_socket_options;
 
-        int n_nodes;
+        int number_of_nodes;
+        int number_of_nodes_online;
         LIST_HEAD(Node, nodes);
         LIST_HEAD(Node, anonymous_nodes);
 
@@ -49,6 +50,8 @@ bool manager_parse_config(Manager *manager, const char *configfile);
 
 bool manager_start(Manager *manager);
 void manager_stop(Manager *manager);
+
+void manager_check_system_status(Manager *manager, int prev_number_of_nodes_online);
 
 Node *manager_find_node(Manager *manager, const char *name);
 Node *manager_find_node_by_path(Manager *manager, const char *path);

--- a/src/manager/node.c
+++ b/src/manager/node.c
@@ -879,6 +879,9 @@ static int node_method_register(sd_bus_message *m, void *userdata, UNUSED sd_bus
 
         node_unset_agent_bus(node);
 
+        /* update number of online nodes and check the new system state */
+        manager_check_system_status(manager, manager->number_of_nodes_online++);
+
         bc_log_infof("Registered managed node from fd %d as '%s'", sd_bus_get_fd(agent_bus), name);
 
         return sd_bus_reply_method_return(m, "");
@@ -976,6 +979,9 @@ static int node_disconnected(UNUSED sd_bus_message *message, void *userdata, UNU
                         }
                 }
                 node_unset_agent_bus(node);
+
+                /* update number of online nodes and check the new system state */
+                manager_check_system_status(manager, manager->number_of_nodes_online--);
         }
 
         return 0;

--- a/tests/tests/tier0/monitor-system-status-ctrl-stop/main.fmf
+++ b/tests/tests/tier0/monitor-system-status-ctrl-stop/main.fmf
@@ -1,0 +1,3 @@
+summary: Test if the system status changed signal is being emitted when the controller
+    is stopped
+id: accfdfc5-31c7-4fda-b549-e3c43da0b9dc

--- a/tests/tests/tier0/monitor-system-status-ctrl-stop/python/system-monitor.py
+++ b/tests/tests/tier0/monitor-system-status-ctrl-stop/python/system-monitor.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from bluechi.api import Manager
+from dasbus.loop import EventLoop
+from dasbus.typing import Variant
+
+import sys
+import signal
+
+
+def sig_handler(_signo, _stack_frame):
+    sys.exit(0)
+
+
+signal.signal(signal.SIGTERM, sig_handler)
+signal.signal(signal.SIGINT, sig_handler)
+
+try:
+    f = open("/tmp/events", "w")
+
+    def on_system_status_changed(status: Variant):
+        con_status = status.get_string()
+        f.write(f"{con_status},")
+        f.flush()
+        print(con_status)
+
+    loop = EventLoop()
+
+    mgr = Manager()
+    mgr.on_status_changed(on_system_status_changed)
+
+    loop.run()
+finally:
+    f.close()

--- a/tests/tests/tier0/monitor-system-status-ctrl-stop/systemd/monitor.service
+++ b/tests/tests/tier0/monitor-system-status-ctrl-stop/systemd/monitor.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Monitor BlueChi system
+
+[Service]
+Type=simple
+ExecStart=python3 /tmp/system-monitor.py
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/tests/tier0/monitor-system-status-ctrl-stop/test_monitor_system_status_ctrl_stop.py
+++ b/tests/tests/tier0/monitor-system-status-ctrl-stop/test_monitor_system_status_ctrl_stop.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import time
+from typing import Dict
+
+from bluechi_test.util import read_file
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+
+
+node_one = "node-1"
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+
+    ctrl.create_file("/tmp", "system-monitor.py", read_file("python/system-monitor.py"))
+    ctrl.copy_systemd_service("monitor.service", "systemd", os.path.join("/", "etc", "systemd", "system"))
+
+    result, output = ctrl.exec_run("systemctl start monitor.service")
+    if result != 0:
+        raise Exception(f"Failed to start monitor service: {output}")
+
+    # wait a bit so monitor is set up
+    time.sleep(2)
+
+    result, output = ctrl.exec_run("systemctl stop bluechi-controller")
+    if result != 0:
+        raise Exception(f"Failed to stop bluechi-controller: {output}")
+
+    # wait a bit to process all events
+    time.sleep(1)
+
+    result, output = ctrl.exec_run("cat /tmp/events")
+    if result != 0:
+        raise Exception(f"Failed to get events file: {output}")
+
+    assert output == "down,"
+
+
+def test_monitor_system_status(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiNodeConfig):
+
+    node_one_config = bluechi_node_default_config.deep_copy()
+    node_one_config.node_name = node_one
+
+    bluechi_ctrl_default_config.allowed_node_names = [node_one]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_node_config(node_one_config)
+
+    bluechi_test.run(exec)

--- a/tests/tests/tier0/monitor-system-status/main.fmf
+++ b/tests/tests/tier0/monitor-system-status/main.fmf
@@ -1,0 +1,3 @@
+summary: Test if the system status changed signal is being emitted when nodes disconnect
+    and reconnect
+id: 96615a39-229f-4083-8c7d-cb0c540ca598

--- a/tests/tests/tier0/monitor-system-status/python/system-monitor.py
+++ b/tests/tests/tier0/monitor-system-status/python/system-monitor.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from bluechi.api import Manager
+from dasbus.loop import EventLoop
+from dasbus.typing import Variant
+
+import sys
+import signal
+
+
+def sig_handler(_signo, _stack_frame):
+    sys.exit(0)
+
+
+signal.signal(signal.SIGTERM, sig_handler)
+signal.signal(signal.SIGINT, sig_handler)
+
+try:
+    f = open("/tmp/events", "w")
+
+    def on_system_status_changed(status: Variant):
+        con_status = status.get_string()
+        f.write(f"{con_status},")
+        f.flush()
+        print(con_status)
+
+    loop = EventLoop()
+
+    mgr = Manager()
+    mgr.on_status_changed(on_system_status_changed)
+
+    loop.run()
+finally:
+    f.close()

--- a/tests/tests/tier0/monitor-system-status/systemd/monitor.service
+++ b/tests/tests/tier0/monitor-system-status/systemd/monitor.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Monitor BlueChi system
+
+[Service]
+Type=simple
+ExecStart=python3 /tmp/system-monitor.py
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/tests/tier0/monitor-system-status/test_monitor_system_status.py
+++ b/tests/tests/tier0/monitor-system-status/test_monitor_system_status.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import time
+from typing import Dict
+
+from bluechi_test.util import read_file
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+
+
+node_one = "node-1"
+node_two = "node-2"
+node_three = "node-3"
+nodes = [node_one, node_two, node_three]
+
+
+def stop_all_agents(nodes: Dict[str, BluechiControllerContainer]):
+    for node_name, node in nodes.items():
+        result, output = node.exec_run("systemctl stop bluechi-agent")
+        if result != 0:
+            raise Exception(f"Failed to stop bluechi-agent on node '{node_name}': {output}")
+
+
+def start_all_agents(nodes: Dict[str, BluechiControllerContainer]):
+    for node_name, node in nodes.items():
+        result, output = node.exec_run("systemctl start bluechi-agent")
+        if result != 0:
+            raise Exception(f"Failed to stop bluechi-agent on node '{node_name}': {output}")
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+
+    ctrl.create_file("/tmp", "system-monitor.py", read_file("python/system-monitor.py"))
+    ctrl.copy_systemd_service("monitor.service", "systemd", os.path.join("/", "etc", "systemd", "system"))
+
+    result, output = ctrl.exec_run("systemctl start monitor.service")
+    if result != 0:
+        raise Exception(f"Failed to start monitor service: {output}")
+
+    # wait a bit so monitor is set up
+    time.sleep(2)
+
+    stop_all_agents(nodes)
+
+    # wait a bit to process all events
+    time.sleep(1)
+
+    result, output = ctrl.exec_run("cat /tmp/events")
+    if result != 0:
+        raise Exception(f"Failed to get events file: {output}")
+
+    assert output == "degraded,down,"
+
+    start_all_agents(nodes)
+
+    # wait a bit to process all events
+    time.sleep(1)
+
+    result, output = ctrl.exec_run("cat /tmp/events")
+    if result != 0:
+        raise Exception(f"Failed to get events file: {output}")
+
+    assert output == "degraded,down,degraded,up,"
+
+
+def test_monitor_system_status(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiNodeConfig):
+
+    node_one_config = bluechi_node_default_config.deep_copy()
+    node_one_config.node_name = node_one
+    node_two_config = bluechi_node_default_config.deep_copy()
+    node_two_config.node_name = node_two
+    node_three_config = bluechi_node_default_config.deep_copy()
+    node_three_config.node_name = node_three
+
+    bluechi_ctrl_default_config.allowed_node_names = nodes
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_node_config(node_one_config)
+    bluechi_test.add_bluechi_node_config(node_two_config)
+    bluechi_test.add_bluechi_node_config(node_three_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/603

Added a status property on the manager interface to express the current status of the overall system - all nodes managed by the controller. It also emits a signal if this state changes, e.g. from online to degraded. Node (dis-)connects that don't lead to a state change do not trigger this signal.

TODO:
~- add integration tests~ 

Update: 
- Added integration tests as well. Like those from other monitoring features, not 100% happy about how this has to be done, but couldn't think of a better way, unfortunately. 
- The `apispec` step is failing since the order of generated functions gets rearranged. Not sure why, though. I regenerated the bindings so they contain the new `Status` function. Therefore, this failed step can be ignored for now (will need to investigate the CI step later). 