### PR TITLE
Generate coverage info file for unit test during package build

### DIFF
--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -5,7 +5,7 @@
 
 # coverage collection is disabled by default , it can be enabled passing `--define "with_coverage 1"` option to rpmbuild
 %if 0%{?with_coverage}
-%global coverage_flags -Dwith_coverage=true
+%global coverage_flags -Dwith_coverage=true -Db_coverage=true
 %endif
 
 Name:		bluechi
@@ -25,6 +25,11 @@ BuildRequires:	meson
 BuildRequires:	systemd-devel
 BuildRequires:	systemd-rpm-macros
 BuildRequires:	golang-github-cpuguy83-md2man
+
+%if 0%{?with_coverage}
+BuildRequires:	lcov
+BuildRequires: sed
+%endif
 
 %description
 BlueChi is a systemd service controller for multi-nodes environements with a
@@ -271,6 +276,8 @@ mkdir -p %{buildroot}/%{_datadir}/bluechi-coverage/bin
 cp tests/scripts/gather-code-coverage.sh %{buildroot}/%{_datadir}/bluechi-coverage/bin
 cp tests/scripts/setup-src-dir-for-coverage.sh %{buildroot}/%{_datadir}/bluechi-coverage/bin
 
+mkdir -p %{buildroot}/%{_datadir}/bluechi-coverage/unit-test-results
+
 mkdir -p %{buildroot}/%{_localstatedir}/tmp/bluechi-coverage/
 %endif
 
@@ -285,11 +292,24 @@ popd
 %meson_test
 
 %if 0%{?with_coverage}
-# Install gcda files from unit test execution so they could be packages into bluechi-coverage RPM.
-# Those files cannot be installed inside install section, because unit tests are executed later.
-# Files need to be moved to clean up as using clean section in spec is not recommended by Fedora Packaging Guidelines.
-mv /var/tmp/bluechi-coverage/*.gcda %{buildroot}/%{_datadir}/bluechi-coverage
+# Generate code coverage report from unit tests execution
+ninja coverage-html -C %{_vpath_builddir}
+
+# Remove tests executable files from generate code coverage info, because we want to measure only non-testing source
+# files, and code coverage .info file into bluchi-coverage package, so it can be merged with integration test results
+# later
+lcov --remove \
+    %{_vpath_builddir}/meson-logs/coverage.info \
+    -o %{buildroot}/%{_datadir}/bluechi-coverage/unit-test-results/coverage.info \
+    '*/src/*/test/*'
+
+# Make path to source code local to current directory, because source codes will be on a different place during
+# the merge with integration test results
+sed -i \
+    's/SF:.*src/SF:\/var\/tmp\/bluechi-coverage\/src/' \
+    %{buildroot}/%{_datadir}/bluechi-coverage/unit-test-results/coverage.info
 %endif
+
 
 %changelog
 * Wed Jan 17 2024 Michael Engel <mengel@redhat.com> - 0.7.0-1

--- a/build-scripts/install-coverage.sh
+++ b/build-scripts/install-coverage.sh
@@ -8,8 +8,3 @@ COVERAGE_ROOT="${MESON_INSTALL_DESTDIR_PREFIX}/share/bluechi-coverage"
 # Install all created `*.gcno` files so they could be packaged into bluechi-coverage RPM.
 mkdir -p ${COVERAGE_ROOT}
 ( cd $MESON_BUILD_ROOT ; find . -name "*.gcno" -exec cp -v --parents {} ${COVERAGE_ROOT} \; )
-
-# Unit test source files are not included in debugsource RPM, add them to bluechi-coverage RPM
-TEST_SUBDIR="src/libbluechi/test"
-mkdir -p ${COVERAGE_ROOT}/${TEST_SUBDIR}
-( cd $MESON_SOURCE_ROOT/${TEST_SUBDIR} ; find . -name "*.c" -exec cp -v --parents {} ${COVERAGE_ROOT}/${TEST_SUBDIR} \; )

--- a/tests/scripts/create_coverage_report.py
+++ b/tests/scripts/create_coverage_report.py
@@ -35,8 +35,12 @@ def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
         lcov_list.append("-a")
         lcov_list.append(f"{merge_dir}/{file_path.name}")
 
+    # Append unit tests code coverage results
+    lcov_list.append("-a")
+    lcov_list.append("/var/tmp/bluechi-coverage/unit-test-results/coverage.info")
+
     # Skip creating coverage report when no .info files are found
-    if len(lcov_list) == 1:
+    if len(lcov_list) == 3:
         LOGGER.info(f"No .info files found in {root.name}, skipping...")
         return
 
@@ -45,11 +49,6 @@ def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
     result, output = ctrl.exec_run(" ".join(lcov_list))
     if result != 0:
         raise Exception(f"Error merging info files from each integration test: {output}")
-
-    result, output = ctrl.exec_run(
-        f"lcov --remove {merge_dir}/{merge_file_name} -o {merge_dir}/{merge_file_name} '*/src/*/test/*'")
-    if result != 0:
-        raise Exception(f"Error removing coverage for unit test file: {output}")
 
     LOGGER.debug(f"Generating report for merged info file '{merge_dir}/{merge_file_name}'")
     result, output = ctrl.exec_run(f"genhtml {merge_dir}/{merge_file_name} --output-directory={report_dir_name}")


### PR DESCRIPTION
Prior to the patch .gcda files from unit tests execution are packaged
into bluechi-coverage and later merged with integration test .gcda file
to create unified code coverage report.
As a part of this patch we generate code coverage info file for unit
tests and package this info into bluechi-coverage, which simplifies
generating unified code coverage report.

Signed-off-by: Martin Perina <mperina@redhat.com>
