### PR TITLE
added unit test for log_target_to_str

### DIFF
--- a/src/libbluechi/log/log.c
+++ b/src/libbluechi/log/log.c
@@ -19,10 +19,10 @@ const char *log_target_to_str(LogFn logfn) {
                 log_target = BC_LOG_TARGET_JOURNALD;
         }
         if (bc_log_to_stderr_full_with_location == logfn) {
-                log_target = BC_LOG_TARGET_STDERR;
+                log_target = BC_LOG_TARGET_STDERR_FULL;
         }
         if (bc_log_to_stderr_with_location == logfn) {
-                log_target = BC_LOG_TARGET_STDERR_FULL;
+                log_target = BC_LOG_TARGET_STDERR;
         }
 
         return log_target;

--- a/src/libbluechi/test/log/log_target_to_str_test.c
+++ b/src/libbluechi/test/log/log_target_to_str_test.c
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libbluechi/common/string-util.h"
+#include "libbluechi/log/log.h"
+
+bool test_log_target_to_str(LogFn fn, const char *expected_log_target) {
+        const char *result = log_target_to_str(fn);
+        if (result != NULL && expected_log_target != NULL && streq(result, expected_log_target)) {
+                return true;
+        }
+        if (result == NULL && expected_log_target == NULL) {
+                return true;
+        }
+        fprintf(stdout,
+                "FAILED: string_to_log_level - Expected '%s', but got '%s'\n",
+                expected_log_target,
+                result);
+        return false;
+}
+
+int main() {
+        bool result = true;
+
+        result = result && test_log_target_to_str(bc_log_to_journald_with_location, BC_LOG_TARGET_JOURNALD);
+        result = result &&
+                        test_log_target_to_str(bc_log_to_stderr_full_with_location, BC_LOG_TARGET_STDERR_FULL);
+        result = result && test_log_target_to_str(bc_log_to_stderr_with_location, BC_LOG_TARGET_STDERR);
+        result = result && test_log_target_to_str(NULL, NULL);
+
+        if (result) {
+                return EXIT_SUCCESS;
+        }
+        return EXIT_FAILURE;
+}

--- a/src/libbluechi/test/log/meson.build
+++ b/src/libbluechi/test/log/meson.build
@@ -2,6 +2,7 @@
 
 common_src = [
   'string_to_log_level_test',
+  'log_target_to_str_test',
   'bc_log_init_test',
 ]
 


### PR DESCRIPTION
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/805

It adds an unit test for log_target_to_str. Also, it fixes mixed up stderr and stderr-full in the function under test.