### PR TITLE
Remove workaround for podman-py #350

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,8 +73,6 @@ jobs:
       - name: Install unpackaged python libraries from PyPi
         run: |
           pip install "tmt[provision]==1.30" "tmt[report-junit]==1.30" podman pytest pyyaml paramiko
-          # Mitigate https://github.com/containers/podman-py/issues/350
-          pip install rich
 
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/tests/scripts/tests-setup.sh
+++ b/tests/scripts/tests-setup.sh
@@ -14,13 +14,11 @@ function install_worker_deps(){
         python3-pytest \
         python3-pyyaml \
         -y
-    # Mitigate https://github.com/containers/podman-py/issues/350
-    dnf install python3-rich -y
 }
 
 function setup_worker_ssh(){
     dnf install openssh-server passwd -y
-    
+
     # root access is needed in order to access BlueChi's API
     echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
     echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
@@ -91,8 +89,6 @@ function setup_container_test(){
     # Install required dependencies only when asked
     if [ "$INSTALL_DEPS" == "yes" ]; then
         install_worker_deps
-        # Mitigate https://github.com/containers/podman-py/issues/350
-        dnf install python3-rich -y
     fi
 
     BUILD_ARG=""


### PR DESCRIPTION
Remove manual installation of python-rich dependency, which was required
due to issue https://github.com/containers/podman-py/issues/350 in
podman-py 4.8 and which should be fixed in podman-py 4.9

Signed-off-by: Martin Perina <mperina@redhat.com>