### PR TITLE
agent: add ExecStop to systemd bluechi-agent

### DIFF
--- a/systemd-units/bluechi-agent-user.service
+++ b/systemd-units/bluechi-agent-user.service
@@ -10,3 +10,4 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/usr/libexec/bluechi-agent --user
+ExecStop=/bin/kill -TERM $MAINPID

--- a/systemd-units/bluechi-agent.service
+++ b/systemd-units/bluechi-agent.service
@@ -10,6 +10,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/usr/libexec/bluechi-agent
+ExecStop=/bin/kill -TERM $MAINPID
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Without this statment the bluechi-agent is not stopping with systemctl stop bluechi-agent.

Fixes: https://github.com/eclipse-bluechi/bluechi/issues/702