### PR TITLE
implemented ssh client and test suite

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install unpackaged python libraries from PyPi
         run: |
-          pip install "tmt[provision]==1.30" "tmt[report-junit]==1.30" podman pytest pytest-timeout
+          pip install "tmt[provision]==1.30" "tmt[report-junit]==1.30" podman pytest pytest-timeout pyyaml paramiko
           # Mitigate https://github.com/containers/podman-py/issues/350
           pip install rich
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,9 +23,11 @@ Then install the required packages:
 dnf install \
     createrepo_c \
     podman \
+    python3-paramiko \
     python3-podman \
     python3-pytest \
     python3-pytest-timeout \
+    python3-pyyaml \
     tmt \
     tmt-report-junit \
     -y

--- a/tests/bluechi_test/fixtures.py
+++ b/tests/bluechi_test/fixtures.py
@@ -3,13 +3,21 @@
 import logging
 import os
 import pytest
+import yaml
 
 from podman import PodmanClient
-from typing import Union
+from typing import Union, List, Dict, Any, Tuple
 
-from bluechi_test.test import BluechiTest
+from bluechi_test.test import BluechiTest, BluechiContainerTest, BluechiSSHTest
 from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
 from bluechi_test.util import get_primary_ip
+
+
+def _get_env_value(env_var: str, default_value: str) -> str:
+    value = os.getenv(env_var)
+    if value is None:
+        return default_value
+    return value
 
 
 @pytest.fixture(scope='session')
@@ -46,6 +54,88 @@ def bluechi_ctrl_svc_port() -> str:
 
 
 @pytest.fixture(scope='session')
+def machines_ssh_user() -> str:
+    """Returns the user for connecting to the available hosts via SSH"""
+
+    return _get_env_value('SSH_USER', 'root')
+
+
+@pytest.fixture(scope='session')
+def machines_ssh_password() -> str:
+    """Returns the password for connecting to the available hosts via SSH"""
+
+    return _get_env_value('SSH_PASSWORD', "")
+
+
+def _read_topology() -> Dict[str, Any]:
+    """
+    Returns the parsed YAML for the tmt guest topology:
+    https://tmt.readthedocs.io/en/stable/spec/plans.html#guest-topology-format
+    """
+    tmt_yaml_file = _get_env_value("TMT_TOPOLOGY_YAML", "")
+    if tmt_yaml_file is None or tmt_yaml_file == "":
+        return get_primary_ip()
+
+    topology = ""
+    with open(tmt_yaml_file, "r") as f:
+        topology = yaml.safe_load(f.read())
+    return topology
+
+
+@pytest.fixture(scope='session')
+def bluechi_ctrl_host_ip() -> str:
+    """
+    Returns the ip of the host on which bluechi controller service is running.
+    It determines the controller guest by looking for the name [controller, bluechi-controller]
+    in the name.
+    """
+    topology = _read_topology()
+
+    if "guests" not in topology:
+        return get_primary_ip()
+
+    for guest in topology["guests"]:
+        if "name" in guest and "controller" in guest["role"]:
+            return guest["hostname"]
+
+    return get_primary_ip()
+
+
+@pytest.fixture(scope='session')
+def available_hosts() -> Dict[str, List[Tuple[str, str]]]:
+    """
+    Returns the available hosts.
+    Consists of a dictionary with "agent" and "controller" keys. The
+    respective lists contain a tuple with the guest name and the hostname.
+    Not used in container setup.
+    """
+    topology = _read_topology()
+
+    hosts = dict()
+
+    if "guests" not in topology:
+        return hosts
+
+    for guest_name, values in topology["guests"].items():
+        if values["role"] == "controller":
+            hosts["controller"] = [(guest_name, values["hostname"])]
+        elif values["role"] == "agent":
+            if "agent" not in hosts:
+                hosts["agent"] = []
+            hosts["agent"].append((guest_name, values["hostname"]))
+
+    return hosts
+
+
+@pytest.fixture(scope='session')
+def is_multihost_run(available_hosts: Dict[str, List[Tuple[str, str]]]) -> bool:
+    """"Returns flag if current run is a multihost test or not. Uses number of available hosts."""
+    return len(available_hosts) > 1 and \
+        "controller" in available_hosts and \
+        "agent" in available_hosts
+
+
+@pytest.fixture(scope='session')
 def run_with_valgrind() -> bool:
     """Returns 1 if bluechi should be run with valgrind for memory management testing"""
 
@@ -59,13 +149,6 @@ def run_with_coverage() -> bool:
     return _get_env_value('WITH_COVERAGE', 0) == '1'
 
 
-def _get_env_value(env_var: str, default_value: str) -> str:
-    value = os.getenv(env_var)
-    if value is None:
-        return default_value
-    return value
-
-
 @pytest.fixture(scope='session')
 def podman_client() -> PodmanClient:
     """Returns the podman client instance"""
