### PR TITLE
added file cleanup for multihost tests

### DIFF
--- a/tests/bluechi_test/bluechictl.py
+++ b/tests/bluechi_test/bluechictl.py
@@ -3,7 +3,7 @@
 import logging
 
 from enum import Enum
-from typing import Tuple, Iterator, Any, Optional, Union
+from typing import Tuple, Iterator, Any, Optional, Union, Dict, List
 
 from bluechi_test.client import Client
 
@@ -23,6 +23,8 @@ class BluechiCtl():
 
     def __init__(self, client: Client) -> None:
         self.client = client
+
+        self.tracked_services: Dict[str, List[str]] = dict()
 
     def _run(self, log_txt: str, cmd: str, check_result: bool, expected_result: int) \
             -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
@@ -78,6 +80,11 @@ class BluechiCtl():
 
     def start_unit(self, node_name: str, unit_name: str, check_result: bool = True, expected_result: int = 0) \
             -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
+        # track started units to stop and reset failures on cleanup
+        if node_name not in self.tracked_services:
+            self.tracked_services[node_name] = []
+        self.tracked_services[node_name].append(unit_name)
+
         return self._run(
             f"Starting unit '{unit_name}' on node '{node_name}'",
             f"start {node_name} {unit_name}",

--- a/tests/bluechi_test/fixtures.py
+++ b/tests/bluechi_test/fixtures.py
@@ -76,7 +76,7 @@ def _read_topology() -> Dict[str, Any]:
     if tmt_yaml_file is None or tmt_yaml_file == "":
         return get_primary_ip()
 
-    topology = ""
+    topology = dict()
     with open(tmt_yaml_file, "r") as f:
         topology = yaml.safe_load(f.read())
     return topology
@@ -94,9 +94,9 @@ def bluechi_ctrl_host_ip() -> str:
     if "guests" not in topology:
         return get_primary_ip()
 
-    for guest in topology["guests"]:
-        if "name" in guest and "controller" in guest["role"]:
-            return guest["hostname"]
+    for _, values in topology["guests"].items():
+        if values["role"] == "controller":
+            return values["hostname"]
 
     return get_primary_ip()
 
@@ -215,7 +215,6 @@ def bluechi_test(
         return BluechiSSHTest(available_hosts,
                               machines_ssh_user,
                               machines_ssh_password,
-                              bluechi_ctrl_svc_port,
                               tmt_test_serial_number,
                               tmt_test_data_dir,
                               run_with_valgrind,

--- a/tests/bluechi_test/systemctl.py
+++ b/tests/bluechi_test/systemctl.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from typing import Any, Iterator, Optional, Set, Tuple, Union
+from typing import Any, Iterator, Optional, Set, Tuple, Union, List
 
 from bluechi_test.client import Client
 
@@ -15,6 +15,8 @@ class SystemCtl():
 
     def __init__(self, client: Client) -> None:
         self.client = client
+
+        self.tracked_services: List[str] = []
 
     def _do_operation_on_unit(self, unit_name: str, operation: str, check_result: bool, expected_result: int) \
             -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
@@ -36,6 +38,9 @@ class SystemCtl():
 
     def start_unit(self, unit_name: str, check_result: bool = True, expected_result: int = 0)  \
             -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
+        # track started units to stop and reset failures on cleanup
+        self.tracked_services.append(unit_name)
+
         return self._do_operation_on_unit(unit_name, "start", check_result, expected_result)
 
     def stop_unit(self,
@@ -63,6 +68,9 @@ class SystemCtl():
 
     def restart_unit(self, unit_name: str, check_result: bool = True, expected_result: int = 0)  \
             -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
+        # track started units to stop and reset failures on cleanup
+        self.tracked_services.append(unit_name)
+
         return self._do_operation_on_unit(unit_name, "restart", check_result, expected_result)
 
     def reset_failed_for_unit(self, unit_name: str, check_result: bool = True, expected_result: int = 0)  \

--- a/tests/tests/main.fmf
+++ b/tests/tests/main.fmf
@@ -1,4 +1,5 @@
 component: bluechi
+tag: [multihost]
 test: |
     pytest -svv \
     --confcutdir=../../../ \

--- a/tests/tests/tier0/bluechi-agent-cmd-line-c-invalid-config/test_bluechi_agent_cmd_line_c_invalid_config.py
+++ b/tests/tests/tier0/bluechi-agent-cmd-line-c-invalid-config/test_bluechi_agent_cmd_line_c_invalid_config.py
@@ -18,12 +18,12 @@ failed_status = "failed"
 def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
 
     node_foo = nodes[NODE_FOO]
-    config_file_location = "/var/tmp"
+    config_file_location = "/tmp"
     bluechi_agent_str = "bluechi-agent"
-    invalid_conf_str = "config-files/invalid.conf"
+    invalid_conf_str = "invalid.conf"
 
     # Copying relevant config files into node container
-    content = read_file(invalid_conf_str)
+    content = read_file(os.path.join("config-files", invalid_conf_str))
     node_foo.create_file(config_file_location, invalid_conf_str, content)
 
     LOGGER.debug("Setting invalid.conf as conf file for foo and checking if failed")

--- a/tests/tests/tier0/bluechi-agent-connect-via-controller-address/test_bluechi_agent_connect_via_controller_address.py
+++ b/tests/tests/tier0/bluechi-agent-connect-via-controller-address/test_bluechi_agent_connect_via_controller_address.py
@@ -13,9 +13,9 @@ NODE_FOO = "node-FOO"
 
 def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
     node_foo = nodes[NODE_FOO]
-    config_file_location = "/var/tmp"
+    config_file_location = "/tmp"
     bluechi_agent_str = "bluechi-agent"
-    invalid_conf_str = "config/Invalid-ControllerAddress.conf"
+    invalid_conf_str = "Invalid-ControllerAddress.conf"
     invalid_controller_address = "Invalid-ControllerAddress.conf"
     service = "org.eclipse.bluechi"
     object = "/org/eclipse/bluechi"
@@ -25,7 +25,7 @@ def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
     assert node_foo.wait_for_unit_state_to_be(bluechi_agent_str, "active", delay=2)
     assert 's "up"' == ctrl.exec_run(f"busctl get-property {service} {object} {interface} {property}")[1]
 
-    content = read_file(invalid_conf_str)
+    content = read_file(os.path.join("config", invalid_conf_str))
     node_foo.create_file(config_file_location, invalid_conf_str, content)
 
     node_foo.restart_with_config_file(os.path.join(config_file_location, invalid_controller_address), bluechi_agent_str)

--- a/tests/tests/tier0/bluechi-agent-logisquiet/main.fmf
+++ b/tests/tests/tier0/bluechi-agent-logisquiet/main.fmf
@@ -1,2 +1,3 @@
 summary: Test if bluechi agent can handle different types of values for LogIsQuiet in the configuration
 id: 96aa0e17-5e23-4cc3-bc34-88368b8cc07b
+tag: []

--- a/tests/tests/tier0/bluechi-agent-loglevel/main.fmf
+++ b/tests/tests/tier0/bluechi-agent-loglevel/main.fmf
@@ -1,2 +1,3 @@
 summary: Test if bluechi agent can handle different types of values for LogLevel in the configuration
 id: f3dda8c1-ceb7-446c-9d65-2aa8ca798099
+tag: []

--- a/tests/tests/tier0/bluechi-agent-logtarget/main.fmf
+++ b/tests/tests/tier0/bluechi-agent-logtarget/main.fmf
@@ -1,2 +1,3 @@
 summary: Test if bluechi agent can handle different types of values for LogTarget in the configuration
 id: 5cf92c54-e073-475c-970f-b8e090ec4da2
+tag: []

--- a/tests/tests/tier0/bluechi-agent-started-and-connected/test_agent_started_and_connected.py
+++ b/tests/tests/tier0/bluechi-agent-started-and-connected/test_agent_started_and_connected.py
@@ -9,9 +9,7 @@ from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
 
 def foo_startup_verify(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
 
-    result, output = ctrl.bluechictl.get_unit_status("node-foo", "bluechi-agent.service")
-    assert result == 0
-    assert str(output).split('\n')[2].split('|')[2].strip() == 'active'
+    nodes["node-foo"].wait_for_bluechi_agent()
 
     # TODO: Add code to test that agent on node foo is successfully connected to bluechi controller
 

--- a/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/test_bluechi_change_port_with_c_cmd_option.py
+++ b/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/test_bluechi_change_port_with_c_cmd_option.py
@@ -16,14 +16,13 @@ def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
     config_file_location = "/var/tmp"
     bluechi_agent_str = "bluechi-agent"
     bluechi_controller_str = "bluechi-controller"
-    file_location_ctrl = os.path.join("config-files", "ctrl_port_8421.conf")
-    file_location_agent = os.path.join("config-files", "agent_port_8421.conf")
 
     # Copying relevant config files into the nodes container
-    content = read_file(file_location_agent)
-    node_foo.create_file(config_file_location, file_location_agent, content)
-    content = read_file(file_location_ctrl)
-    ctrl.create_file(config_file_location, file_location_ctrl, content)
+    content = read_file(os.path.join("config-files", "agent_port_8421.conf"))
+    node_foo.create_file(config_file_location, "agent_port_8421.conf", content)
+
+    content = read_file(os.path.join("config-files", "ctrl_port_8421.conf"))
+    ctrl.create_file(config_file_location, "ctrl_port_8421.conf", content)
 
     ctrl.restart_with_config_file(
         os.path.join(config_file_location, "ctrl_port_8421.conf"), bluechi_controller_str)

--- a/tests/tests/tier0/bluechi-controller-set-loglevel-invalid/test_bluechi_controller_set_loglevel_invalid.py
+++ b/tests/tests/tier0/bluechi-controller-set-loglevel-invalid/test_bluechi_controller_set_loglevel_invalid.py
@@ -7,8 +7,9 @@ from bluechi_test.config import BluechiControllerConfig
 
 def exec(ctrl: BluechiControllerMachine, _: Dict[str, BluechiAgentMachine]):
 
-    _, output = ctrl.bluechictl.set_log_level_on_controller("INF", check_result=False)
-    assert "Disconnect" not in output
+    result, _ = ctrl.bluechictl.set_log_level_on_controller("INF", check_result=False)
+    # call to set invalid loglevel should fail
+    assert result != 0
 
 
 def test_bluechi_controller_set_loglevel_invalid(

--- a/tests/tests/tier0/bluechi-list-units-on-all-nodes/main.fmf
+++ b/tests/tests/tier0/bluechi-list-units-on-all-nodes/main.fmf
@@ -1,3 +1,7 @@
 summary: Test if bluechi list-nodes returns the same list of units from all
     nodes which can be gathered by running systemctl on each node
 id: efbf2397-de69-4f67-a8a8-b2c10bc68c13
+
+# disabled for multihost till this is solved: 
+# https://github.com/eclipse-bluechi/bluechi/issues/767
+tag: []

--- a/tests/tests/tier0/bluechi-version-option-provided/test_version_option_provided.py
+++ b/tests/tests/tier0/bluechi-version-option-provided/test_version_option_provided.py
@@ -12,7 +12,7 @@ def check_help_option(ctrl: BluechiControllerMachine, _: Dict[str, BluechiAgentM
     assert rpm_re == 0
 
     # There is no way to strip dist part from the release using rpm query flags, so we need to replace it manually
-    bc_ver_rel = rpm_out.replace(".el9", "")
+    bc_ver_rel = ".".join(rpm_out.split(".")[:-1])
     executables = [
         '/usr/libexec/bluechi-controller',
         '/usr/libexec/bluechi-agent'

--- a/tests/tests/tier0/monitor-system-status/main.fmf
+++ b/tests/tests/tier0/monitor-system-status/main.fmf
@@ -1,3 +1,4 @@
 summary: Test if the system status changed signal is being emitted when nodes disconnect
     and reconnect
 id: 96615a39-229f-4083-8c7d-cb0c540ca598
+tag: []

--- a/tests/tests/tier0/monitor-wildcard-node-reconnect/main.fmf
+++ b/tests/tests/tier0/monitor-wildcard-node-reconnect/main.fmf
@@ -1,2 +1,3 @@
 summary: Test if the proper virtual signals are emitted when a monitor with wildcard subscription is active and a node disconnects and reconnects again
 id: 071d8a13-aee6-4dc0-9a91-0fb9a2e38a93
+tag: []

--- a/tests/tests/tier0/proxy-service-multiple-services-multiple-nodes/main.fmf
+++ b/tests/tests/tier0/proxy-service-multiple-services-multiple-nodes/main.fmf
@@ -1,2 +1,3 @@
 summary: Test proper lifetimes of all services when multiple services on multiple nodes request the same service on the same node
 id: 4b5a0d32-4b85-404d-9a02-f58531bf1957
+tag: []


### PR DESCRIPTION
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/662

In order to run all tests on a set of provisioned hosts, the state of the host needs to be restored after each test run. This includes:
- removing all added files
- restoring all changed files
- stopping all systemd units and reset failed ones (incl. bluechi)

By keeping track of these operations, the test class is able to execute respective cleanup tasks on the hosts. Therefore, the cleanup from machine class has been moved to the ssh test class. The container test class still only removes the created  containers.

Also, added a tag on the root main.fmf to mark all tests by default to be able to run in a multihost setting. Certain tests that exceed the available number of hosts (>3) are disabled for now. And fixed/improved some of the integration tests. 

---

**Testing this change:**

In order to test this on testing farm (GH CI with containers is automatic), a dedicated branch has been created:
https://github.com/engelmi/bluechi/tree/added-cleanup-to-integration-test-experiment
It changes the plan `tier0.fmf` to use a multihost setup and filters only for tests with the `tag: multihost` - which is set for all tests except some few that exceed the maximum number of nodes (>3). 

Request to start on testing farm: (an exported API token is required)
```bash
testing-farm request --path tests --git-ref added-cleanup-to-integration-test-experiment --git-url https://github.com/engelmi/bluechi.git --compose Fedora-Rawhide --pipeline-type tmt-multihost
```

And here are the results:
http://artifacts.osci.redhat.com/testing-farm/57eb8333-a3d6-4239-8df8-fce66840f4ad/
