### PR TITLE
remove unit test file coverage

### DIFF
--- a/tests/scripts/create_coverage_report.py
+++ b/tests/scripts/create_coverage_report.py
@@ -41,6 +41,11 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
     if result != 0:
         raise Exception(f"Error merging info files from each integration test: {output}")
 
+    result, output = ctrl.exec_run(
+        f"lcov --remove {merge_dir}/{merge_file_name} -o {merge_dir}/{merge_file_name} '*/src/libbluechi/test/*'")
+    if result != 0:
+        raise Exception(f"Error removing coverage for unit test file: {output}")
+
     LOGGER.debug(f"Generating report for merged info file '{merge_dir}/{merge_file_name}'")
     result, output = ctrl.exec_run(f"genhtml {merge_dir}/{merge_file_name} --output-directory={report_dir_name}")
     if result != 0:


### PR DESCRIPTION
Remove coverage for unit test files like libbluechi/test/common/list_test.c from the generated HTML coverage info and report. This prevents distorting the coverage % due to executed code in the test files themselves. 

Example output:

![image](https://github.com/eclipse-bluechi/bluechi/assets/26504678/c2547e72-faeb-4214-a337-4563dcbdc74d)
