### PR TITLE
Split up parse config function

### DIFF
--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -408,21 +408,14 @@ Agent *agent_new(void) {
         agent->api_bus_service_name = steal_pointer(&service_name);
         agent->peer_socket_options = steal_pointer(&socket_opts);
         agent->unit_infos = unit_infos;
-        LIST_HEAD_INIT(agent->outstanding_requests);
-        LIST_HEAD_INIT(agent->tracked_jobs);
-        LIST_HEAD_INIT(agent->proxy_services);
-
-        agent->unit_infos = hashmap_new(
-                        sizeof(AgentUnitInfo), 0, 0, 0, unit_info_hash, unit_info_compare, unit_info_clear, NULL);
-        if (agent->unit_infos == NULL) {
-                return NULL;
-        }
-
         agent->connection_state = AGENT_CONNECTION_STATE_DISCONNECTED;
         agent->connection_retry_count = 0;
         agent->wildcard_subscription_active = false;
         agent->metrics_enabled = false;
         agent->disconnect_timestamp = 0;
+        LIST_HEAD_INIT(agent->outstanding_requests);
+        LIST_HEAD_INIT(agent->tracked_jobs);
+        LIST_HEAD_INIT(agent->proxy_services);
 
         return steal_pointer(&agent);
 }
@@ -494,6 +487,7 @@ void agent_unref(Agent *agent) {
         free_and_null(agent->orch_addr);
         free_and_null(agent->api_bus_service_name);
         free_and_null(agent->controller_address);
+        free_and_null(agent->peer_socket_options);
 
         if (agent->event != NULL) {
                 sd_event_unrefp(&agent->event);

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -597,14 +597,15 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
                 }
         }
 
+        return true;
+}
 
-        // set logging configuration
-        bc_log_init(agent->config);
-
+bool agent_apply_config(Agent *agent) {
         const char *value = NULL;
         value = cfg_get_value(agent->config, CFG_NODE_NAME);
         if (value) {
                 if (!agent_set_name(agent, value)) {
+                        bc_log_error("Failed to set CONTROLLER NAME");
                         return false;
                 }
         }
@@ -612,6 +613,7 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
         value = cfg_get_value(agent->config, CFG_CONTROLLER_HOST);
         if (value) {
                 if (!agent_set_host(agent, value)) {
+                        bc_log_error("Failed to set CONTROLLER HOST");
                         return false;
                 }
         }
@@ -626,6 +628,7 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
         value = cfg_get_value(agent->config, CFG_CONTROLLER_ADDRESS);
         if (value) {
                 if (!agent_set_controller_address(agent, value)) {
+                        bc_log_error("Failed to set CONTROLLER ADDRESS");
                         return false;
                 }
         }
@@ -665,10 +668,6 @@ bool agent_parse_config(Agent *agent, const char *configfile) {
                 bc_log_error("Failed to set IP RECVERR");
                 return false;
         }
-
-
-        _cleanup_free_ const char *dumped_cfg = cfg_dump(agent->config);
-        bc_log_debug_with_data("Final configuration used", "\n%s", dumped_cfg);
 
         return true;
 }

--- a/src/agent/agent.h
+++ b/src/agent/agent.h
@@ -107,6 +107,7 @@ bool agent_set_name(Agent *agent, const char *name);
 bool agent_set_heartbeat_interval(Agent *agent, const char *interval_msec);
 void agent_set_systemd_user(Agent *agent, bool systemd_user);
 bool agent_parse_config(Agent *agent, const char *configfile);
+bool agent_apply_config(Agent *agent);
 
 bool agent_start(Agent *agent);
 void agent_stop(Agent *agent);

--- a/src/agent/main.c
+++ b/src/agent/main.c
@@ -133,12 +133,20 @@ int main(int argc, char *argv[]) {
                 return EXIT_FAILURE;
         }
 
-        /* First load config */
         if (!agent_parse_config(agent, opt_config)) {
                 return EXIT_FAILURE;
         }
 
