### PR TITLE
Remove controller_ref function from controller/controller.c

### DIFF
--- a/src/controller/controller.c
+++ b/src/controller/controller.c
@@ -59,11 +59,6 @@ Controller *controller_new(void) {
         return controller;
 }
 
-Controller *controller_ref(Controller *controller) {
-        controller->ref_count++;
-        return controller;
-}
-
 void controller_unref(Controller *controller) {
         assert(controller->ref_count > 0);
 

--- a/src/controller/controller.h
+++ b/src/controller/controller.h
@@ -42,7 +42,6 @@ struct Controller {
 };
 
 Controller *controller_new(void);
-Controller *controller_ref(Controller *controller);
 void controller_unref(Controller *controller);
 
 bool controller_set_port(Controller *controller, const char *port);


### PR DESCRIPTION
Remove controller_ref function from controller/controller.c, which was
not used anywhere.

Signed-off-by: Martin Perina <mperina@redhat.com>