### PR TITLE
Test agent connect via ControllerAddress

### DIFF
--- a/tests/tests/tier0/bluechi-agent-connect-via-controller-address/config/Invalid-ControllerAddress.conf
+++ b/tests/tests/tier0/bluechi-agent-connect-via-controller-address/config/Invalid-ControllerAddress.conf
@@ -1,0 +1,2 @@
+[bluechi-agent]
+ControllerAddress=tcp:host=127.0.0.1,port=80000

--- a/tests/tests/tier0/bluechi-agent-connect-via-controller-address/main.fmf
+++ b/tests/tests/tier0/bluechi-agent-connect-via-controller-address/main.fmf
@@ -1,0 +1,2 @@
+summary: Test if bluechi-agent connects with ControllerAddress option
+id: 96aa0e17-5e23-4cc3-bc34-88368b8cc07b

--- a/tests/tests/tier0/bluechi-agent-connect-via-controller-address/test_bluechi_agent_connect_via_controller_address.py
+++ b/tests/tests/tier0/bluechi-agent-connect-via-controller-address/test_bluechi_agent_connect_via_controller_address.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from typing import Dict
+import os
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
+from bluechi_test.util import read_file
+
+NODE_FOO = "node-FOO"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    node_foo = nodes[NODE_FOO]
+    config_file_location = "/var/tmp"
+    bluechi_agent_str = "bluechi-agent"
+    invalid_conf_str = "config/Invalid-ControllerAddress.conf"
+    invalid_controller_address = "Invalid-ControllerAddress.conf"
+    service = "org.eclipse.bluechi"
+    object = "/org/eclipse/bluechi"
+    interface = "org.eclipse.bluechi.Controller"
+    property = "Status"
+
+    assert node_foo.wait_for_unit_state_to_be(bluechi_agent_str, "active", delay=2)
+    assert 's "up"' == ctrl.exec_run(f"busctl get-property {service} {object} {interface} {property}")[1]
+
+    content = read_file(invalid_conf_str)
+    node_foo.create_file(config_file_location, invalid_conf_str, content)
+
+    node_foo.restart_with_config_file(os.path.join(config_file_location, invalid_controller_address), bluechi_agent_str)
+    assert node_foo.wait_for_unit_state_to_be(bluechi_agent_str, "active", delay=2)
+    assert 's "down"' == ctrl.exec_run(f"busctl get-property {service} {object} {interface} {property}")[1]
+
+
+def test_agent_invalid_configuration(
+        bluechi_test: BluechiTest,
+        bluechi_node_default_config: BluechiAgentConfig, bluechi_ctrl_default_config: BluechiControllerConfig):
+
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = NODE_FOO
+    node_foo_cfg.controller_address = f"tcp:host={node_foo_cfg.controller_host},port={node_foo_cfg.controller_port}"
+    node_foo_cfg.controller_host = ""
+    node_foo_cfg.controller_port = ""
+
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Added a test for agent to test if it connectes via ControllerAddress. This test will run an agent and change its configuration to use localhost instead of the real valid IP address in ControllerAddress  and expect the agent to be failed because the controller is not listening on this IP.

Related: https://github.com/eclipse-bluechi/bluechi/issues/668