### PR TITLE
cleanup controller when start fails

### DIFF
--- a/src/controller/main.c
+++ b/src/controller/main.c
@@ -100,5 +100,6 @@ int main(int argc, char *argv[]) {
         if (controller_start(controller)) {
                 return EXIT_SUCCESS;
         }
+        controller_stop(controller);
         return EXIT_FAILURE;
 }


### PR DESCRIPTION
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/730

When `controller_start` fails, the cleanup in `controller_stop` still needs to be executed to remove all initialized nodes.