### PR TITLE
bluechictl: status command to show nodes list

### DIFF
--- a/doc/docs/getting_started/examples_bluechictl.md
+++ b/doc/docs/getting_started/examples_bluechictl.md
@@ -17,7 +17,7 @@ laptop              |bluechi-agent.service                                      
 pi                  |bluechi-agent.service                                      |   active|  running
 ```
 
-## Monitoring of units and nodes
+## Monitoring of units
 
 The `bluechictl monitor <node-name> <unit-name>` command enables to view changes in real-time. For example, to monitor all state changes of `cow.service` on `pi` the following command can be issued:
 
@@ -48,10 +48,12 @@ Subscribing to node '*' and unit '*'
 
     This enables an observer to do the necessary re-queries since state changes could have happened while the node was disconnected.
 
+## Monitoring of nodes
+
 In addition to monitoring units, BlueChi's APIs can be used to query and monitor the node connection states:
 
 ```bash
-$ bluechictl monitor node-connection
+$ bluechictl status
 
 NODE                          | STATE     | LAST SEEN                   
 =========================================================================
@@ -67,6 +69,18 @@ NODE                          | STATE     | LAST SEEN
 laptop                        | online    | now                         
 pi                            | online    | 2023-10-06 08:38:20,000+0200                         
 ```
+
+It is also possible to show the status of a specific node
+
+```bash
+$ bluechictl status laptop
+
+NODE                          | STATE     | LAST SEEN
+=========================================================================
+laptop                        | online    | now
+```
+
+In addition, a flag `-w/--watch` can be used with `bluechictl status` to continuously display the nodes status, refreshing on node status change.
 
 ## Operations on units
 
@@ -113,4 +127,17 @@ $ bluechictl freeze pi cow.service
 
 # revert the previous freeze
 $ bluechictl thaw pi cow.service
+```
+
+## Print unit status
+
+The `bluechictl status <node-name> <unit-name>` will print the specific unit info and status
+
+```bash
+$ bluechictl status laptop httpd.service
+
+UNIT            | LOADED    | ACTIVE    | SUBSTATE  | FREEZERSTATE  | ENABLED   |
+---------------------------------------------------------------------------------
+httpd.service   | loaded    | active    | running   | running       | enabled   |
+
 ```

--- a/doc/man/bluechictl.1.md
+++ b/doc/man/bluechictl.1.md
@@ -30,21 +30,44 @@ Print current bluechictl version
 
 Performs one of the listed lifecycle operations on the given systemd unit for the `bluechi-agent`.
 
-### **bluechictl** [*enable|disable*] [*agent*] [*unit1*,*...*]
+### **bluechictl** [*enable*] [*agent*] [*unit1*,*...*]
 
-Enable/Disable the list of systemd unit files for the `bluechi-agent`.
+Enable the list of systemd unit files for the `bluechi-agent`.
+
+
+**Options:**
+
+**--force**, **-f**
+    Override existing symlinks
+
+**--runtime**
+    Enable unit files temporarily until next reboot
+
+**--no-reload**
+    Don't reload daemon after enabling unit files
+
+### **bluechictl** [*disable*] [*agent*] [*unit1*,*...*]
+
+Disable the list of systemd unit files for the `bluechi-agent`.
+
+
+**Options:**
+
+**--no-reload**
+    Don't reload daemon after disabling unit files
 
 ### **bluechictl** *list-units* [*agent*]
 
 Fetches information about all systemd units on the bluechi-agents. If [bluechi-agent] is not specified, all agents are queried.
 
+**Options:**
+
+**--filter**
+    Use glob filter for the unit names
+
 ### **bluechictl** *monitor* [*agent*] [*unit1*,*unit2*,*...*]
 
 Creates a monitor on the given agent to observe changes in the specified units. Wildcards **\*** to match all agents and/or units are also supported.
-
-### **bluechictl** *monitor* *node-connection*
-
-Creates a monitor to observe connection state changes for all nodes.
 
 
 **Example:**
