### PR TITLE
Add lsof for integration-test-base

### DIFF
--- a/tests/containers/integration-test-base
+++ b/tests/containers/integration-test-base
@@ -4,6 +4,7 @@ RUN dnf upgrade --refresh --nodocs -y && \
     dnf install --nodocs epel-release -y && \
     dnf install --nodocs \
             lcov \
+            lsof \
             policycoreutils-python-utils \
             python3-dasbus \
             selinux-policy \


### PR DESCRIPTION
lsof needed to check if port connected inside
controller/agent container.