### PR TITLE
Fix various meson warnings

### DIFF
--- a/README.developer.md
+++ b/README.developer.md
@@ -196,8 +196,9 @@ meson configure -D<option-name>=<option-value>
 
 Current options include:
 
-- `with_coverage`: This option ensures that BlueChi is built to collect coverage when running a BlueChi binary
 - `with_analyzer`: This option enables the [gcc option for static analysis](https://gcc.gnu.org/onlinedocs/gcc-13.2.0/gcc/Static-Analyzer-Options.html)
+- `with_coverage`: This option ensures that BlueChi is built to collect coverage when running a BlueChi binary
+- `with_man_pages`: This option enables building man pages as a part of the project build
 
 #### Bindings
 

--- a/doc/man/meson.build
+++ b/doc/man/meson.build
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-want_man = get_option('man') == 'true'
+want_man = get_option('with_man_pages')
 md2man = find_program('go-md2man', required : false)
 if want_man and not md2man.found()
   message('go-md2man not found, man page generation disabled automatically')

--- a/meson.build
+++ b/meson.build
@@ -33,10 +33,10 @@ endif
 
 # Set option to get coverage collection
 with_coverage = get_option('with_coverage')
-if with_coverage == 'true'
+if with_coverage
   add_project_arguments('-coverage', language : 'c')
   add_project_arguments(
-    '-fprofile-dir=' + join_paths(get_option('prefix'), get_option('localstatedir'), 'tmp', 'bluechi-coverage'), 
+    '-fprofile-dir=' + join_paths(get_option('prefix'), get_option('localstatedir'), 'tmp', 'bluechi-coverage'),
     language : 'c')
   add_project_link_arguments('-lgcov', language : 'c')
   # Coverage source code mapping files `*.gcno` are created as a part of the build for each `*.c` file, but it's

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,9 +7,8 @@ option('dbus-srv-user', type: 'string', description: 'The (existing) user which 
 option('with_analyzer', type : 'boolean', value : false,
     description : 'Add the gcc option -fanalyzer for static analysis')
 
-option('with_coverage', type : 'combo',
-    choices : ['true', 'false'], value : 'false',
-    description : 'Add coverage collection')
+option('with_coverage', type : 'boolean', value : false,
+    description : 'Enable the code coverage collection')
 
 option('with_man_pages', type : 'boolean', value : true,
     description : 'Build and install man pages')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,15 +2,14 @@ option('api_bus', type: 'combo',
     choices: ['user', 'system'], value: 'system',
     description: 'The D-Bus daemon on which the public BlueChi API is provided')
 
-option('man', type : 'combo',
-    choices : ['true', 'false'], value : 'true',
-    description : 'Build and install man pages')
+option('dbus-srv-user', type: 'string', description: 'The (existing) user which runs bluechi')
+
+option('with_analyzer', type : 'boolean', value : false,
+    description : 'Add the gcc option -fanalyzer for static analysis')
 
 option('with_coverage', type : 'combo',
     choices : ['true', 'false'], value : 'false',
     description : 'Add coverage collection')
 
-option('with_analyzer', type : 'boolean', value : false,
-    description : 'Add the gcc option -fanalyzer for static analysis')
-
-option('dbus-srv-user', type: 'string', description: 'The (existing) user which runs bluechi')
+option('with_man_pages', type : 'boolean', value : true,
+    description : 'Build and install man pages')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,7 +10,7 @@ option('with_coverage', type : 'combo',
     choices : ['true', 'false'], value : 'false',
     description : 'Add coverage collection')
 
-option('with_analyzer', type : 'boolean', value : 'false',
+option('with_analyzer', type : 'boolean', value : false,
     description : 'Add the gcc option -fanalyzer for static analysis')
 
 option('dbus-srv-user', type: 'string', description: 'The (existing) user which runs bluechi')

--- a/selinux/meson.build
+++ b/selinux/meson.build
@@ -24,5 +24,3 @@ install_data(
   ['bluechi_agent_selinux.8', 'bluechi_controller_selinux.8'],
   install_dir : join_paths(get_option('mandir'), ('man8')),
 )
-
-


### PR DESCRIPTION
- Don't use string literals as value for boolean options
- Rename build option `man` to `with_man_pages`
- Use boolean type for `with_coverage` build option
- Remove unneeded empty lines in selinux/meson.build
