### PR TITLE
Test validity of -v/--version option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ builddir/
 bluechi.spec
 rpmbuild/
 artifacts/
+build-scripts/RELEASE
+
 ## python build artifacts
 build/
 dist/

--- a/build-scripts/build-srpm.sh
+++ b/build-scripts/build-srpm.sh
@@ -1,6 +1,10 @@
 #!/bin/bash -xe
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+# Clean previously generated release cache
+$(dirname "$(readlink -f "$0")")/version.sh clean
+
+# Create source archive
 source $(dirname "$(readlink -f "$0")")/create-archive.sh
 
 mv bluechi-$VERSION.tar.gz rpmbuild/SOURCES/

--- a/build-scripts/create-archive.sh
+++ b/build-scripts/create-archive.sh
@@ -6,7 +6,14 @@ source $(dirname "$(readlink -f "$0")")/create-spec.sh
 # Prepare source archive
 [[ -d rpmbuild/SOURCES ]] || mkdir -p rpmbuild/SOURCES
 
-git archive --format=tar --prefix=bluechi-$VERSION/ --add-file=bluechi.spec -o bluechi-$VERSION.tar HEAD
+git archive \
+    --format=tar \
+    -o bluechi-$VERSION.tar \
+    --prefix=bluechi-$VERSION/build-scripts/ \
+    --add-file=build-scripts/RELEASE \
+    --prefix=bluechi-$VERSION/ \
+    --add-file=bluechi.spec \
+    HEAD
 git submodule foreach --recursive \
     "git archive --prefix=bluechi-$VERSION/\$path/ --output=\$sha1.tar HEAD && \
      tar --concatenate --file=$(pwd)/bluechi-$VERSION.tar \$sha1.tar && rm \$sha1.tar"

--- a/build-scripts/version.sh
+++ b/build-scripts/version.sh
@@ -7,6 +7,8 @@ VERSION=0.8.0
 IS_RELEASE=false
 # Used for official releases. Increment if necessary
 RELEASE="1"
+# Used to cache generated snapshot release for further usage
+RELEASE_FILE=$(dirname "$(readlink -f "$0")")/RELEASE
 
 function short(){
     echo ${VERSION}
@@ -21,9 +23,18 @@ function release(){
 
     if [ $IS_RELEASE = false ]; then
         # Used for nightly builds
-        RELEASE="0.$(date +%04Y%02m%02d%02H%02M).git$(git rev-parse --short ${GITHUB_SHA:-HEAD})"
+        if [ -f "${RELEASE_FILE}" ]; then
+            RELEASE="$(cat ${RELEASE_FILE})"
+        else
+            RELEASE="0.$(date +%04Y%02m%02d%02H%02M).git$(git rev-parse --short ${GITHUB_SHA:-HEAD})"
+            echo ${RELEASE} > ${RELEASE_FILE}
+        fi
     fi
     echo $RELEASE
+}
+
+function clean(){
+    rm -f "${RELEASE_FILE}"
 }
 
 [ -z $1 ] && short || $1

--- a/tests/tests/tier0/bluechi-version-option-provided/main.fmf
+++ b/tests/tests/tier0/bluechi-version-option-provided/main.fmf
@@ -1,0 +1,2 @@
+summary: Test if bluechi-controller, bluechi-agent and bluechictl provides --version option
+id: e5a0fc8f-7254-4e57-a312-f3ce811d8086

--- a/tests/tests/tier0/bluechi-version-option-provided/test_version_option_provided.py
+++ b/tests/tests/tier0/bluechi-version-option-provided/test_version_option_provided.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.config import BluechiControllerConfig
+
+
+def check_help_option(ctrl: BluechiControllerMachine, _: Dict[str, BluechiAgentMachine]):
+    rpm_re, rpm_out = ctrl.exec_run('rpm -q --qf "%{version}-%{release}" bluechi-controller')
+    assert rpm_re == 0
+
+    # There is no way to strip dist part from the release using rpm query flags, so we need to replace it manually
+    bc_ver_rel = rpm_out.replace(".el9", "")
+    executables = [
+        '/usr/libexec/bluechi-controller',
+        '/usr/libexec/bluechi-agent'
+    ]
+
+    for executable in executables:
+        s_re, s_out = ctrl.exec_run(f"{executable} -v")
+        l_re, l_out = ctrl.exec_run(f"{executable} --version")
+
+        assert s_re == 0
+        assert l_re == 0
+        assert s_out == l_out
+        assert bc_ver_rel in s_out
+
+
+def test_version_option_provided(bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(check_help_option)


### PR DESCRIPTION
* Test validity of -v/--version option
* Align RPM release with release reported by command line tools

Fixes: https://github.com/eclipse-bluechi/bluechi/issues/753
Signed-off-by: Martin Perina <mperina@redhat.com>