### PR TITLE
Fix image workflow

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Push manifest o quay.io
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: quay.io/bluechi/${{ inputs.image }}
+          image: ${{ inputs.image }}
           registry: quay.io/bluechi
           username: bluechi+bluechi_bot
           password: ${{ secrets.QUAY_BOT_API_TOKEN }}

--- a/build-scripts/build-push-containers.sh
+++ b/build-scripts/build-push-containers.sh
@@ -10,7 +10,6 @@ function push(){
 }
 
 function build(){
-    buildah manifest rm $IMAGE &> /dev/null
     buildah manifest create $IMAGE
 
     buildah bud --tag "quay.io/bluechi/$IMAGE" \

--- a/tests/README.md
+++ b/tests/README.md
@@ -202,11 +202,15 @@ Both, `integration-test-local` as well as `integration-test-snapshot`, are based
 
 ### Updating container images in registry
 
-Currently, the base images are pushed manually to the [bluechi on quay.io](https://quay.io/organization/bluechi) organization and its repositories. If any updates are required, please reach out to the [code owners](../.github/CODEOWNERS).
+The base images can either be build and pushed locally or via a github workflow to the [bluechi on quay.io](https://quay.io/organization/bluechi) organization and its repositories. If any updates are required, please reach out to the [code owners](../.github/CODEOWNERS).
 
-**Note to codeowners:**
+#### Building and pushing via workflow
 
-The base images [build-base](./containers/build-base) and [integration-test-base](./containers/integration-test-base) can be built for multiple architectures (arm64 and amd64) using the [build-containers.sh](../build-scripts/build-containers.sh) script. It'll build the images for the supported architectures as well as a manifest, which can then be pushed to the registry.
+The base images [build-base](./containers/build-base) and [integration-test-base](./containers/integration-test-base) can be built and pushed to quay by using the [Container Image Workflow](../.github/workflows/images.yml). It can be found and triggered here in the [Actions tab](https://github.com/eclipse-bluechi/bluechi/actions/workflows/images.yml) of the BlueChi repo.
+
+#### Building and pushing locally
+
+The base images [build-base](./containers/build-base) and [integration-test-base](./containers/integration-test-base) are built for multiple architectures (arm64 and amd64) using the [build-containers.sh](../build-scripts/build-containers.sh) script. It'll build the images for the supported architectures as well as a manifest, which can then be pushed to the registry.
 
 Building for multiple architectures, the following packages are required:
 


### PR DESCRIPTION
This PR fixes the workflow to build and push BlueChi base images to quay.io. 
It can be manually triggered here:
https://github.com/eclipse-bluechi/bluechi/actions/workflows/images.yml
