### PR TITLE
ReloadUnit test

### DIFF
--- a/tests/bluechi_test/bluechictl.py
+++ b/tests/bluechi_test/bluechictl.py
@@ -92,6 +92,15 @@ class BluechiCtl():
             expected_result
         )
 
+    def reload_unit(self, node_name: str, unit_name: str, check_result: bool = True, expected_result: int = 0) \
+            -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
+        return self._run(
+            f"Reloading unit {unit_name} on node {node_name}",
+            f"reload {node_name} {unit_name}",
+            check_result,
+            expected_result
+        )
+
     def stop_unit(self, node_name: str, unit_name: str, check_result: bool = True, expected_result: int = 0) \
             -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
         return self._run(

--- a/tests/tests/tier0/bluechi-reload-unit/main.fmf
+++ b/tests/tests/tier0/bluechi-reload-unit/main.fmf
@@ -1,0 +1,2 @@
+summary: Test reload service
+id: 44b0d11e-fcad-4523-acf7-ff0c0421501e

--- a/tests/tests/tier0/bluechi-reload-unit/systemd/service-for-reload.service
+++ b/tests/tests/tier0/bluechi-reload-unit/systemd/service-for-reload.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=A very simple service
+[Service]
+Type=simple
+ExecStart=/bin/true
+RemainAfterExit=yes
+ExecReload=systemctl start simple.service

--- a/tests/tests/tier0/bluechi-reload-unit/systemd/simple.service
+++ b/tests/tests/tier0/bluechi-reload-unit/systemd/simple.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Service For Integration Test
+
+[Service]
+Type=simple
+ExecStart=/bin/true
+RemainAfterExit=yes

--- a/tests/tests/tier0/bluechi-reload-unit/test_bluechi_reload_unit_service.py
+++ b/tests/tests/tier0/bluechi-reload-unit/test_bluechi_reload_unit_service.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+import logging
+import os
+
+from typing import Dict
+from bluechi_test.test import BluechiTest
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
+
+LOGGER = logging.getLogger(__name__)
+
+NODE_FOO = "node-foo"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+
+    foo = nodes[NODE_FOO]
+    target_dir = os.path.join("/", "etc", "systemd", "system")
+    foo.copy_systemd_service("service-for-reload.service", "systemd", target_dir)
+    foo.copy_systemd_service("simple.service", "systemd", target_dir)
+    assert foo.wait_for_unit_state_to_be("simple.service", "inactive")
+    assert foo.wait_for_unit_state_to_be("service-for-reload.service", "inactive")
+
+    ctrl.bluechictl.start_unit(NODE_FOO, "service-for-reload.service")
+    assert foo.wait_for_unit_state_to_be("simple.service", "inactive")
+    assert foo.wait_for_unit_state_to_be("service-for-reload.service", "active")
+
+    ctrl.bluechictl.reload_unit(NODE_FOO, "service-for-reload.service")
+    assert foo.wait_for_unit_state_to_be("simple.service", "active")
+    assert foo.wait_for_unit_state_to_be("service-for-reload.service", "active")
+
+
+def test_bluechi_reload_unit_service(
+        bluechi_test: BluechiTest,
+        bluechi_node_default_config: BluechiAgentConfig, bluechi_ctrl_default_config: BluechiControllerConfig):
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = NODE_FOO
+
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO]
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Reload Integration Test

This test will test the functionality of ReloadUnit.
Two services will be added to the node container.
One of them will be activated by systemctl and then
reloaded with bluechi reload' and that suppose to make
the other service active.
