### PR TITLE
Test validity of -h/--help option

### DIFF
--- a/tests/tests/tier0/bluechi-help-option-provided/main.fmf
+++ b/tests/tests/tier0/bluechi-help-option-provided/main.fmf
@@ -1,0 +1,2 @@
+summary: Test if bluechi-controller, bluechi-agent and bluechictl provides --help option
+id: 16b85131-9616-43e3-8c90-905671a953a3

--- a/tests/tests/tier0/bluechi-help-option-provided/test_help_option_provided.py
+++ b/tests/tests/tier0/bluechi-help-option-provided/test_help_option_provided.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.config import BluechiControllerConfig
+
+
+def check_help_option(ctrl: BluechiControllerMachine, _: Dict[str, BluechiAgentMachine]):
+    executables = [
+        '/usr/libexec/bluechi-controller',
+        '/usr/libexec/bluechi-agent',
+        '/usr/bin/bluechictl'
+    ]
+
+    for executable in executables:
+        s_re, s_out = ctrl.exec_run(f"{executable} -h")
+        l_re, l_out = ctrl.exec_run(f"{executable} --help")
+
+        assert s_re == 0
+        assert l_re == 0
+        assert 'Usage' in s_out
+        assert 'Usage' in l_out
+        assert s_out == l_out
+
+
+def test_help_option_provided(bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(check_help_option)


### PR DESCRIPTION
Tests, bluechi-controller, bluechi-agent and bluechictl provides both
short (-h) and long (--help) option and those options provides some
content.

Signed-off-by: Martin Perina <mperina@redhat.com>