### PR TITLE
fixed workflow for publishing to pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          dnf install python3-gobject
           python3 -m ensurepip --default-pip
           python3 -m pip install --upgrade pip setuptools wheel build
           python3 -m pip install -r src/bindings/generator/requirements.txt
@@ -73,16 +74,6 @@ jobs:
       - name: Generate python bindings
         run: |
           ./build-scripts/generate-bindings.sh python
-
-      - name: Check for changes in generated python code
-        run: |
-          git config --global --add safe.directory $(pwd)
-          git diff --exit-code src/bindings/python/
-
-      - name: Prompt rebuilding python bindings
-        if: ${{ failure() }}
-        run: |
-          echo "Changes in D-Bus API spec detected. Please generated them."
 
       - name: Build python bindings package
         run: |


### PR DESCRIPTION
Install missing python3-gobject dependency (which, for some reason, suddenly is missing even though the quay.io image hasn't changed since the last release). Also, remove check for diff for now since the generator produces unordered output, e.g. the functions and classes might be in different order (see #716). 