### PR TITLE
replaced pytest-timeout with custom timeout

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install unpackaged python libraries from PyPi
         run: |
-          pip install "tmt[provision]==1.30" "tmt[report-junit]==1.30" podman pytest pytest-timeout pyyaml paramiko
+          pip install "tmt[provision]==1.30" "tmt[report-junit]==1.30" podman pytest pyyaml paramiko
           # Mitigate https://github.com/containers/podman-py/issues/350
           pip install rich
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,7 +26,6 @@ dnf install \
     python3-paramiko \
     python3-podman \
     python3-pytest \
-    python3-pytest-timeout \
     python3-pyyaml \
     tmt \
     tmt-report-junit \

--- a/tests/bluechi_test/util.py
+++ b/tests/bluechi_test/util.py
@@ -2,6 +2,7 @@
 
 import logging
 import random
+import signal
 import string
 import socket
 
@@ -44,3 +45,27 @@ def get_random_name(name_length: int) -> str:
     # choose from all lowercase letter
     letters = string.ascii_lowercase
     return ''.join(random.choice(letters) for _ in range(name_length))
+
+
+# timeout for setting up tests in s
+TIMEOUT_SETUP = 20
+# timeout for running tests in s
+TIMEOUT_TEST = 45
+# timeout for collecting test results in s
+TIMEOUT_GATHER = 20
+
+
+class Timeout:
+    def __init__(self, seconds=1, error_message='Timeout'):
+        self.seconds = seconds
+        self.error_message = error_message
+
+    def handle_timeout(self, signum, frame):
+        raise TimeoutError(self.error_message)
+
+    def __enter__(self):
+        signal.signal(signal.SIGALRM, self.handle_timeout)
+        signal.alarm(self.seconds)
+
+    def __exit__(self, type, value, traceback):
+        signal.alarm(0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import pytest
-
-
 pytest_plugins = [
     "bluechi_test.fixtures"
 ]
-
-
-# Set minimum timeout for all tests to 45 seconds.
-# If some test needs bigger timeout, please override it for the specific test
-# using @pytest.mark.timeout annotation
-def pytest_collection_modifyitems(items):
-    for item in items:
-        if item.get_closest_marker('timeout') is None:
-            item.add_marker(pytest.mark.timeout(45))

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,6 @@
 tmt >= 1.22
 junit-xml >= 1.9
 pytest >= 7.3.1
-pytest-timeout >= 2.1.0
 podman >= 4.5.0
 flake8 >= 6.0.0
 strato-skipper >= 2.0.2

--- a/tests/scripts/tests-setup.sh
+++ b/tests/scripts/tests-setup.sh
@@ -12,7 +12,6 @@ function install_worker_deps(){
         python3-paramiko \
         python3-podman \
         python3-pytest \
-        python3-pytest-timeout \
         python3-pyyaml \
         -y
     # Mitigate https://github.com/containers/podman-py/issues/350


### PR DESCRIPTION
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/772

When pytest-timeout triggers a timeout is triggered, the test will be exited with pytest.fail and test artifacts might not be collected - so debugging issues with timeouts become hard to debug.
Therefore, replace pytest-timeout with a slim, custom implementation that throws an error when timeout is reached. In addition, lets distinguish between timeouts for setup, test execution and artifact collection.