### PR TITLE
Add test for bluechictl execution without parameters

### DIFF
--- a/tests/tests/tier0/bluechi-no-param-provided/main.fmf
+++ b/tests/tests/tier0/bluechi-no-param-provided/main.fmf
@@ -1,0 +1,3 @@
+summary: Test if bluechictl without any parameters shows help message and then exits
+    with error
+id: 1c40b19a-0e1c-47b0-97af-dfb74f26fde8

--- a/tests/tests/tier0/bluechi-no-param-provided/test_no_param_provided.py
+++ b/tests/tests/tier0/bluechi-no-param-provided/test_no_param_provided.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.config import BluechiControllerConfig
+
+
+def check_help_option(ctrl: BluechiControllerMachine, _: Dict[str, BluechiAgentMachine]):
+    result, out = ctrl.exec_run("/usr/bin/bluechictl")
+    assert result != 0
+    assert 'Usage' in out
+
+
+def test_help_option_provided(bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(check_help_option)


### PR DESCRIPTION
Adds a test, that bluechictl executed without parameters shows help and
then exits with error result code.

Fixes: https://github.com/eclipse-bluechi/bluechi/issues/781
Signed-off-by: Martin Perina <mperina@redhat.com>