-        /* Then override individual options */
+        bc_log_init(agent->config);
+        _cleanup_free_ const char *dumped_cfg = cfg_dump(agent->config);
+        bc_log_debug_with_data("Final configuration used", "\n%s", dumped_cfg);
+
+        if (!agent_apply_config(agent)) {
+                return EXIT_FAILURE;
+        }
+
+        /* Override individual options */
+
         agent_set_systemd_user(agent, opt_user);
 
         if (opt_port && !agent_set_port(agent, opt_port)) {

--- a/src/agent/meson.build
+++ b/src/agent/meson.build
@@ -24,3 +24,6 @@ executable(
   install: true,
   install_dir: join_paths(prefixdir, get_option('libexecdir'))
 )
+
+# build test binaries
+subdir('test')

--- a/src/agent/test/agent/agent_apply_config_test.c
+++ b/src/agent/test/agent/agent_apply_config_test.c
@@ -1,0 +1,248 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "agent/agent.h"
+
+
+void print_error_result(const char *func_name, bool expected, bool actual) {
+        fprintf(stderr,
+                "FAILED: expected %s to return '%s', but got '%s'\n",
+                func_name,
+                bool_to_str(expected),
+                bool_to_str(actual));
+}
+
+void print_agent_field_error(
+                const char *func_name, const char *field_name, const char *expected, const char *actual) {
+        fprintf(stderr,
+                "FAILED: expected %s to set 'agent->%s' to '%s', but got '%s'\n",
+                func_name,
+                field_name,
+                expected,
+                actual);
+}
+
+bool check_str(const char *func_name, const char *field_name, const char *expected, const char *actual) {
+        if (expected == NULL && actual == NULL) {
+                return true;
+        }
+        if ((expected == NULL && actual != NULL) || (expected != NULL && actual == NULL) ||
+            !streq(expected, actual)) {
+                print_agent_field_error(func_name, field_name, expected, actual);
+                return false;
+        }
+        return true;
+}
+
+bool check_agent(
+                const char *func_name,
+                Agent *agent,
+                const char *expected_name,
+                const char *expected_host,
+                uint16_t expected_port,
+                const char *expected_address,
+                long int expected_heartbeat_interval) {
+        bool result = true;
+        result = result && check_str(func_name, "name", expected_name, agent->name);
+        result = result && check_str(func_name, "host", expected_host, agent->host);
+        result = result &&
+                        check_str(func_name, "controller_address", expected_address, agent->controller_address);
+        if (expected_port != agent->port) {
+                _cleanup_free_ char *actual = NULL;
+                int r = asprintf(&actual, "%d", agent->port);
+                if (r < 0) {
+                        fprintf(stderr,
+                                "FAILED: Unexpected error when parsing actual port to string: %s",
+                                strerror(-r));
+                        return false;
+                }
+
+                _cleanup_free_ char *expected = NULL;
+                r = asprintf(&expected, "%d", expected_port);
+                if (r < 0) {
+                        fprintf(stderr,
+                                "FAILED: Unexpected error when parsing expected port to string: %s",
+                                strerror(-r));
+                        return false;
+                }
+                print_agent_field_error(func_name, "port", expected, actual);
+                result = false;
+        }
+        if (expected_heartbeat_interval != agent->heartbeat_interval_msec) {
+                _cleanup_free_ char *intvl_actual = NULL;
+                int r = asprintf(&intvl_actual, "%ld", agent->heartbeat_interval_msec);
+                if (r < 0) {
+                        fprintf(stderr,
+                                "FAILED: Unexpected error when parsing actual heartbeat intvl to string: %s",
+                                strerror(-r));
+                        return false;
+                }
+
+                _cleanup_free_ char *intvl_expected = NULL;
+                r = asprintf(&intvl_expected, "%ld", expected_heartbeat_interval);
+                if (r < 0) {
+                        fprintf(stderr,
+                                "FAILED: Unexpected error when parsing expected heartbeat intvl to string: %s",
+                                strerror(-r));
+                        return false;
+                }
+                print_agent_field_error(func_name, "heartbeat_interval_msec", intvl_expected, intvl_actual);
+                result = false;
+        }
+
+        // socket options have private members and can't be evaluated at the moment
+
+        return result;
+}
+
+bool test_agent_apply_config_none() {
+        _cleanup_agent_ Agent *agent = agent_new();
+        int r = cfg_initialize(&agent->config);
+        if (r < 0) {
+                fprintf(stderr, "Unexpected error when initializing config: %s", strerror(-r));
+                return false;
+        }
+
+        bool result = agent_apply_config(agent);
+        if (!result) {
+                print_error_result(__func__, true, result);
+                return false;
+        }
+
+        return check_agent(__func__, agent, NULL, NULL, 0, NULL, 0);
+}
+
+bool test_agent_apply_config_valid_all() {
+        _cleanup_agent_ Agent *agent = agent_new();
+        int r = cfg_initialize(&agent->config);
+        if (r < 0) {
+                fprintf(stderr, "Unexpected error when initializing config: %s", strerror(-r));
+                return false;
+        }
+
+        cfg_set_value(agent->config, CFG_NODE_NAME, "node-foo");
+        cfg_set_value(agent->config, CFG_CONTROLLER_HOST, "127.0.0.1");
+        cfg_set_value(agent->config, CFG_CONTROLLER_PORT, "1337");
+        cfg_set_value(agent->config, CFG_CONTROLLER_ADDRESS, "unix::");
+        cfg_set_value(agent->config, CFG_HEARTBEAT_INTERVAL, "1000");
+        cfg_set_value(agent->config, CFG_TCP_KEEPALIVE_TIME, "10000");
+        cfg_set_value(agent->config, CFG_TCP_KEEPALIVE_INTERVAL, "5000");
+        cfg_set_value(agent->config, CFG_TCP_KEEPALIVE_COUNT, "3");
+        cfg_set_value(agent->config, CFG_IP_RECEIVE_ERRORS, "true");
+
+        bool result = agent_apply_config(agent);
+        if (!result) {
+                print_error_result(__func__, true, result);
+                return false;
+        }
+
+        return check_agent(__func__, agent, "node-foo", "127.0.0.1", 1337, "unix::", 1000);
+}
+
+bool test_agent_apply_config_invalid_port() {
+        _cleanup_agent_ Agent *agent = agent_new();
+        int r = cfg_initialize(&agent->config);
+        if (r < 0) {
+                fprintf(stderr, "Unexpected error when initializing config: %s", strerror(-r));
+                return false;
+        }
+
+        cfg_set_value(agent->config, CFG_CONTROLLER_PORT, "invalid");
+
+        bool result = agent_apply_config(agent);
+        if (result) {
+                print_error_result(__func__, false, result);
+                return false;
+        }
+        return true;
+}
+
+bool test_agent_apply_config_invalid_heartbeat() {
+        _cleanup_agent_ Agent *agent = agent_new();
+        int r = cfg_initialize(&agent->config);
+        if (r < 0) {
+                fprintf(stderr, "Unexpected error when initializing config: %s", strerror(-r));
+                return false;
+        }
+
+        cfg_set_value(agent->config, CFG_HEARTBEAT_INTERVAL, "invalid");
+
+        bool result = agent_apply_config(agent);
+        if (result) {
+                print_error_result(__func__, false, result);
+                return false;
+        }
+        return true;
+}
+
+bool test_agent_apply_config_invalid_tcpkeeptime() {
+        _cleanup_agent_ Agent *agent = agent_new();
+        int r = cfg_initialize(&agent->config);
+        if (r < 0) {
+                fprintf(stderr, "Unexpected error when initializing config: %s", strerror(-r));
+                return false;
+        }
+
+        cfg_set_value(agent->config, CFG_TCP_KEEPALIVE_TIME, "invalid");
+
+        bool result = agent_apply_config(agent);
+        if (result) {
+                print_error_result(__func__, false, result);
+                return false;
+        }
+        return true;
+}
+
+bool test_agent_apply_config_invalid_tcpkeepintvl() {
+        _cleanup_agent_ Agent *agent = agent_new();
+        int r = cfg_initialize(&agent->config);
+        if (r < 0) {
+                fprintf(stderr, "Unexpected error when initializing config: %s", strerror(-r));
+                return false;
+        }
+
+        cfg_set_value(agent->config, CFG_TCP_KEEPALIVE_INTERVAL, "invalid");
+
+        bool result = agent_apply_config(agent);
+        if (result) {
+                print_error_result(__func__, false, result);
+                return false;
+        }
+        return true;
+}
+
+bool test_agent_apply_config_invalid_tcpkeepcnt() {
+        _cleanup_agent_ Agent *agent = agent_new();
+        int r = cfg_initialize(&agent->config);
+        if (r < 0) {
+                fprintf(stderr, "Unexpected error when initializing config: %s", strerror(-r));
+                return false;
+        }
+
+        cfg_set_value(agent->config, CFG_TCP_KEEPALIVE_COUNT, "invalid");
+
+        bool result = agent_apply_config(agent);
+        if (result) {
+                print_error_result(__func__, false, result);
+                return false;
+        }
+        return true;
+}
+
+int main() {
+        bool result = true;
+        result = result && test_agent_apply_config_none();
+        result = result && test_agent_apply_config_valid_all();
+        result = result && test_agent_apply_config_invalid_port();
+        result = result && test_agent_apply_config_invalid_heartbeat();
+        result = result && test_agent_apply_config_invalid_tcpkeeptime();
+        result = result && test_agent_apply_config_invalid_tcpkeepintvl();
+        result = result && test_agent_apply_config_invalid_tcpkeepcnt();
+
+        if (result) {
+                return EXIT_SUCCESS;
+        }
+        return EXIT_FAILURE;
+}

--- a/src/agent/test/agent/meson.build
+++ b/src/agent/test/agent/meson.build
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+agent_src = [
+  'agent_apply_config_test',
+]
+
+# setup node test src files to include in compilation
+node_test_src = []
+foreach src : node_src
+    # skip main to avoid duplicate main function error
+    if src == 'main.c'
+        continue
+    endif
+    node_test_src += '../../' + src
+endforeach
+
+foreach src : agent_src
+  exec_test = executable(src, 
+    node_test_src + [src + '.c'],
+    dependencies: [
+        systemd_dep,
+        inih_dep,
+        hashmapc_dep,
+    ],
+    link_with: [
+        bluechi_lib,
+    ],
+    c_args: common_cflags,
+    include_directories: include_directories('../../..'),
+  )
+  test(src, exec_test)
+endforeach

--- a/src/agent/test/meson.build
+++ b/src/agent/test/meson.build
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+subdir('agent')

--- a/src/controller/controller.c
+++ b/src/controller/controller.c
@@ -312,9 +312,10 @@ bool controller_parse_config(Controller *controller, const char *configfile) {
                 }
         }
 
