### PR TITLE
Test for loglevel for controller and agent

### DIFF
--- a/tests/tests/tier0/bluechi-agent-set-loglevel/main.fmf
+++ b/tests/tests/tier0/bluechi-agent-set-loglevel/main.fmf
@@ -1,0 +1,2 @@
+summary: Test setloglevel for controller container
+id: bb9d4394-bd53-4d36-b8ba-ee91697c4850

--- a/tests/tests/tier0/bluechi-agent-set-loglevel/test_bluechi_agent_set_loglevel.py
+++ b/tests/tests/tier0/bluechi-agent-set-loglevel/test_bluechi_agent_set_loglevel.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from typing import Dict
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+
+NODE_FOO = "node-foo"
+
+
+def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer]):
+    node_foo = nodes[NODE_FOO]
+
+    service = "org.eclipse.bluechi.Agent"
+    object = "/org/eclipse/bluechi"
+    interface = "org.eclipse.bluechi.Agent"
+
+    ctrl.exec_run(f"bluechictl set-loglevel {NODE_FOO} INFO")
+    _, output = node_foo.exec_run(f"busctl  get-property {service} {object} {interface} LogLevel")
+    assert "INFO" in output
+
+    ctrl.exec_run(f"bluechictl set-loglevel {NODE_FOO} DEBUG")
+    _, output = node_foo.exec_run(f"busctl  get-property {service} {object} {interface} LogLevel")
+    assert "DEBUG" in output
+
+
+def test_controller_setloglevel(
+        bluechi_test: BluechiTest,
+        bluechi_node_default_config: BluechiNodeConfig, bluechi_ctrl_default_config: BluechiControllerConfig):
+
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = NODE_FOO
+
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO]
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.add_bluechi_node_config(node_foo_cfg)
+
+    bluechi_test.run(exec)

--- a/tests/tests/tier0/bluechi-controller-set-loglevel/main.fmf
+++ b/tests/tests/tier0/bluechi-controller-set-loglevel/main.fmf
@@ -1,0 +1,2 @@
+summary: Test setloglevel for controller container
+id: bb9d4394-bd53-4d36-b8ba-ee91697c4850

--- a/tests/tests/tier0/bluechi-controller-set-loglevel/test_bluechi_controller_set_loglevel.py
+++ b/tests/tests/tier0/bluechi-controller-set-loglevel/test_bluechi_controller_set_loglevel.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from typing import Dict
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig
+
+
+def exec(ctrl: BluechiControllerContainer, _: Dict[str, BluechiNodeContainer]):
+    service = "org.eclipse.bluechi"
+    object = "/org/eclipse/bluechi"
+    interface = "org.eclipse.bluechi.Controller"
+    ctrl.exec_run("bluechictl set-loglevel INFO")
+    _, output = ctrl.exec_run(f"busctl  get-property {service} {object} {interface} LogLevel")
+    assert "INFO" in output
+    ctrl.exec_run("bluechictl set-loglevel DEBUG")
+    _, output = ctrl.exec_run(f"busctl  get-property {service} {object} {interface} LogLevel")
+    assert "DEBUG" in output
+
+
+def test_controller_setloglevel(
+        bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.run(exec)


### PR DESCRIPTION
Testing if log level will change if SetLoglevel function will be use with bluechictl in container and agent. Loglevel will be set to DEBUG and then to Info. Metric feature will be used to get output and check if the output is as expected

Reletad:https://github.com/eclipse-bluechi/bluechi/issues/668