### PR TITLE
Test DaemonReload

### DIFF
--- a/tests/bluechi_test/bluechictl.py
+++ b/tests/bluechi_test/bluechictl.py
@@ -110,6 +110,15 @@ class BluechiCtl():
             expected_result
         )
 
+    def daemon_reload_node(self, node_name: str, check_result: bool = True, expected_result: int = 0) \
+            -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
+        return self._run(
+            f"Daemon Reload on node '{node_name}'",
+            f"daemon-reload {node_name}",
+            check_result,
+            expected_result
+        )
+
     def enable_unit(self, node_name: str, unit_name: str, check_result: bool = True, expected_result: int = 0) \
             -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
         return self._run(

--- a/tests/tests/tier0/bluechi-daemon-reload/main.fmf
+++ b/tests/tests/tier0/bluechi-daemon-reload/main.fmf
@@ -1,0 +1,2 @@
+summary: Test bluechictl daemon-reload. This test will send an unrunble test will fail at start but then will be change and update with daemon-reload
+id: bb9d4394-bd53-4d36-b8ba-ee91697c4850

--- a/tests/tests/tier0/bluechi-daemon-reload/systemd/simple.service
+++ b/tests/tests/tier0/bluechi-daemon-reload/systemd/simple.service
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=/s
+RemainAfterExit=yes

--- a/tests/tests/tier0/bluechi-daemon-reload/test_bluechi_deamon_reload.py
+++ b/tests/tests/tier0/bluechi-daemon-reload/test_bluechi_deamon_reload.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import logging
+
+from typing import Dict
+from bluechi_test.test import BluechiTest
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
+
+LOGGER = logging.getLogger(__name__)
+NODE_FOO = "node-foo"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+
+    node_foo = nodes[NODE_FOO]
+    service_file = "simple.service"
+    service_path = os.path.join("/", "etc", "systemd", "system", service_file)
+
+    node_foo.copy_systemd_service(service_file, "systemd",
+                                  os.path.join("/", "etc", "systemd", "system"))
+    ctrl.bluechictl.start_unit(NODE_FOO, service_file)
+    assert node_foo.wait_for_unit_state_to_be(service_file, "failed")
+
+    node_foo.exec_run(f"sed -i '/ExecStart=/c\\ExecStart=/bin/true' {service_path}")
+    ctrl.bluechictl.daemon_reload_node(NODE_FOO)
+    ctrl.bluechictl.start_unit(NODE_FOO, service_file)
+    assert node_foo.wait_for_unit_state_to_be(service_file, "active")
+
+
+def test_bluechi_deamon_reload(
+        bluechi_test: BluechiTest,
+        bluechi_node_default_config: BluechiAgentConfig, bluechi_ctrl_default_config: BluechiControllerConfig):
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = NODE_FOO
+
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO]
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
This integration test tests the Daemond Reload by adding new service that won't start first. After changing the file and by using daemon reload the service will start and will be 'active'