### PR TITLE
Test metrics enable and then disable

### DIFF
--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -1563,6 +1563,7 @@ static int agent_method_disable_metrics(sd_bus_message *m, void *userdata, UNUSE
         }
         agent->metrics_enabled = false;
         sd_bus_slot_unrefp(&agent->metrics_slot);
+        agent->metrics_slot = NULL;
         bc_log_debug("Metrics disabled");
         return sd_bus_reply_method_return(m, "");
 }

--- a/tests/bluechi_test/bluechictl.py
+++ b/tests/bluechi_test/bluechictl.py
@@ -129,3 +129,21 @@ class BluechiCtl():
             check_result,
             expected_result
         )
+
+    def enable_metrics(self, check_result: bool = True, expected_result: int = 0) \
+            -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
+        return self._run(
+            "Enabling metrics",
+            "metrics enable",
+            check_result,
+            expected_result
+        )
+
+    def disable_metrics(self, check_result: bool = True, expected_result: int = 0) \
+            -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
+        return self._run(
+            "Disabling metrics",
+            "metrics disable",
+            check_result,
+            expected_result
+        )

--- a/tests/tests/tier0/metrics-enable-and-disable/main.fmf
+++ b/tests/tests/tier0/metrics-enable-and-disable/main.fmf
@@ -1,0 +1,2 @@
+summary: Test if metrics reporting is enabled and disabled correctly
+id: ed71f395-b5f9-44a2-abfb-738c77e0539c

--- a/tests/tests/tier0/metrics-enable-and-disable/python/metrics_is_enabled.py
+++ b/tests/tests/tier0/metrics-enable-and-disable/python/metrics_is_enabled.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from bluechi.api import Metrics, Node, UInt64
+from dasbus.error import DBusError
+from dasbus.loop import EventLoop
+
+
+class TestMetricsIsEnabled(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.loop = EventLoop()
+        self.metrics = Metrics()
+        self.signal_received = False
+        self.loop_quitter = None
+
+    def test_metrics_is_enabled(self):
+        def on_start_unit_metrics_received(node_name: str,
+                                           job_id: str,
+                                           unit: str,
+                                           job_time_micros: UInt64,
+                                           start_time: UInt64) -> None:
+            if (node_name == "node-foo" and unit == "simple.service"):
+                self.signal_received = True
+                self.loop.quit()
+        try:
+            # This will fail if metrics are disabled
+            self.metrics.on_start_unit_job_metrics(on_start_unit_metrics_received)
+        except DBusError as ex:
+            raise Exception(f"Error subscribing to metrics: {ex}")
+
+        n = Node("node-foo")
+        assert n.start_unit('simple.service', 'replace') != ""
+
+        self.loop.run()
+        assert n.stop_unit('simple.service', 'replace') != ""
+
+        assert self.signal_received
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/metrics-enable-and-disable/systemd/simple.service
+++ b/tests/tests/tier0/metrics-enable-and-disable/systemd/simple.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Just sleeping
+
+[Service]
+Type=simple
+ExecStart=/bin/true
+RemainAfterExit=yes

--- a/tests/tests/tier0/metrics-enable-and-disable/test_metrics_enable_and_disable.py
+++ b/tests/tests/tier0/metrics-enable-and-disable/test_metrics_enable_and_disable.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import logging
+from typing import Dict
+
+from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.test import BluechiTest
+
+LOGGER = logging.getLogger(__name__)
+
+node_foo_name = "node-foo"
+simple_service = "simple.service"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    foo = nodes[node_foo_name]
+
+    source_dir = "systemd"
+    target_dir = os.path.join("/", "etc", "systemd", "system")
+    foo.copy_systemd_service(simple_service, source_dir, target_dir)
+    assert foo.wait_for_unit_state_to_be(simple_service, "inactive")
+
+    result, output = ctrl.run_python(os.path.join("python", "metrics_is_enabled.py"))
+    if result == 0:
+        raise Exception(f"Metrics not disabled: {output}")
+    assert foo.wait_for_unit_state_to_be(simple_service, "inactive")
+
+    ctrl.bluechictl.enable_metrics()
+
+    result, output = ctrl.run_python(os.path.join("python", "metrics_is_enabled.py"))
+    if result != 0:
+        raise Exception(f"Metrics not enabled: {output}")
+    assert foo.wait_for_unit_state_to_be(simple_service, "inactive")
+
+    ctrl.bluechictl.disable_metrics()
+
+    result, output = ctrl.run_python(os.path.join("python", "metrics_is_enabled.py"))
+    if result == 0:
+        raise Exception(f"Metrics not disabled: {output}")
+    assert foo.wait_for_unit_state_to_be(simple_service, "inactive")
+
+
+def test_metrics_enable_and_disable(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiAgentConfig):
+
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = node_foo_name
+
+    bluechi_ctrl_default_config.allowed_node_names = [node_foo_name]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Adds an integration test which checks that metrics are enabled and disabled correctly back-and-forth

Relates to #668 