### PR TITLE
Update GH actions to latest releases

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: Name of the image to build and push to quay.io 
+        description: Name of the image to build and push to quay.io
         required: true
         type: choice
         options:
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -24,7 +24,7 @@ jobs:
       - name: Build manifest
         run: |
           ./build-scripts/build-push-containers.sh ${{ inputs.image }}
-      
+
       - name: Push manifest o quay.io
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,7 +16,7 @@ jobs:
       ARTIFACTS_DIR: exported-artifacts
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'true'
@@ -36,7 +36,7 @@ jobs:
           createrepo_c $ARTIFACTS_DIR
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rpm-artifacts
           path: ${{ env.ARTIFACTS_DIR}}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
@@ -70,12 +70,12 @@ jobs:
           pip install rich
 
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: rpm-artifacts
           path: 'tests/bluechi-rpms'
@@ -112,21 +112,21 @@ jobs:
 
       - name: Upload tmt artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tmt-artifacts
           path: '/var/tmp/tmt'
 
       - name: Upload coverage HTML report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-artifacts-html
           path: '/var/tmp/report'
 
       - name: Upload coverage file
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-artifacts-info
           path: '/var/tmp/merged.info'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
 
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
 
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
 
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
 
@@ -127,24 +127,24 @@ jobs:
   apispec:
     needs: changes
     if: ${{ needs.changes.outputs.apispec == 'true' }}
-    name: 
+    name:
     runs-on: ubuntu-latest
     container:
       image: quay.io/bluechi/build-base:latest
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
-      
+
       - name: Install dependencies
-        run: | 
+        run: |
           python3 -m ensurepip --default-pip
           python3 -m pip install -r src/bindings/generator/requirements.txt
           pip install wheel
           dnf install -y python3-gobject
-      
+
       - name: Generate and build python bindings
         run: |
           ./build-scripts/generate-bindings.sh python

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,19 +15,19 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'true'
 
       - name: Mark source directory as safe
-        run: | 
+        run: |
           git config --global --add safe.directory $(pwd)
-      
+
       - name: Build source rpm
         run: |
           ./build-scripts/build-srpm.sh
-      
+
       - name: Get BlueChi version
         run: |
           echo "BLUECHI_VERSION=$(./build-scripts/version.sh)" >> $GITHUB_ENV
@@ -37,11 +37,11 @@ jobs:
           mkdir -p /tmp/bluechi-${{ env.BLUECHI_VERSION }}
           cp -r ./ /tmp/bluechi-${{ env.BLUECHI_VERSION }}/
           rm -rf /tmp/bluechi-${{ env.BLUECHI_VERSION }}/.git/
-          mv /tmp/bluechi-${{ env.BLUECHI_VERSION }}/ ./ 
+          mv /tmp/bluechi-${{ env.BLUECHI_VERSION }}/ ./
 
           zip -r bluechi-${{ env.BLUECHI_VERSION }}.zip bluechi-${{ env.BLUECHI_VERSION }}/
           tar czf bluechi-${{ env.BLUECHI_VERSION }}.tar.gz bluechi-${{ env.BLUECHI_VERSION }}/
-      
+
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
 
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload unit test logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unit-test-logs
           path: ./builddir/meson-logs/testlog-valgrind.txt


### PR DESCRIPTION
Updates GH actions to latest releases to fix following warning:

```
Node.js 16 actions are deprecated. Please update the following
actions to use Node.js 20
```

Signed-off-by: Martin Perina <mperina@redhat.com>
