### PR TITLE
Remove unused command_ref method

### DIFF
--- a/src/libbluechi/cli/command.c
+++ b/src/libbluechi/cli/command.c
@@ -21,11 +21,6 @@ Command *new_command() {
         return steal_pointer(&command);
 }
 
-Command *command_ref(Command *command) {
-        command->ref_count++;
-        return command;
-}
-
 void command_unref(Command *command) {
         command->ref_count--;
         if (command->ref_count != 0) {

--- a/src/libbluechi/cli/command.h
+++ b/src/libbluechi/cli/command.h
@@ -24,7 +24,6 @@ struct Command {
 };
 
 Command *new_command();
-Command *command_ref(Command *command);
 void command_unref(Command *command);
 DEFINE_CLEANUP_FUNC(Command, command_unref)
 #define _cleanup_command_ _cleanup_(command_unrefp)


### PR DESCRIPTION
Signed-off-by: Martin Perina <mperina@redhat.com>