@@ -59,6 +82,25 @@ bluechictl monitor \\\* dbus.service,apache2.service
 
 Performs `daemon-reload` for the `bluechi-agent`.
 
-### **bluechictl** [*status*] [*agent*] [*unit1*,*...*]
+### **bluechictl** *status* [*agent*]
+
+Fetches the status of all the agents or a specific agent: state (online/offline) and when was it last seen
+
+
+**Options:**
+
+**--watch**, **-w**
+    Continuously display agent(s) status, updating when state change update received
+
+
+**Example:**
+
+bluechictl status
+
+bluechictl status rpi
+
+bluechictl status -w
+
+### **bluechictl** *status* [*agent*] [*unit1*,*...*]
 
 Fetches the status of the systemd units for the `bluechi-agent`.

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -30,3 +30,5 @@ DEFINE_CLEANUP_FUNC(Client, client_unref)
 
 int client_create_message_new_method_call(
                 Client *client, const char *node_name, const char *member, sd_bus_message **new_message);
+
+int client_start_event_loop(Client *client);

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -21,6 +21,7 @@
 #define OPT_FORCE 1u << 2u
 #define OPT_RUNTIME 1u << 3u
 #define OPT_NO_RELOAD 1u << 4u
+#define OPT_WATCH 1u << 5u
 
 int method_version(UNUSED Command *command, UNUSED void *userdata) {
         printf("bluechictl version %s\n", CONFIG_H_BC_VERSION);
@@ -41,7 +42,7 @@ const Method methods[] = {
         { "enable",        2, ARG_ANY, OPT_FORCE | OPT_RUNTIME | OPT_NO_RELOAD, method_enable,        usage_bluechi},
         { "disable",       2, ARG_ANY, OPT_NONE,                                method_disable,       usage_bluechi},
         { "daemon-reload", 1, 1,       OPT_NONE,                                method_daemon_reload, usage_bluechi},
-        { "status",        2, ARG_ANY, OPT_NONE,                                method_status,        usage_bluechi},
+        { "status",        0, ARG_ANY, OPT_WATCH,                               method_status,        usage_bluechi},
         { "set-loglevel",  1, 2,       OPT_NONE,                                method_set_loglevel,  usage_bluechi},
         { "version",       0, 0,       OPT_NONE,                                method_version,       usage_bluechi},
         { NULL,            0, 0,       0,                                       NULL,                 NULL         }
@@ -52,16 +53,18 @@ const OptionType option_types[] = {
         { ARG_FORCE_SHORT,     ARG_FORCE,     OPT_FORCE    },
         { ARG_RUNTIME_SHORT,   ARG_RUNTIME,   OPT_RUNTIME  },
         { ARG_NO_RELOAD_SHORT, ARG_NO_RELOAD, OPT_NO_RELOAD},
+        { ARG_WATCH_SHORT,     ARG_WATCH,     OPT_WATCH    },
         { 0,                   NULL,          0            }
 };
 
-#define GETOPT_OPTSTRING ARG_HELP_SHORT_S ARG_FORCE_SHORT_S
+#define GETOPT_OPTSTRING ARG_HELP_SHORT_S ARG_FORCE_SHORT_S ARG_WATCH_SHORT_S
 const struct option getopt_options[] = {
         {ARG_HELP,       no_argument,       0, ARG_HELP_SHORT     },
         { ARG_FILTER,    required_argument, 0, ARG_FILTER_SHORT   },
         { ARG_FORCE,     no_argument,       0, ARG_FORCE_SHORT    },
         { ARG_RUNTIME,   no_argument,       0, ARG_RUNTIME_SHORT  },
         { ARG_NO_RELOAD, no_argument,       0, ARG_NO_RELOAD_SHORT},
+        { ARG_WATCH,     no_argument,       0, ARG_WATCH_SHORT    },
         { NULL,          0,                 0, '\0'               }
 };
 

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -40,7 +40,7 @@ const Method methods[] = {
         { "monitor",       0, 2,       OPT_NONE,                                method_monitor,       usage_bluechi},
         { "metrics",       1, 1,       OPT_NONE,                                method_metrics,       usage_bluechi},
         { "enable",        2, ARG_ANY, OPT_FORCE | OPT_RUNTIME | OPT_NO_RELOAD, method_enable,        usage_bluechi},
-        { "disable",       2, ARG_ANY, OPT_NONE,                                method_disable,       usage_bluechi},
+        { "disable",       2, ARG_ANY, OPT_NO_RELOAD,                           method_disable,       usage_bluechi},
         { "daemon-reload", 1, 1,       OPT_NONE,                                method_daemon_reload, usage_bluechi},
         { "status",        0, ARG_ANY, OPT_WATCH,                               method_status,        usage_bluechi},
         { "set-loglevel",  1, 2,       OPT_NONE,                                method_set_loglevel,  usage_bluechi},

--- a/src/client/method-help.c
+++ b/src/client/method-help.c
@@ -32,8 +32,8 @@ void usage_bluechi() {
         printf("    usage: metrics listen\n");
         printf("  - monitor: creates a monitor on the given node to observe changes in the specified units\n");
         printf("    usage: monitor [node] [unit1,unit2,...]\n");
-        printf("  - monitor node-connection: creates a monitor to observe changes in state of all nodes\n");
-        printf("    usage: monitor node-connection\n");
+        printf("  - status: shows the status of a node, or statuses of all nodes, or status of a unit on node\n");
+        printf("    usage: status [nodename [unitname]] [-w/--watch]\n");
         printf("  - daemon-reload: reload systemd daemon on a specific node\n");
         printf("    usage: daemon-reload nodename\n");
 }

--- a/src/client/method-monitor.c
+++ b/src/client/method-monitor.c
@@ -4,37 +4,6 @@
 
 #include "libbluechi/common/common.h"
 #include "libbluechi/common/list.h"
-#include "libbluechi/common/time-util.h"
-#include "libbluechi/service/shutdown.h"
-
-static int start_event_loop(sd_bus *api_bus) {
-        _cleanup_sd_event_ sd_event *event = NULL;
-        int r = sd_event_default(&event);
-        if (r < 0) {
-                fprintf(stderr, "Failed to create event loop: %s", strerror(-r));
-                return r;
-        }
-
-        r = sd_bus_attach_event(api_bus, event, SD_EVENT_PRIORITY_NORMAL);
-        if (r < 0) {
-                fprintf(stderr, "Failed to attach api bus to event: %s", strerror(-r));
-                return r;
-        }
-
-        r = event_loop_add_shutdown_signals(event, NULL);
-        if (r < 0) {
-                fprintf(stderr, "Failed to add signals to agent event loop: %s", strerror(-r));
-                return r;
-        }
-
-        r = sd_event_loop(event);
-        if (r < 0) {
-                fprintf(stderr, "Failed to start event loop: %s", strerror(-r));
-                return r;
-        }
-
-        return 0;
-}
 
 /***************************************************************
  ******** Monitor: Changes in systemd units of agents **********
@@ -162,14 +131,14 @@ static int on_unit_properties_changed_signal(
 }
 
 /* units are comma separated */
-static int method_monitor_units_on_nodes(sd_bus *api_bus, char *node, char *units) {
+static int method_monitor_units_on_nodes(Client *client, char *node, char *units) {
         _cleanup_sd_bus_error_ sd_bus_error error = SD_BUS_ERROR_NULL;
         _cleanup_sd_bus_message_ sd_bus_message *reply = NULL;
         char *monitor_path = NULL;
         int r = 0;
 
         r = sd_bus_call_method(
-                        api_bus,
+                        client->api_bus,
                         BC_INTERFACE_BASE_NAME,
                         BC_OBJECT_PATH,
                         MANAGER_INTERFACE,
@@ -191,7 +160,7 @@ static int method_monitor_units_on_nodes(sd_bus *api_bus, char *node, char *unit
         printf("Monitor path: %s\n", monitor_path);
 
         r = sd_bus_match_signal(
-                        api_bus,
+                        client->api_bus,
                         NULL,
                         BC_INTERFACE_BASE_NAME,
                         monitor_path,
@@ -205,7 +174,7 @@ static int method_monitor_units_on_nodes(sd_bus *api_bus, char *node, char *unit
         }
 
         r = sd_bus_match_signal(
-                        api_bus,
+                        client->api_bus,
                         NULL,
                         BC_INTERFACE_BASE_NAME,
                         monitor_path,
@@ -219,7 +188,7 @@ static int method_monitor_units_on_nodes(sd_bus *api_bus, char *node, char *unit
         }
 
         r = sd_bus_match_signal(
-                        api_bus,
+                        client->api_bus,
                         NULL,
                         BC_INTERFACE_BASE_NAME,
                         monitor_path,
@@ -233,7 +202,7 @@ static int method_monitor_units_on_nodes(sd_bus *api_bus, char *node, char *unit
         }
 
         r = sd_bus_match_signal(
-                        api_bus,
+                        client->api_bus,
                         NULL,
                         BC_INTERFACE_BASE_NAME,
                         monitor_path,
@@ -248,7 +217,12 @@ static int method_monitor_units_on_nodes(sd_bus *api_bus, char *node, char *unit
 
         _cleanup_sd_bus_message_ sd_bus_message *m = NULL;
         r = sd_bus_message_new_method_call(
-                        api_bus, &m, BC_INTERFACE_BASE_NAME, monitor_path, MONITOR_INTERFACE, "SubscribeList");
+                        client->api_bus,
+                        &m,
+                        BC_INTERFACE_BASE_NAME,
+                        monitor_path,
+                        MONITOR_INTERFACE,
+                        "SubscribeList");
         if (r < 0) {
                 fprintf(stderr, "Failed creating subscription call: %s\n", strerror(-r));
                 return r;
@@ -282,357 +256,16 @@ static int method_monitor_units_on_nodes(sd_bus *api_bus, char *node, char *unit
                 return r;
         }
 
-        r = sd_bus_call(api_bus, m, BC_DEFAULT_DBUS_TIMEOUT, &error, &reply);
+        r = sd_bus_call(client->api_bus, m, BC_DEFAULT_DBUS_TIMEOUT, &error, &reply);
         if (r < 0) {
                 fprintf(stderr, "Failed to subscribe to monitor: %s\n", error.message);
                 return r;
         }
 
-        return start_event_loop(api_bus);
-}
-
-
-/***************************************************************
- ******** Monitor: Connection state changes of agents **********
- ***************************************************************/
-
-typedef struct Node Node;
-typedef struct Nodes Nodes;
-typedef struct NodeConnection NodeConnection;
-
-struct NodeConnection {
-        char *name;
-        char *node_path;
-        char *state;
-        uint64_t last_seen;
-};
-
-typedef struct Node {
-        sd_bus *api_bus;
-        NodeConnection *connection;
-        LIST_FIELDS(Node, nodes);
-        Nodes *nodes;
-} Node;
-
-typedef struct Nodes {
-        LIST_HEAD(Node, nodes);
-} Nodes;
-
-static Node *
-                node_new(sd_bus *api_bus,
-                         Nodes *head,
-                         const char *node_name,
-                         const char *node_path,
-                         const char *node_state,
-                         uint64_t last_seen_timestamp) {
-        Node *node = malloc0(sizeof(Node));
-        if (node == NULL) {
-                return NULL;
-        }
-        node->connection = malloc0(sizeof(NodeConnection));
-        if (node->connection == NULL) {
-                free(node);
-                node = NULL;
-                return NULL;
-        }
-        node->connection->name = strdup(node_name);
-        node->connection->node_path = strdup(node_path);
-        node->connection->state = strdup(node_state);
-        node->connection->last_seen = last_seen_timestamp;
-        node->api_bus = api_bus;
-        node->nodes = head;
-        LIST_APPEND(nodes, head->nodes, node);
-        return node;
-}
-
-static Nodes *nodes_new() {
-        Nodes *nodes = malloc0(sizeof(Nodes));
-        if (nodes == NULL) {
-                return NULL;
-        }
-        LIST_HEAD_INIT(nodes->nodes);
-        return nodes;
-}
-
-static char *node_connection_fmt_last_seen(NodeConnection *con) {
-        if (streq(con->state, "online")) {
-                return strdup("now");
-        } else if (streq(con->state, "offline") && con->last_seen == 0) {
-                return strdup("never");
-        }
-
-        struct timespec t;
-        t.tv_sec = (time_t) con->last_seen;
-        t.tv_nsec = 0;
-        return get_formatted_log_timestamp_for_timespec(t, false);
-}
-
-static void node_unref(Node *node) {
-        if (node == NULL) {
-                return;
-        }
-
-        if (node->connection != NULL) {
-                free_and_null(node->connection->name);
-                free_and_null(node->connection->node_path);
-                free_and_null(node->connection->state);
-                free_and_null(node->connection);
-        }
-
-        if (node->nodes != NULL) {
-                node->nodes = NULL;
-        }
-
-        free(node);
-        node = NULL;
-}
-
-
-static void nodes_unref(Nodes *nodes) {
-        if (nodes == NULL) {
-                return;
-        }
-
-        Node *curr = NULL;
-        Node *next = NULL;
-        LIST_FOREACH_SAFE(nodes, curr, next, nodes->nodes) {
-                node_unref(curr);
-        }
-
-        free(nodes);
-        nodes = NULL;
-}
-
-DEFINE_CLEANUP_FUNC(Nodes, nodes_unref)
-#define _cleanup_nodes_ _cleanup_(nodes_unrefp)
-
-static void print_nodes(Nodes *nodes) {
-        /* clear screen */
-        printf("\033[2J");
-        printf("\033[%d;%dH", 0, 0);
-
-        /* print monitor header */
-        printf("%-30.30s| %-10.10s| %-28.28s\n", "NODE", "STATE", "LAST SEEN");
-        printf("=========================================================================\n");
-
-        Node *curr = NULL;
-        Node *next = NULL;
-        LIST_FOREACH_SAFE(nodes, curr, next, nodes->nodes) {
-                _cleanup_free_ char *last_seen = node_connection_fmt_last_seen(curr->connection);
-                printf("%-30.30s| %-10.10s| %-28.28s\n",
-                       curr->connection->name,
-                       curr->connection->state,
-                       last_seen);
-        }
-}
-
-
-static int fetch_last_seen_timestamp_property(
-                sd_bus *api_bus, const char *node_path, uint64_t *ret_last_seen_timestamp) {
-        _cleanup_sd_bus_error_ sd_bus_error prop_error = SD_BUS_ERROR_NULL;
-        _cleanup_sd_bus_message_ sd_bus_message *prop_reply = NULL;
-
-        int r = sd_bus_get_property(
-                        api_bus,
-                        BC_INTERFACE_BASE_NAME,
-                        node_path,
-                        NODE_INTERFACE,
-                        "LastSeenTimestamp",
-                        &prop_error,
-                        &prop_reply,
-                        "t");
-        if (r < 0) {
-                return r;
-        }
-
-        uint64_t last_seen_timestamp = 0;
-        r = sd_bus_message_read(prop_reply, "t", &last_seen_timestamp);
-        if (r < 0) {
-                return r;
-        }
-        *ret_last_seen_timestamp = last_seen_timestamp;
-
-        return 0;
-}
-
-static int parse_status_from_changed_properties(sd_bus_message *m, char **ret_connection_status) {
-        if (ret_connection_status == NULL) {
-                fprintf(stderr, "NULL pointer to connection status not allowed");
-                return -EINVAL;
-        }
-
-        int r = sd_bus_message_enter_container(m, SD_BUS_TYPE_ARRAY, "{sv}");
-        if (r < 0) {
-                fprintf(stderr, "Failed to read changed properties: %s\n", strerror(-r));
-                return r;
-        }
-
-        for (;;) {
-                r = sd_bus_message_enter_container(m, SD_BUS_TYPE_DICT_ENTRY, "sv");
-                if (r <= 0) {
-                        break;
-                }
-
-                const char *key = NULL;
-                r = sd_bus_message_read(m, "s", &key);
-                if (r < 0) {
-                        fprintf(stderr, "Failed to read next unit changed property: %s\n", strerror(-r));
-                        return r;
-                }
-                if (r == 0) {
-                        break;
-                }
-
-                /* only process property changes for the node status */
-                if (!streq(key, "Status")) {
-                        break;
-                }
-
-                /* node status is always of type string */
-                r = sd_bus_message_enter_container(m, SD_BUS_TYPE_VARIANT, "s");
-                if (r < 0) {
-                        fprintf(stderr, "Failed to enter content of variant type: %s", strerror(-r));
-                        return r;
-                }
-                char *status = NULL;
-                r = sd_bus_message_read(m, "s", &status);
-                if (r < 0) {
-                        fprintf(stderr, "Failed to read value of changed property: %s\n", strerror(-r));
-                        return r;
-                }
-                *ret_connection_status = strdup(status);
-
-                r = sd_bus_message_exit_container(m);
-                if (r < 0) {
-                        fprintf(stderr, "Failed to exit container: %s\n", strerror(-r));
-                        return r;
-                }
-        }
-
-        return sd_bus_message_exit_container(m);
-}
-
-static int on_node_connection_state_changed(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *error) {
-        Node *node = userdata;
-
-        (void) sd_bus_message_skip(m, "s");
-
-        _cleanup_free_ char *con_state = NULL;
-        int r = parse_status_from_changed_properties(m, &con_state);
-        if (r < 0) {
-                return r;
-        }
-        if (con_state == NULL) {
-                fprintf(stderr, "Received connection status change signal with missing 'Status' key.");
-                return 0;
-        }
-
-        r = fetch_last_seen_timestamp_property(
-                        node->api_bus, node->connection->node_path, &node->connection->last_seen);
-        if (r < 0) {
-                fprintf(stderr,
-                        "Failed to get last seen property of node %s: %s\n",
-                        node->connection->name,
-                        strerror(-r));
-                return r;
-        }
-
-        free(node->connection->state);
-        node->connection->state = strdup(con_state);
-
-        print_nodes(node->nodes);
-
-        return 0;
-}
-
-int method_monitor_node_connection_state(sd_bus *api_bus) {
-        _cleanup_sd_bus_error_ sd_bus_error error = SD_BUS_ERROR_NULL;
-        _cleanup_sd_bus_message_ sd_bus_message *reply = NULL;
-        int r = 0;
-
-        r = sd_bus_call_method(
-                        api_bus,
-                        BC_INTERFACE_BASE_NAME,
-                        BC_OBJECT_PATH,
-                        MANAGER_INTERFACE,
-                        "ListNodes",
-                        &error,
-                        &reply,
-                        "");
-        if (r < 0) {
-                fprintf(stderr, "Failed to list nodes: %s\n", error.message);
-                return r;
-        }
-
-        _cleanup_nodes_ Nodes *nodes = nodes_new();
-        if (nodes == NULL) {
-                fprintf(stderr, "Failed to create Node list, OOM");
-                return -ENOMEM;
-        }
-
-        r = sd_bus_message_enter_container(reply, SD_BUS_TYPE_ARRAY, "(sos)");
-        if (r < 0) {
-                fprintf(stderr, "Failed to open reply array: %s\n", strerror(-r));
-                return r;
-        }
-        while (sd_bus_message_at_end(reply, false) == 0) {
-                const char *name = NULL;
-                const char *path = NULL;
-                const char *state = NULL;
-                uint64_t last_seen_timestamp = 0;
-
-                r = sd_bus_message_read(reply, "(sos)", &name, &path, &state);
-                if (r < 0) {
-                        fprintf(stderr, "Failed to read node information: %s\n", strerror(-r));
-                        return r;
-                }
-
-                if (streq(state, "offline")) {
-                        r = fetch_last_seen_timestamp_property(api_bus, path, &last_seen_timestamp);
-                        if (r < 0) {
-                                fprintf(stderr,
-                                        "Failed to get last seen property of node %s: %s\n",
-                                        name,
-                                        strerror(-r));
-                                return r;
-                        }
-                }
-
-                Node *node = node_new(api_bus, nodes, name, path, state, last_seen_timestamp);
-                if (node == NULL) {
-                        fprintf(stderr, "Failed to create Node, OOM");
-                        return -ENOMEM;
-                }
-                r = sd_bus_match_signal(
-                                api_bus,
-                                NULL,
-                                BC_INTERFACE_BASE_NAME,
-                                path,
-                                "org.freedesktop.DBus.Properties",
-                                "PropertiesChanged",
-                                on_node_connection_state_changed,
-                                node);
-                if (r < 0) {
-                        fprintf(stderr,
-                                "Failed to create callback for NodeConnectionStateChanged: %s\n",
-                                strerror(-r));
-                        return r;
-                }
-        }
-
-        print_nodes(nodes);
-
-        return start_event_loop(api_bus);
+        return client_start_event_loop(client);
 }
 
 int method_monitor(Command *command, void *userdata) {
-        Client *client = (Client *) userdata;
-        /* monitor node connection status changes */
-        if (command->opargc == 1 && streq(command->opargv[0], "node-connection")) {
-                return method_monitor_node_connection_state(client->api_bus);
-        }
-
-        /* monitor systemd units on the specified nodes */
         char *arg0 = SYMBOL_WILDCARD;
         char *arg1 = SYMBOL_WILDCARD;
         switch (command->opargc) {
@@ -648,5 +281,5 @@ int method_monitor(Command *command, void *userdata) {
         default:
                 return -EINVAL;
         }
-        return method_monitor_units_on_nodes(client->api_bus, arg0, arg1);
+        return method_monitor_units_on_nodes(userdata, arg0, arg1);
 }

--- a/src/libbluechi/common/opt.h
+++ b/src/libbluechi/common/opt.h
@@ -50,4 +50,8 @@
 #define ARG_NO_RELOAD "no-reload"
 #define ARG_NO_RELOAD_SHORT 1002
 
+#define ARG_WATCH "watch"
+#define ARG_WATCH_SHORT 'w'
+#define ARG_WATCH_SHORT_S "w"
+
 #define GETOPT_UNKNOWN_OPTION '?'


### PR DESCRIPTION
Removing the `bluechictl monitor node-connection` functionality and move it to `bluechictl status`, slightly expanding it.

`bluechictl status` will print the list of nodes with their status and when it was last seen.

```
$ sudo bluechictl status
NODE                          | STATE     | LAST SEEN                   
=========================================================================
laptop                        | online    | now                                            
rpi4                          | offline   | never                       
```

`bluechictl status node` will print the same for for the node `node`

```
$ sudo bluechictl status laptop
NODE                          | STATE     | LAST SEEN                   
=========================================================================
laptop                        | online    | now                         
```

Also adding `-w/--watch` flag to `bluechictl status` command, allowing to continuously monitor the node/nodes status (like the original `bluechictl monitor node-connection`)

`bluechictl status node unit` retains the original functionality

Resolves #281 