### PR TITLE
Proposal: combine unit and integration test coverage report

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,11 +1,8 @@
 name: Integration tests
 
 on:
-  push:
-    branches: [main, hirte-*]
-  pull_request:
-    branches: [main, hirte-*]
-  workflow_dispatch:
+  workflow_call:
+
 
 jobs:
   rpmbuild:
@@ -105,10 +102,13 @@ jobs:
           MERGE_FILE="/var/tmp/tmt/run-001/plans/tier0/report/default-0/merged.info"
           COVERAGE_DIR="/var/tmp/tmt/run-001/plans/tier0/report/default-0/report/"
           if [ -d "$COVERAGE_DIR" ]; then
-            cp -r $COVERAGE_DIR /var/tmp
-            cp $MERGE_FILE /var/tmp
+            mkdir -p /var/tmp/coverage
+            mv $MERGE_FILE /var/tmp/coverage/integration-test-coverage.info
+
+            mkdir -p /var/tmp/coverage/integration-test-report
+            mv $COVERAGE_DIR/* /var/tmp/coverage/integration-test-report
+
             rm -rf $COVERAGE_DIR
-            rm -rf $MERGE_FILE
           fi
       
       - name: Upload tmt artifacts
@@ -118,17 +118,16 @@ jobs:
           name: tmt-artifacts
           path: '/var/tmp/tmt'
 
-      - name: Upload coverage HTML report
+      - name: Upload coverage artifact (info)
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: coverage-artifacts-html
-          path: '/var/tmp/report'
-      
-      - name: Upload coverage file
+          name: integration-test-coverage-info
+          path: '/var/tmp/coverage/integration-test-coverage.info'
+
+      - name: Upload coverage artifact (html)
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: coverage-artifacts-info
-          path: '/var/tmp/merged.info'
-      
+          name: integration-test-coverage-html
+          path: '/var/tmp/coverage/integration-test-report'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,97 @@
+name: BlueChi Tests
+
+on:
+  push:
+    branches: [main, hirte-*]
+  pull_request:
+    branches: [main, hirte-*]
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    uses: ./.github/workflows/unit-tests.yml
+
+  integration-tests:
+    uses: ./.github/workflows/integration-tests.yml
+
+  publish-coverage:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/bluechi/build-base:latest
+    needs: [unit-tests, integration-tests]
+
+    steps:  
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+
+      - name: Download unit test coverage artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: unit-test-coverage-info
+          path: '/tmp/coverage'
+
+      - name: Download integration test coverage artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: integration-test-coverage-info
+          path: '/tmp/coverage'
+      
+      - name: Download rpm artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: rpm-artifacts
+          path: '/tmp/bluechi-rpms'
+      
+      # For code coverage from integration tests
+      - name: Install debug sources for genhtml
+        run: |
+          dnf install \
+            python3-dasbus \
+            selinux-policy \
+            -y
+          dnf install --repo bluechi-rpms \
+            --repofrompath bluechi-rpms,file:///tmp/bluechi-rpms/ \
+            --nogpgcheck \
+            --nodocs \
+            bluechi-controller \
+            bluechi-controller-debuginfo \
+            bluechi-agent \
+            bluechi-agent-debuginfo \
+            bluechi-ctl \
+            bluechi-ctl-debuginfo \
+            bluechi-selinux \
+            python3-bluechi \
+            -y
+
+      # For code coverage from unit tests
+      - name: Manipulate entries from unit test coverage
+        run: | 
+          BC_VRA="$(rpm -q --qf '%{VERSION}-%{RELEASE}.%{ARCH}' bluechi-agent 2>/dev/null)"
+          sed -i "s/\/usr\/src\/debug\/bluechi-$BC_VRA\/src/\/__w\/bluechi\/bluechi\/src/g" /tmp/coverage/integration-test-coverage.info
+
+      - name: Merge unit and integration test coverage
+        run: |
+          lcov \
+            -a /tmp/coverage/unit-test-coverage.info \
+            -a /tmp/coverage/integration-test-coverage.info \
+            -o /var/tmp/overall-coverage.info
+      
+      - name: Generate overall test coverage report
+        run: |
+          genhtml /var/tmp/overall-coverage.info --output-directory=/var/tmp/test-coverage-report
+      
+      - name: Upload coverage artifact (info)
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: overall-test-coverage-info
+          path: '/var/tmp/overall-coverage.info'
+      
+      - name: Upload coverage artifact (html)
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: overall-test-coverage-html
+          path: '/var/tmp/test-coverage-report'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,11 +1,8 @@
 name: Unit tests
 
 on:
-  push:
-    branches: [main, hirte-*]
-  pull_request:
-    branches: [main, hirte-*]
-  workflow_dispatch:
+  workflow_call:
+
 
 jobs:
   test:
@@ -41,9 +38,21 @@ jobs:
         run: |
           meson test --wrap='valgrind --leak-check=full --error-exitcode=1 --track-origins=yes' -C builddir
 
-      - name: Generating coverage report
+      - name: Generating coverage report (info)
+        run: |
+          ninja coverage -C builddir
+
+      - name: Generating coverage report (html)
         run: |
           ninja coverage-html -C builddir
+          
+      - name: Move and rename coverage artifacts
+        run: |
+          mkdir -p /var/tmp/coverage
+          mv builddir/meson-logs/coverage.info /var/tmp/coverage/unit-test-coverage.info
+          
+          mkdir -p /var/tmp/coverage/unit-test-report
+          mv builddir/meson-logs/coveragereport/* /var/tmp/coverage/unit-test-report/
 
       - name: Upload unit test logs
         if: always()
@@ -52,14 +61,21 @@ jobs:
           name: unit-test-logs
           path: ./builddir/meson-logs/testlog-valgrind.txt
 
-      - name: Upload coverage HTML artifact
+      - name: Upload coverage artifact (info)
         uses: actions/upload-artifact@v3
         with:
-          name: coverage
-          path: builddir/meson-logs/coveragereport
+          name: unit-test-coverage-info
+          path: /var/tmp/coverage/unit-test-coverage.info
+          if-no-files-found: error
+
+      - name: Upload coverage artifact (html)
+        uses: actions/upload-artifact@v3
+        with:
+          name: unit-test-coverage-html
+          path: /var/tmp/coverage/unit-test-report/
           if-no-files-found: error
 
       - name: Report coverage results
         run: |
-          cd builddir/meson-logs/coveragereport/
+          cd /var/tmp/coverage/unit-test-report/
           html2text --ignore-images --ignore-links -b 0 --bypass-tables index.html >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
In order to view the overall coverage achieved by both, unit and integration tests, the existing workflows for those two test types have been made reusable and are being called by a common test workflow. This new workflow also combines the collected coverage files to provide the overall coverage of BlueChi.

This solution is a bit hacky. One of the reasons is that the base directory of both test types are different (`/usr/src/debug/...` vs `/__w/bluechi/bluechi/...`) and these are made equal using `sed` - and since the unit tests establish a base line via lcov, these files and path is chosen (source files are from the same commit, so no difference here). 

Again, this PR is a first proposal and more refinement is probably needed afterwards, e.g. the integration tests don't establish a base line so that unused files are missed/listed (which might impact the line/func counts). 

Example report:
![image](https://github.com/eclipse-bluechi/bluechi/assets/26504678/10e7b802-c4d8-4acc-9ecb-129ba3888d0a)
Note: The `test` directories are missing in the integration test since no base line is established as explained above. They are listed here due to the unit tests. 