### PR TITLE
Test if bluechictl version is aligned with RPM version

### DIFF
--- a/tests/bluechi_test/bluechictl.py
+++ b/tests/bluechi_test/bluechictl.py
@@ -147,3 +147,12 @@ class BluechiCtl():
             check_result,
             expected_result
         )
+
+    def version(self, check_result: bool = True, expected_result: int = 0) \
+            -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
+        return self._run(
+            "Getting version",
+            "version",
+            check_result,
+            expected_result
+        )

--- a/tests/tests/tier0/bluechi-version-option-provided/test_version_option_provided.py
+++ b/tests/tests/tier0/bluechi-version-option-provided/test_version_option_provided.py
@@ -27,6 +27,10 @@ def check_help_option(ctrl: BluechiControllerMachine, _: Dict[str, BluechiAgentM
         assert s_out == l_out
         assert bc_ver_rel in s_out
 
+    bctl_re, bctl_out = ctrl.bluechictl.version()
+    assert bctl_re == 0
+    assert bc_ver_rel in bctl_out
+
 
 def test_version_option_provided(bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
     bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)


### PR DESCRIPTION
Tests if bluechictl version aligns with the version provided by RPM
package.

Signed-off-by: Martin Perina <mperina@redhat.com>