### PR TITLE
added bluechi-proxy to help option test

### DIFF
--- a/tests/tests/tier0/bluechi-help-option-provided/test_help_option_provided.py
+++ b/tests/tests/tier0/bluechi-help-option-provided/test_help_option_provided.py
@@ -11,6 +11,7 @@ def check_help_option(ctrl: BluechiControllerMachine, _: Dict[str, BluechiAgentM
     executables = [
         '/usr/libexec/bluechi-controller',
         '/usr/libexec/bluechi-agent',
+        '/usr/libexec/bluechi-proxy',
         '/usr/bin/bluechictl'
     ]
 


### PR DESCRIPTION
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/808

Adds the bluechi-proxy binary to the list of executables in the integration test for validating the help option