@@ -76,8 +159,11 @@ def podman_client() -> PodmanClient:
 
 
 @pytest.fixture(scope='session')
-def bluechi_image_id(podman_client: PodmanClient, bluechi_image_name: str) -> Union[str, None]:
+def bluechi_image_id(podman_client: PodmanClient, bluechi_image_name: str, is_multihost_run: bool) -> Union[str, None]:
     """Returns the image ID of bluechi testing containers"""
+    if is_multihost_run:
+        return None
+
     image = next(
         iter(
             podman_client.images.list(
@@ -97,10 +183,10 @@ def bluechi_ctrl_default_config(bluechi_ctrl_svc_port: str):
 
 
 @pytest.fixture(scope='function')
-def bluechi_node_default_config(bluechi_ctrl_svc_port: str):
+def bluechi_node_default_config(bluechi_ctrl_svc_port: str, bluechi_ctrl_host_ip: str):
     return BluechiAgentConfig(
         file_name="agent.conf",
-        controller_host=get_primary_ip(),
+        controller_host=bluechi_ctrl_host_ip,
         controller_port=bluechi_ctrl_svc_port)
 
 
@@ -111,7 +197,9 @@ def additional_ports():
 
 @pytest.fixture(scope='function')
 def bluechi_test(
+        is_multihost_run: bool,
         podman_client: PodmanClient,
+        available_hosts: Dict[str, List[Tuple[str, str]]],
         bluechi_image_id: str,
         bluechi_ctrl_host_port: str,
         bluechi_ctrl_svc_port: str,
@@ -119,9 +207,21 @@ def bluechi_test(
         tmt_test_data_dir: str,
         run_with_valgrind: bool,
         run_with_coverage: bool,
-        additional_ports: dict):
+        additional_ports: dict,
+        machines_ssh_user: str,
+        machines_ssh_password: str) -> BluechiTest:
 
-    return BluechiTest(
+    if is_multihost_run:
+        return BluechiSSHTest(available_hosts,
+                              machines_ssh_user,
+                              machines_ssh_password,
+                              bluechi_ctrl_svc_port,
+                              tmt_test_serial_number,
+                              tmt_test_data_dir,
+                              run_with_valgrind,
+                              run_with_coverage)
+
+    return BluechiContainerTest(
         podman_client,
         bluechi_image_id,
         bluechi_ctrl_host_port,

--- a/tests/bluechi_test/util.py
+++ b/tests/bluechi_test/util.py
@@ -17,12 +17,12 @@ def read_file(local_file: str) -> Union[str, None]:
     return content
 
 
-def get_primary_ip() -> str:
+def get_primary_ip(address: str = "254.254.254.254") -> str:
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.settimeout(0)
     try:
         # connect to an arbitrary address
-        s.connect(("254.254.254.254", 1))
+        s.connect((address, 1))
         ip = s.getsockname()[0]
     except Exception:
         LOGGER.exception("Failed to get IP, falling back to localhost.")

--- a/tests/plans/tier0.fmf
+++ b/tests/plans/tier0.fmf
@@ -17,7 +17,7 @@ prepare:
     - name: Prepare containers setup
       how: shell
       script: |
-          ./scripts/tests-setup.sh
+          ./scripts/tests-setup.sh setup_container_test
 execute:
     how: tmt
 report:

--- a/tests/scripts/tests-setup.sh
+++ b/tests/scripts/tests-setup.sh
@@ -3,40 +3,128 @@
 
 set -x
 
-# Install required dependencies only when asked
-if [ "$INSTALL_DEPS" == "yes" ]; then
+COPR_REPO="@centos-automotive-sig/bluechi-snapshot"
+
+function install_worker_deps(){
     dnf install \
         podman \
         python3-dasbus \
+        python3-paramiko \
         python3-podman \
         python3-pytest \
         python3-pytest-timeout \
+        python3-pyyaml \
         -y
     # Mitigate https://github.com/containers/podman-py/issues/350
     dnf install python3-rich -y
+}
+
+function setup_worker_ssh(){
+    dnf install openssh-server passwd -y
+    
+    # root access is needed in order to access BlueChi's API
+    echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
+    echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+
+    systemctl restart sshd
+
+    if [ -z "${SSH_USER}" ]; then
+        SSH_USER="root"
+    fi
+    if [ -z "${SSH_PASSWORD}" ]; then
+        SSH_PASSWORD="root"
+    fi
+    echo "$SSH_PASSWORD" | passwd "$SSH_USER" --stdin
+}
+
+function setup_worker(){
+    if [ "$INSTALL_WORKER_DEPS" == "yes" ]; then
+        dnf upgrade --refresh --nodocs -y
+        dnf install --nodocs epel-release -y
+        dnf install --nodocs \
+                lcov \
+                lsof \
+                policycoreutils-python-utils \
+                python3-dasbus \
+                selinux-policy \
+                systemd \
+                systemd-devel \
+                valgrind \
+            -y
+    fi
+
+    dnf install -y dnf-plugin-config-manager
+    dnf copr enable -y @centos-automotive-sig/bluechi-snapshot
+    dnf install \
+        --nogpgcheck \
+        --nodocs \
+        bluechi-controller \
+        bluechi-controller-debuginfo \
+        bluechi-agent \
+        bluechi-agent-debuginfo \
+        bluechi-ctl \
+        bluechi-ctl-debuginfo \
+        bluechi-selinux \
+        python3-bluechi \
+        -y
+    dnf -y clean all
+
+    if [ "$SETUP_SSH" == "yes" ]; then
+        setup_worker_ssh
+    fi
+}
+
+function setup_executor(){
+    # Install required dependencies only when asked
+    if [ "$INSTALL_EXECUTOR_DEPS" == "yes" ]; then
+        install_worker_deps
+    fi
+}
+
+
+
+function setup_multihost_test(){
+    [ -z $1 ] && echo "Missing option for multihost test setup. Pass in either 'setup_executor' or 'setup_worker'" && exit 1
+    $1
+}
+
+function setup_container_test(){
+    # Install required dependencies only when asked
+    if [ "$INSTALL_DEPS" == "yes" ]; then
+        install_worker_deps
+        # Mitigate https://github.com/containers/podman-py/issues/350
+        dnf install python3-rich -y
+    fi
+
+    BUILD_ARG=""
+
+    # By default we want to use bluechi-snapshot repo, but when building from packit testing farm we need to pass custom
+    # copr repo to the container (packit uses temporary COPR repos for unmerged PRs)
+    if [ "$PACKIT_COPR_PROJECT" != "" ]; then
+        COPR_REPO="$PACKIT_COPR_PROJECT"
+    fi
+    BUILD_ARG="--build-arg copr_repo=$COPR_REPO"
+
+    podman build \
+        ${BUILD_ARG} \
+        -f ./containers/$CONTAINER_USED \
+        -t $BLUECHI_IMAGE_NAME \
+        .
+    if [[ $? -ne 0 ]]; then
+        exit 1
+    fi
+
+    if [ "$(systemctl --user is-active podman.socket)" != "active" ]; then
+        echo "Integration tests requires access to podman using user socket"
+        systemctl --user enable podman.socket
+        systemctl --user start podman.socket
+    fi
+}
+
+[ -z $1 ] && echo "Requires type of test. Either 'setup_container_test' or 'setup_multihost_test'" && exit 1
+if [ "$1" == "setup_multihost_test" ]; then
+    $1 $2
+    exit 0
 fi
 
-BUILD_ARG=""
-
-# By default we want to use bluechi-snapshot repo, but when building from packit testing farm we need to pass custom
-# copr repo to the container (packit uses temporary COPR repos for unmerged PRs)
-COPR_REPO="@centos-automotive-sig/bluechi-snapshot"
-if [ "$PACKIT_COPR_PROJECT" != "" ]; then
-    COPR_REPO="$PACKIT_COPR_PROJECT"
-fi
-BUILD_ARG="--build-arg copr_repo=$COPR_REPO"
-
-podman build \
-    ${BUILD_ARG} \
-    -f ./containers/$CONTAINER_USED \
-    -t $BLUECHI_IMAGE_NAME \
-    .
-if [[ $? -ne 0 ]]; then
-    exit 1
-fi
-
-if [ "$(systemctl --user is-active podman.socket)" != "active" ]; then
-    echo "Integration tests requires access to podman using user socket"
-    systemctl --user enable podman.socket
-    systemctl --user start podman.socket
-fi
+$1


### PR DESCRIPTION
This PR implements the SSH client based on paramiko (https://www.paramiko.org/). It also derives two classes from the `BluechiTest` - for container and ssh usage. This way the different `setup` and `teardown` (e.g. deleting created files from host) can be implemented later. 

---

**Testing this change:**

In order to test this, a dedicated branch has been created:
https://github.com/engelmi/bluechi/tree/experiment-multihost
It exchanges the plan `tier0.fmf` with one for multihost (`tier1.fmf`) and filters only for tests with tier 1 - which has been set on only one test. This way only this single test is executed, avoiding to fail for multiple due to the missing cleanup (future PR).

Request to start on testing farm: (an exported API token is required)
```bash
testing-farm request --path tests --git-ref experiment-multihost --git-url https://github.com/engelmi/bluechi.git --compose Fedora-Rawhide --pipeline-type tmt-multihost
```

And here are the results:
http://artifacts.osci.redhat.com/testing-farm/616032a6-645f-4178-aea3-a97f4c28fefb/
