### PR TITLE
Merge the info file inside the container

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -55,7 +55,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install \
                   genisoimage \
-                  lcov \
                   libkrb5-dev \
                   libvirt-daemon-system \
                   libvirt-dev \

--- a/tests/scripts/create_coverage_report.py
+++ b/tests/scripts/create_coverage_report.py
@@ -5,7 +5,6 @@ import os
 import pathlib
 
 from typing import Dict
-from bluechi_test import command
 from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
 from bluechi_test.config import BluechiControllerConfig
 from bluechi_test.test import BluechiTest
@@ -14,40 +13,33 @@ from bluechi_test.util import read_file
 LOGGER = logging.getLogger(__name__)
 
 
-def merge_all_info_files(start_path, merge_file_name):
-    lcov_list = list()
-    lcov_list.append("lcov")
-
-    root = pathlib.Path(start_path)
-
-    for file_path in root.glob("**/*.info"):
-        file = str(file_path)
-        LOGGER.debug(f"Found info file '{file}'")
-        lcov_list.append("-a")
-        lcov_list.append(file)
-
-    lcov_list.append("-o")
-    lcov_list.append(merge_file_name)
-
-    command.Command(args=" ".join(lcov_list)).run()
-
-
 def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
     path_to_info_files = os.environ["TMT_TREE"].split('/tree')[0] + "/execute/data/"
     path_to_tests_results = os.environ["TMT_TREE"].split('/tree')[0] + "/report/default-0"
     merge_file_name = "merged.info"
-    merge_file_full_path = path_to_tests_results + "/" + merge_file_name
     merge_dir = "/tmp"
     report_dir_name = "/report"
 
-    merge_all_info_files(path_to_info_files, merge_file_full_path)
+    # Copy info files to the ctrl container and run lcov command
+    root = pathlib.Path(path_to_info_files)
+    lcov_list = list()
+    lcov_list.append("lcov")
+    for file_path in root.glob("**/*.info"):
+        LOGGER.debug(f"Found info file '{str(file_path)}'")
+        content = read_file(file_path)
+        ctrl.create_file(merge_dir, file_path.name, content)
+        lcov_list.append("-a")
+        lcov_list.append(f"{merge_dir}/{file_path.name}")
 
-    if os.path.exists(merge_file_full_path):
-        LOGGER.debug(f"Generating report for merged info file '{merge_file_full_path}'")
-        content = read_file(merge_file_full_path)
-        ctrl.create_file(merge_dir, merge_file_name, content)
-        ctrl.exec_run(f"genhtml {merge_dir}/{merge_file_name} --output-directory={report_dir_name}")
-        ctrl.get_file(report_dir_name, path_to_tests_results)
+    lcov_list.append("-o")
+    lcov_list.append(f"{merge_dir}/{merge_file_name}")
+
+    ctrl.exec_run(" ".join(lcov_list))
+    result, output = ctrl.exec_run(f"genhtml {merge_dir}/{merge_file_name} --output-directory={report_dir_name}")
+    if result != 0:
+        raise Exception(f"Failed to do run genthtml inside the container: {output}")
+    ctrl.get_file(report_dir_name, path_to_tests_results)
+    ctrl.get_file(f"{merge_dir}/{merge_file_name}", path_to_tests_results)
 
 
 def test_create_coverag_report(


### PR DESCRIPTION
To avoid lcov version differences generated info files will be copied to the container and only then merged. 
This will avoid using the lcov installed on the host and will prevent lcov version differences.

Related:https://github.com/eclipse-bluechi/bluechi/issues/713