-        // set logging configuration
-        bc_log_init(controller->config);
+        return true;
+}
 
+bool controller_apply_config(Controller *controller) {
         const char *port = NULL;
         port = cfg_get_value(controller->config, CFG_CONTROLLER_PORT);
         if (port) {
@@ -369,12 +370,6 @@ bool controller_parse_config(Controller *controller, const char *configfile) {
                 bc_log_error("Failed to set IP RECVERR");
                 return false;
         }
-
-
-        _cleanup_free_ const char *dumped_cfg = cfg_dump(controller->config);
-        bc_log_debug_with_data("Final configuration used", "\n%s", dumped_cfg);
-
-        /* TODO: Handle per-node-name option section */
 
         return true;
 }

--- a/src/controller/controller.h
+++ b/src/controller/controller.h
@@ -47,6 +47,7 @@ void controller_unref(Controller *controller);
 
 bool controller_set_port(Controller *controller, const char *port);
 bool controller_parse_config(Controller *controller, const char *configfile);
+bool controller_apply_config(Controller *controller);
 
 bool controller_start(Controller *controller);
 void controller_stop(Controller *controller);

--- a/src/controller/main.c
+++ b/src/controller/main.c
@@ -4,8 +4,7 @@
 #include <stdlib.h>
 
 #include "libbluechi/common/opt.h"
-#include "libbluechi/common/parse-util.h"
-#include "libbluechi/service/shutdown.h"
+#include "libbluechi/log/log.h"
 
 #include "controller.h"
 
@@ -86,12 +85,19 @@ int main(int argc, char *argv[]) {
                 return EXIT_FAILURE;
         }
 
-        /* First load config */
         if (!controller_parse_config(controller, opt_config)) {
                 return EXIT_FAILURE;
         }
 
-        /* Then override individual options */
+        bc_log_init(controller->config);
+        _cleanup_free_ const char *dumped_cfg = cfg_dump(controller->config);
+        bc_log_debug_with_data("Final configuration used", "\n%s", dumped_cfg);
+
+        if (!controller_apply_config(controller)) {
+                return EXIT_FAILURE;
+        }
+
+        /* Override individual options */
 
         if (opt_port && !controller_set_port(controller, opt_port)) {
                 return EXIT_FAILURE;

--- a/src/controller/meson.build
+++ b/src/controller/meson.build
@@ -34,3 +34,6 @@ executable(
   c_args: common_cflags,
   include_directories: include_directories('..')
 )
+
+# build test binaries
+subdir('test')

--- a/src/controller/test/controller/controller_apply_config_test.c
+++ b/src/controller/test/controller/controller_apply_config_test.c
@@ -1,0 +1,244 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libbluechi/common/common.h"
+
+#include "controller/controller.h"
+#include "controller/node.h"
+
+/*
+ * custom controller cleanup to remove added nodes since
+ * controller_set_config_values extracts node names from
+ * ALLOWED_NODE_NAMES and pre-creates nodes
+ */
+void controller_cleanup(Controller *controller) {
+        if (controller) {
+                Node *curr = NULL;
+                Node *next = NULL;
+                LIST_FOREACH_SAFE(nodes, curr, next, controller->nodes) {
+                        controller_remove_node(controller, curr);
+                }
+        }
+        controller_unrefp(&controller);
+}
+
+DEFINE_CLEANUP_FUNC(Controller, controller_cleanup)
+#define _test_cleanup_controller_ _cleanup_(controller_cleanupp)
+
+
+void print_error_result(const char *func_name, bool expected, bool actual) {
+        fprintf(stderr,
+                "FAILED: expected %s to return '%s', but got '%s'\n",
+                func_name,
+                bool_to_str(expected),
+                bool_to_str(actual));
+}
+
+void print_controller_field_error(
+                const char *func_name, const char *field_name, const char *expected, const char *actual) {
+        fprintf(stderr,
+                "FAILED: expected %s to set 'controller->%s' to '%s', but got '%s'\n",
+                func_name,
+                field_name,
+                expected,
+                actual);
+}
+
+bool check_str(const char *func_name, const char *field_name, const char *expected, const char *actual) {
+        if (expected == NULL && actual == NULL) {
+                return true;
+        }
+        if ((expected == NULL && actual != NULL) || (expected != NULL && actual == NULL) ||
+            !streq(expected, actual)) {
+                print_controller_field_error(func_name, field_name, expected, actual);
+                return false;
+        }
+        return true;
+}
+
+bool check_controller(
+                const char *func_name,
+                Controller *controller,
+                uint16_t expected_port,
+                const char **expected_node_names,
+                uint16_t expected_node_number) {
+        bool result = true;
+
+        if (expected_port != controller->port) {
+                _cleanup_free_ char *actual = NULL;
+                int r = asprintf(&actual, "%d", controller->port);
+                if (r < 0) {
+                        fprintf(stderr,
+                                "FAILED: Unexpected error when parsing actual port to string: %s",
+                                strerror(-r));
+                        return false;
+                }
+
+                _cleanup_free_ char *expected = NULL;
+                r = asprintf(&expected, "%d", expected_port);
+                if (r < 0) {
+                        fprintf(stderr,
+                                "FAILED: Unexpected error when parsing expected port to string: %s",
+                                strerror(-r));
+                        return false;
+                }
+                print_controller_field_error(func_name, "port", expected, actual);
+                result = false;
+        }
+
+        // socket options have private members and can't be evaluated at the moment
+
+        for (uint16_t i = 0; i < expected_node_number; i++) {
+                bool found = false;
+                Node *curr = NULL;
+                Node *next = NULL;
+                LIST_FOREACH_SAFE(nodes, curr, next, controller->nodes) {
+                        if (streq(expected_node_names[i], curr->name)) {
+                                found = true;
+                                break;
+                        }
+                }
+                if (!found) {
+                        fprintf(stderr,
+                                "FAILED: '%s' - didn't find node '%s'\n",
+                                func_name,
+                                expected_node_names[i]);
+                        result = false;
+                }
+        }
+
+
+        return result;
+}
+
+bool test_controller_apply_config_none() {
+        _test_cleanup_controller_ Controller *controller = controller_new();
+        int r = cfg_initialize(&controller->config);
+        if (r < 0) {
+                fprintf(stderr, "Unexpected error when initializing config: %s", strerror(-r));
+                return false;
+        }
+
+        bool result = controller_apply_config(controller);
+        if (!result) {
+                print_error_result(__func__, true, result);
+                return false;
+        }
+
+        return check_controller(__func__, controller, 0, NULL, 0);
+}
+
+
+bool test_controller_apply_config_valid_all() {
+        _test_cleanup_controller_ Controller *controller = controller_new();
+        int r = cfg_initialize(&controller->config);
+        if (r < 0) {
+                fprintf(stderr, "Unexpected error when initializing config: %s", strerror(-r));
+                return false;
+        }
+
+        cfg_set_value(controller->config, CFG_CONTROLLER_PORT, "1337");
+        cfg_set_value(controller->config, CFG_ALLOWED_NODE_NAMES, "foo,bar,another");
+        cfg_set_value(controller->config, CFG_TCP_KEEPALIVE_TIME, "10000");
+        cfg_set_value(controller->config, CFG_TCP_KEEPALIVE_INTERVAL, "5000");
+        cfg_set_value(controller->config, CFG_TCP_KEEPALIVE_COUNT, "3");
+        cfg_set_value(controller->config, CFG_IP_RECEIVE_ERRORS, "true");
+
+        bool result = controller_apply_config(controller);
+        if (!result) {
+                print_error_result(__func__, true, result);
+                return false;
+        }
+
+        const char *expected_nodes[3] = { "foo", "bar", "another" };
+        return check_controller(__func__, controller, 1337, expected_nodes, 3);
+}
+
+bool test_controller_apply_config_invalid_port() {
+        _test_cleanup_controller_ Controller *controller = controller_new();
+        int r = cfg_initialize(&controller->config);
+        if (r < 0) {
+                fprintf(stderr, "Unexpected error when initializing config: %s", strerror(-r));
+                return false;
+        }
+
+        cfg_set_value(controller->config, CFG_CONTROLLER_PORT, "invalid");
+
+        bool result = controller_apply_config(controller);
+        if (result) {
+                print_error_result(__func__, false, result);
+                return false;
+        }
+        return true;
+}
+
+bool test_controller_apply_config_invalid_tcpkeeptime() {
+        _test_cleanup_controller_ Controller *controller = controller_new();
+        int r = cfg_initialize(&controller->config);
+        if (r < 0) {
+                fprintf(stderr, "Unexpected error when initializing config: %s", strerror(-r));
+                return false;
+        }
+
+        cfg_set_value(controller->config, CFG_TCP_KEEPALIVE_TIME, "invalid");
+
+        bool result = controller_apply_config(controller);
+        if (result) {
+                print_error_result(__func__, false, result);
+                return false;
+        }
+        return true;
+}
+
+bool test_controller_apply_config_invalid_tcpkeepintvl() {
+        _test_cleanup_controller_ Controller *controller = controller_new();
+        int r = cfg_initialize(&controller->config);
+        if (r < 0) {
+                fprintf(stderr, "Unexpected error when initializing config: %s", strerror(-r));
+                return false;
+        }
+
+        cfg_set_value(controller->config, CFG_TCP_KEEPALIVE_INTERVAL, "invalid");
+
+        bool result = controller_apply_config(controller);
+        if (result) {
+                print_error_result(__func__, false, result);
+                return false;
+        }
+        return true;
+}
+
+bool test_controller_apply_config_invalid_tcpkeepcnt() {
+        _test_cleanup_controller_ Controller *controller = controller_new();
+        int r = cfg_initialize(&controller->config);
+        if (r < 0) {
+                fprintf(stderr, "Unexpected error when initializing config: %s", strerror(-r));
+                return false;
+        }
+
+        cfg_set_value(controller->config, CFG_TCP_KEEPALIVE_COUNT, "invalid");
+
+        bool result = controller_apply_config(controller);
+        if (result) {
+                print_error_result(__func__, false, result);
+                return false;
+        }
+        return true;
+}
+
+int main() {
+        bool result = true;
+        result = result && test_controller_apply_config_none();
+        result = result && test_controller_apply_config_valid_all();
+        result = result && test_controller_apply_config_invalid_port();
+        result = result && test_controller_apply_config_invalid_tcpkeeptime();
+        result = result && test_controller_apply_config_invalid_tcpkeepintvl();
+        result = result && test_controller_apply_config_invalid_tcpkeepcnt();
+
+        if (result) {
+                return EXIT_SUCCESS;
+        }
+        return EXIT_FAILURE;
+}

--- a/src/controller/test/controller/meson.build
+++ b/src/controller/test/controller/meson.build
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+controller_src = [
+  'controller_apply_config_test',
+]
+
+# setup controller test src files to include in compilation
+controller_test_src = []
+foreach src : orch_src
+    # skip main to avoid duplicate main function error
+    if src == 'main.c'
+        continue
+    endif
+    controller_test_src += '../../' + src
+endforeach
+
+foreach src : controller_src
+  exec_test = executable(src, 
+    controller_test_src + [src + '.c'],
+    dependencies: [
+        systemd_dep,
+        inih_dep,
+        hashmapc_dep,
+    ],
+    link_with: [
+        bluechi_lib,
+    ],
+    c_args: common_cflags,
+    include_directories: include_directories('../../..'),
+  )
+  test(src, exec_test)
+endforeach

--- a/src/controller/test/meson.build
+++ b/src/controller/test/meson.build
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+subdir('controller')

--- a/tests/scripts/create_coverage_report.py
+++ b/tests/scripts/create_coverage_report.py
@@ -42,7 +42,7 @@ def exec(ctrl: BluechiControllerContainer, nodes: Dict[str, BluechiNodeContainer
         raise Exception(f"Error merging info files from each integration test: {output}")
 
     result, output = ctrl.exec_run(
-        f"lcov --remove {merge_dir}/{merge_file_name} -o {merge_dir}/{merge_file_name} '*/src/libbluechi/test/*'")
+        f"lcov --remove {merge_dir}/{merge_file_name} -o {merge_dir}/{merge_file_name} '*/src/*/test/*'")
     if result != 0:
         raise Exception(f"Error removing coverage for unit test file: {output}")
 


### PR DESCRIPTION
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/678

The parse functions agent_parse_config and controller_parse_config initialize the config, set default values there, load configuration from all sources and sets the loaded values to the agent/controller fields. This is a bit much, therefore, split setting the values out to a dedicated function. In addition to a smaller, easier to read function it also simplifies writing unit tests - which are also added in this PR. 

It also fixes two memory leaks:
- agent_unref did not free the peer_socket_options
- unit_infos was allocated twice