### PR TITLE
pin tmt version to 1.30

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install unpackaged python libraries from PyPi
         run: |
-          pip install "tmt[provision]" "tmt[report-junit]" podman pytest pytest-timeout
+          pip install "tmt[provision]==1.30" "tmt[report-junit]==1.30" podman pytest pytest-timeout
           # Mitigate https://github.com/containers/podman-py/issues/350
           pip install rich
 


### PR DESCRIPTION
On 06.02.2024 the tmt version 1.31 was released. It adds a new preparation task (at least in our setup), which fails. Pinning it to 1.30 for now.