### PR TITLE
use polling instead of sleep for checking processed events

### DIFF
--- a/tests/tests/tier0/monitor-system-status/test_monitor_system_status.py
+++ b/tests/tests/tier0/monitor-system-status/test_monitor_system_status.py
@@ -1,14 +1,17 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
+import logging
 import time
-from typing import Dict
+from typing import Dict, List
 
 from bluechi_test.util import read_file
 from bluechi_test.test import BluechiTest
 from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
 from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
 
+
+LOGGER = logging.getLogger(__name__)
 
 node_one = "node-1"
 node_two = "node-2"
@@ -17,6 +20,7 @@ nodes = [node_one, node_two, node_three]
 
 
 def stop_all_agents(nodes: Dict[str, BluechiControllerContainer]):
+    LOGGER.debug("Stopping all agents...")
     for node_name, node in nodes.items():
         result, output = node.exec_run("systemctl stop bluechi-agent")
         if result != 0:
@@ -24,10 +28,40 @@ def stop_all_agents(nodes: Dict[str, BluechiControllerContainer]):
 
 
 def start_all_agents(nodes: Dict[str, BluechiControllerContainer]):
+    LOGGER.debug("Starting all agents...")
     for node_name, node in nodes.items():
         result, output = node.exec_run("systemctl start bluechi-agent")
         if result != 0:
             raise Exception(f"Failed to stop bluechi-agent on node '{node_name}': {output}")
+
+
+def check_events(ctrl: BluechiControllerContainer, expected_events: List[str]):
+    """
+    Continuously poll the current content in /tmp/events. As soon as the file
+    contains the same number of events as the expected_events, assert that the
+    content is the same - the order is important.
+    """
+
+    LOGGER.debug("Checking events processed by the system monitor...")
+
+    # In the worst case, this infinite loop will be cancelled by pytests timeout
+    # Its left sooner when we get the expected number of events
+    while True:
+        result, output = ctrl.exec_run("cat /tmp/events")
+        if result != 0:
+            raise Exception(f"Unexpected error while getting events file: {output}")
+
+        events = output.split(",")
+        LOGGER.info(f"Got monitored events: '{events}', comparing with expected '{expected_events}'")
+
+        # output contains format like 'degraded,up,'
+        # So -1 is used to take the additional element into account
+        if (len(events) - 1) == len(expected_events):
+            for i in range(len(expected_events)):
+                assert events[i] == expected_events[i]
+            break
+
+        time.sleep(1)
 
 
 def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
@@ -44,25 +78,11 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
 
     stop_all_agents(nodes)
 
-    # wait a bit to process all events
-    time.sleep(1)
-
-    result, output = ctrl.exec_run("cat /tmp/events")
-    if result != 0:
-        raise Exception(f"Failed to get events file: {output}")
-
-    assert output == "degraded,down,"
+    check_events(ctrl, ["degraded", "down"])
 
     start_all_agents(nodes)
 
-    # wait a bit to process all events
-    time.sleep(1)
-
-    result, output = ctrl.exec_run("cat /tmp/events")
-    if result != 0:
-        raise Exception(f"Failed to get events file: {output}")
-
-    assert output == "degraded,down,degraded,up,"
+    check_events(ctrl, ["degraded", "down", "degraded", "up"])
 
 
 def test_monitor_system_status(


### PR DESCRIPTION
Follow up of #695.

In the integration tests for the system status, the events processed by the monitor should be continuously be pulled and evaluated (with proper logs) instead of simply waiting a fixed amount of time. This makes the tests less brittle on slower infrastructure.