### PR TITLE
Detect systemctl operation result for stop action

### DIFF
--- a/src/controller/node.c
+++ b/src/controller/node.c
@@ -10,6 +10,7 @@
 #include "monitor.h"
 #include "node.h"
 #include "proxy_monitor.h"
+#include <systemd/sd-bus.h>
 
 #define DEBUG_AGENT_MESSAGES 0
 
@@ -1569,6 +1570,7 @@ static int node_method_set_log_level(sd_bus_message *m, UNUSED void *userdata, U
                         level);
         if (r < 0) {
                 bc_log_errorf("Failed to set log level call: %s", error.message);
+                sd_bus_error_free(&error);
                 return sd_bus_reply_method_errorf(
                                 m,
                                 SD_BUS_ERROR_FAILED,

--- a/tests/bluechi_test/test.py
+++ b/tests/bluechi_test/test.py
@@ -209,6 +209,7 @@ class BluechiTest():
         try:
             self.shutdown_bluechi(ctrl_container, node_container)
         except Exception as ex:
+            test_result = ex
             LOGGER.error(f"Failed to shutdown BlueChi components: {ex}")
             traceback.print_exc()
 
@@ -219,6 +220,7 @@ class BluechiTest():
             if self.run_with_coverage:
                 self.gather_coverage(ctrl_container, node_container)
         except Exception as ex:
+            test_result = ex
             LOGGER.error(f"Failed to collect logs: {ex}")
             traceback.print_exc()
 

--- a/tests/bluechi_test/test.py
+++ b/tests/bluechi_test/test.py
@@ -81,7 +81,7 @@ class BluechiTest():
                                                       self.bluechi_controller_config)
             if self.run_with_valgrind:
                 ctrl_container.enable_valgrind()
-            ctrl_container.exec_run('systemctl start bluechi-controller')
+            ctrl_container.systemctl.start_unit("bluechi-controller")
             ctrl_container.wait_for_unit_state_to_be("bluechi-controller.service", "active")
 
             for cfg in self.bluechi_node_configs:
@@ -97,7 +97,7 @@ class BluechiTest():
                 if self.run_with_valgrind:
                     node.enable_valgrind()
 
-                node.exec_run('systemctl start bluechi-agent')
+                node.systemctl.start_unit("bluechi-agent")
                 node.wait_for_unit_state_to_be("bluechi-agent.service", "active")
 
         except Exception as ex:
@@ -154,11 +154,11 @@ class BluechiTest():
         LOGGER.debug("Stopping all BlueChi components in all container...")
 
         for _, node in nodes.items():
-            node.exec_run("systemctl stop bluechi-agent")
+            node.systemctl.stop_unit("bluechi-agent")
 
         if ctrl is not None:
-            ctrl.exec_run("systemctl stop bluechi-agent")
-            ctrl.exec_run("systemctl stop bluechi-controller")
+            ctrl.systemctl.stop_unit("bluechi-agent")
+            ctrl.systemctl.stop_unit("bluechi-controller")
 
     def teardown(self, ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
         LOGGER.debug("Stopping and removing all container...")


### PR DESCRIPTION
- **Add verification of operation result for systemctl stop**
- **Use SystemCtl class in test.py module**
- **Fail the test if there is an error stopping bluechi services**
- **Fix memory deallocation issue in node_method_set_log_level()**
