### PR TITLE
Tests set-loglevel with invalid input

### DIFF
--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -1600,7 +1600,7 @@ static int agent_method_set_log_level(
         }
         LogLevel loglevel = string_to_log_level(level);
         if (loglevel == LOG_LEVEL_INVALID) {
-                bc_log_errorf("Invalid input for log level: %s", loglevel);
+                bc_log_errorf("Invalid input for log level: %s", level);
                 return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Invalid input for log level");
         }
         bc_log_set_level(loglevel);

--- a/src/controller/controller.c
+++ b/src/controller/controller.c
@@ -886,7 +886,7 @@ static int controller_method_set_log_level(
         }
         LogLevel loglevel = string_to_log_level(level);
         if (loglevel == LOG_LEVEL_INVALID) {
-                bc_log_errorf("Invalid input for log level: %s", loglevel);
+                bc_log_errorf("Invalid input for log level: %s", level);
                 return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_INVALID_ARGS, "Invalid input for log level");
         }
         bc_log_set_level(loglevel);

--- a/tests/tests/tier0/bluechi-agent-set-loglevel-invalid/main.fmf
+++ b/tests/tests/tier0/bluechi-agent-set-loglevel-invalid/main.fmf
@@ -1,0 +1,2 @@
+summary: Test agent cmd -c option with invalid config file
+id: bb9d4394-bd53-4d36-b8ba-ee91697c4850

--- a/tests/tests/tier0/bluechi-agent-set-loglevel-invalid/test_bluechi_agent_set_loglevel_invalid.py
+++ b/tests/tests/tier0/bluechi-agent-set-loglevel-invalid/test_bluechi_agent_set_loglevel_invalid.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+from typing import Dict
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig, BluechiNodeConfig
+
+
+NODE_FOO = "node-foo"
+
+
+def exec(ctrl: BluechiControllerContainer, _: Dict[str, BluechiNodeContainer]):
+
+    _, output = ctrl.exec_run(f"bluechictl set-loglevel {NODE_FOO} INF")
+    print(output)
+    assert b'Disconnect' not in output
+
+
+def test_agent_config_c_option(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiNodeConfig):
+
+    bluechi_node_default_config.node_name = NODE_FOO
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_node_config(bluechi_node_default_config)
+
+    bluechi_test.run(exec)

--- a/tests/tests/tier0/bluechi-controller-set-loglevel-invalid/main.fmf
+++ b/tests/tests/tier0/bluechi-controller-set-loglevel-invalid/main.fmf
@@ -1,0 +1,2 @@
+summary: Test agent cmd -c option with invalid config file
+id: bb9d4394-bd53-4d36-b8ba-ee91697c4850

--- a/tests/tests/tier0/bluechi-controller-set-loglevel-invalid/test_bluechi_controller_set_loglevel_invalid.py
+++ b/tests/tests/tier0/bluechi-controller-set-loglevel-invalid/test_bluechi_controller_set_loglevel_invalid.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+from typing import Dict
+from bluechi_test.test import BluechiTest
+from bluechi_test.container import BluechiControllerContainer, BluechiNodeContainer
+from bluechi_test.config import BluechiControllerConfig
+
+
+def exec(ctrl: BluechiControllerContainer, _: Dict[str, BluechiNodeContainer]):
+
+    _, output = ctrl.exec_run("bluechictl set-loglevel INF")
+    assert "Disconnect" not in output
+
+
+def test_agent_config_c_option(
+        bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
When set-loglevel feature is used with invalid input 
bluechi will crush. An invalid input for bc_log_errorf causes it
Added test for set-loglevel with invalid input (like INF)
for controller and agent.

Signed-off-by: Artiom Divak <adivak@redhat.com>