### PR TITLE
Improve logging in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Run integration tests
         run: |
           cd tests
-          tmt run -v -eCONTAINER_USED=integration-test-local -eWITH_COVERAGE=1
+          tmt run -v -eCONTAINER_USED=integration-test-local -eWITH_COVERAGE=1 -eLOG_LEVEL=DEBUG
 
       - name: Show tmt log output in case of failure
         if: ${{ failure() }}

--- a/tests/bluechi_test/bluechictl.py
+++ b/tests/bluechi_test/bluechictl.py
@@ -28,8 +28,7 @@ class BluechiCtl():
             -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
         LOGGER.debug(log_txt)
         result, output = self.client.exec_run(f"{BluechiCtl.binary_name} {cmd}")
-        LOGGER.debug(f"{log_txt} finished with result '{result}' \
-            and output:\n{output}")
+        LOGGER.debug(f"{log_txt} finished with result '{result}' and output:\n{output}")
         if check_result and result != expected_result:
             raise Exception(f"{log_txt} failed with {result} (expected {expected_result}): {output}")
         return result, output

--- a/tests/bluechi_test/bluechictl.py
+++ b/tests/bluechi_test/bluechictl.py
@@ -28,7 +28,7 @@ class BluechiCtl():
             -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
         LOGGER.debug(log_txt)
         result, output = self.client.exec_run(f"{BluechiCtl.binary_name} {cmd}")
-        LOGGER.debug(f"{log_txt} finished with result '{result}' and output:\n{output}")
+        LOGGER.debug(f"{log_txt} finished with result '{result}' and output '{output}'")
         if check_result and result != expected_result:
             raise Exception(f"{log_txt} failed with {result} (expected {expected_result}): {output}")
         return result, output

--- a/tests/bluechi_test/client.py
+++ b/tests/bluechi_test/client.py
@@ -74,11 +74,12 @@ class ContainerClient(Client):
             Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
 
         result, output = self.container.exec_run(command, tty=tty)
-        LOGGER.debug(f"Executed command '{command}' with result '{result}' and output '{output}'")
 
         if not raw_output and output:
-            output = output.decode('utf-8').strip()
+            # When using tty is enabled, podman uses CRLF line ends, so we need to convert to LF
+            output = output.replace(b"\r", b"").decode("utf-8").strip()
 
+        LOGGER.debug(f"Executed command '{command}' with result '{result}' and output '{output}'")
         return result, output
 
 

--- a/tests/bluechi_test/fixtures.py
+++ b/tests/bluechi_test/fixtures.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import logging
 import os
 import pytest
 
@@ -68,6 +69,9 @@ def _get_env_value(env_var: str, default_value: str) -> str:
 @pytest.fixture(scope='session')
 def podman_client() -> PodmanClient:
     """Returns the podman client instance"""
+    # urllib3 produces too much information in DEBUG mode, which are not interesting for bluechi tests
+    urllib3_logger = logging.getLogger("urllib3.connectionpool")
+    urllib3_logger.setLevel(logging.INFO)
     return PodmanClient()
 
 

--- a/tests/bluechi_test/machine.py
+++ b/tests/bluechi_test/machine.py
@@ -174,12 +174,12 @@ class BluechiMachine():
         gcda_file_location = "/var/tmp/bluechi-coverage"
         coverage_file = f"{gcda_file_location}/coverage-{self.name}.info"
 
-        LOGGER.info("Generating info file started")
+        LOGGER.info(f"Generating info file '{coverage_file}' started")
         result, output = self.client.exec_run(
             f"/usr/share/bluechi-coverage/bin/gather-code-coverage.sh {coverage_file}")
         if result != 0:
             LOGGER.error(f"Failed to gather code coverage: {output}")
-        LOGGER.info("Generating info file finished")
+        LOGGER.info(f"Generating info file '{coverage_file}' finished")
 
         self.client.get_file(f"{coverage_file}", data_coverage_dir)
 

--- a/tests/bluechi_test/systemctl.py
+++ b/tests/bluechi_test/systemctl.py
@@ -21,7 +21,7 @@ class SystemCtl():
 
         LOGGER.debug(f"{operation} unit '{unit_name}'")
         result, output = self.client.exec_run(f"{SystemCtl.binary_name} {operation} {unit_name}")
-        LOGGER.debug(f"{operation} unit '{unit_name}' finished with result '{result}' and output:\n{output}")
+        LOGGER.debug(f"{operation} unit '{unit_name}' finished with result '{result}' and output '{output}'")
         if check_result and result != expected_result:
             raise Exception(
                 f"Failed to {operation} service {unit_name} with {result} (expected {expected_result}): {output}")

--- a/tests/bluechi_test/systemctl.py
+++ b/tests/bluechi_test/systemctl.py
@@ -21,8 +21,7 @@ class SystemCtl():
 
         LOGGER.debug(f"{operation} unit '{unit_name}'")
         result, output = self.client.exec_run(f"{SystemCtl.binary_name} {operation} {unit_name}")
-        LOGGER.debug(f"{operation} unit '{unit_name}' finished with result '{result}' \
-            and output:\n{output}")
+        LOGGER.debug(f"{operation} unit '{unit_name}' finished with result '{result}' and output:\n{output}")
         if check_result and result != expected_result:
             raise Exception(
                 f"Failed to {operation} service {unit_name} with {result} (expected {expected_result}): {output}")


### PR DESCRIPTION
- **Force urllib3 log level to INFO**
- **Fixing multiline string notation for loggging**
- **Make exec_run output content readable in logs**
- **Improves logging in code coverage process**
- **Use DEBUG log level in GH CI integration tests run**
