### PR TITLE
Test that bluechictl list-units aligns with systemctl output

### DIFF
--- a/tests/bluechi_test/bluechictl.py
+++ b/tests/bluechi_test/bluechictl.py
@@ -33,11 +33,19 @@ class BluechiCtl():
             raise Exception(f"{log_txt} failed with {result} (expected {expected_result}): {output}")
         return result, output
 
-    def list_units(self, node_name: str, check_result: bool = True, expected_result: int = 0) \
+    def list_units(self, node_name: str = None, check_result: bool = True, expected_result: int = 0) \
             -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
+        if node_name:
+            return self._run(
+                f"Listing units on node {node_name}",
+                f"list-units {node_name}",
+                check_result,
+                expected_result
+            )
+
         return self._run(
-            f"Listing units on node {node_name}",
-            f"list-units {node_name}",
+            "Listing units on all nodes",
+            "list-units",
             check_result,
             expected_result
         )

--- a/tests/bluechi_test/systemctl.py
+++ b/tests/bluechi_test/systemctl.py
@@ -19,9 +19,7 @@ class SystemCtl():
     def _do_operation_on_unit(self, unit_name: str, operation: str, check_result: bool, expected_result: int) \
             -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
 
-        LOGGER.debug(f"{operation} unit '{unit_name}'")
         result, output = self.client.exec_run(f"{SystemCtl.binary_name} {operation} {unit_name}")
-        LOGGER.debug(f"{operation} unit '{unit_name}' finished with result '{result}' and output '{output}'")
         if check_result and result != expected_result:
             raise Exception(
                 f"Failed to {operation} service {unit_name} with {result} (expected {expected_result}): {output}")

--- a/tests/bluechi_test/systemctl.py
+++ b/tests/bluechi_test/systemctl.py
@@ -27,6 +27,15 @@ class SystemCtl():
                 f"Failed to {operation} service {unit_name} with {result} (expected {expected_result}): {output}")
         return result, output
 
+    def _do_operation(self, operation: str, check_result: bool, expected_result: int) \
+            -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
+
+        result, output = self.client.exec_run(f"{SystemCtl.binary_name} {operation}")
+        if check_result and result != expected_result:
+            raise Exception(
+                f"Failed to execute {operation} with {result} (expected {expected_result}): {output}")
+        return result, output
+
     def start_unit(self, unit_name: str, check_result: bool = True, expected_result: int = 0)  \
             -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
         return self._do_operation_on_unit(unit_name, "start", check_result, expected_result)
@@ -94,3 +103,8 @@ class SystemCtl():
         if len(state) > 1:
             result = state[1]
         return result
+
+    def list_units(self, all_units: bool = False, check_result: bool = True, expected_result: int = 0)  \
+            -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
+        command = "list-units --legend=false{}".format(" --all" if all_units else "")
+        return self._do_operation(command, check_result, expected_result)

--- a/tests/tests/tier0/bluechi-list-units-on-all-nodes/main.fmf
+++ b/tests/tests/tier0/bluechi-list-units-on-all-nodes/main.fmf
@@ -1,0 +1,3 @@
+summary: Test if bluechi list-nodes returns the same list of units from all
+    nodes which can be gathered by running systemctl on each node
+id: efbf2397-de69-4f67-a8a8-b2c10bc68c13

--- a/tests/tests/tier0/bluechi-list-units-on-all-nodes/test_bluechi_list_units_on_all_nodes.py
+++ b/tests/tests/tier0/bluechi-list-units-on-all-nodes/test_bluechi_list_units_on_all_nodes.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import re
+
+from typing import Dict, Tuple
+
+from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.test import BluechiTest
+
+
+node_foo_name = "node-foo"
+node_bar_name = "node-bar"
+
+
+def parse_bluechictl_output(output: str) -> Dict[str, Dict[str, Tuple[str, str]]]:
+    line_pat = re.compile(r"""\s*(?P<node_name>[\S]+)\s*\|
+                              \s*(?P<unit_name>[\S]+)\s*\|
+                              \s*(?P<state>[\S]+)\s*\|
+                              \s*(?P<sub_state>[\S]+)\s*""",
+                          re.VERBOSE)
+    result = {}
+    for line in output.splitlines():
+        if line.startswith("NODE ") or line.startswith("===="):
+            # Ignore header lines
+            continue
+
+        match = line_pat.match(line)
+        if not match:
+            raise Exception(f"Error parsing bluechictl list-units output, invalid line: '{line}'")
+
+        node_units = result.get(match.group("node_name"))
+        if not node_units:
+            node_units = {}
+            result[match.group("node_name")] = node_units
+
+        if match.group("unit_name") in node_units:
+            raise Exception(f"Error parsing bluechictl list-units output, unit already reported, line: '{line}'")
+
+        node_units[match.group("unit_name")] = (match.group("state"), match.group("sub_state"))
+
+    return result
+
+
+def verify_units(all_units: Dict[str, Tuple[str, str]], output: str, node_name: str):
+    esc_seq = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+    line_pat = re.compile(r"""\s*(?P<unit_name>\S+)
+                              .*loaded
+                              \s+(?P<state>\S+)
+                              \s+(?P<sub_state>\S+)
+                              \s+.*$
+                          """,
+                          re.VERBOSE)
+    for line in output.splitlines():
+        # Some systemctl output contains ANSI sequences, which we need to remove before matching
+        line = esc_seq.sub('', line)
+
+        match = line_pat.match(line)
+        if not match:
+            raise Exception(f"Error parsing systemctl list-units output, invalid line: '{line}'")
+
+        found = all_units.get(match.group("unit_name"))
+        if not found or match.group("state") != found[0] or match.group("sub_state") != found[1]:
+            raise Exception("Unit '{}' with state '{}' and substate '{}' reported by systemctl"
+                            " on node '{}', but not reported by bluechictl".format(
+                                match.group("unit_name"),
+                                match.group("state"),
+                                match.group("sub_state"),
+                                node_name))
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    node_foo = nodes[node_foo_name]
+    node_bar = nodes[node_bar_name]
+
+    all_res, all_out = ctrl.bluechictl.list_units()
+    assert all_res == 0
+    all_units = parse_bluechictl_output(all_out)
+
+    foo_res, foo_out = node_foo.systemctl.list_units()
+    assert foo_res == 0
+    verify_units(all_units[node_foo_name], foo_out, node_foo_name)
+
+    bar_res, bar_out = node_bar.systemctl.list_units()
+    assert bar_res == 0
+    verify_units(all_units[node_bar_name], bar_out, node_bar_name)
+
+
+def test_bluechi_nodes_statuses(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiAgentConfig):
+
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = node_foo_name
+
+    node_bar_cfg = bluechi_node_default_config.deep_copy()
+    node_bar_cfg.node_name = node_bar_name
+
+    bluechi_ctrl_default_config.allowed_node_names = [node_foo_name, node_bar_name]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+    bluechi_test.add_bluechi_agent_config(node_bar_cfg)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Tests that bluechictl list-units return all units for all nodes and this
list matches list of units gathered from each node using systemctl.

Fixes: https://github.com/eclipse-bluechi/bluechi/issues/780
Signed-off-by: Martin Perina <mperina@redhat.com>