### PR TITLE
Implement job cancel

### DIFF
--- a/src/libbluechi/common/protocol.h
+++ b/src/libbluechi/common/protocol.h
@@ -70,6 +70,7 @@
 #define SYSTEMD_OBJECT_PATH "/org/freedesktop/systemd1"
 #define SYSTEMD_MANAGER_IFACE "org.freedesktop.systemd1.Manager"
 #define SYSTEMD_UNIT_IFACE "org.freedesktop.systemd1.Unit"
+#define SYSTEMD_JOB_IFACE "org.freedesktop.systemd1.Job"
 
 /* Signal names */
 #define AGENT_HEARTBEAT_SIGNAL_NAME "Heartbeat"

--- a/tests/tests/tier0/bluechi-job-cancel/main.fmf
+++ b/tests/tests/tier0/bluechi-job-cancel/main.fmf
@@ -1,2 +1,2 @@
-summary: Test if a job can be cancelled
-id: 6ebd2116-eb64-43b8-b346-8eb632122549
+summary: Test if a job can be canceled
+id: 46f90231-3b9f-4a00-b58d-44092495d600

--- a/tests/tests/tier0/bluechi-job-cancel/main.fmf
+++ b/tests/tests/tier0/bluechi-job-cancel/main.fmf
@@ -1,0 +1,2 @@
+summary: Test if a job can be cancelled
+id: 6ebd2116-eb64-43b8-b346-8eb632122549

--- a/tests/tests/tier0/bluechi-job-cancel/python/start_and_cancel.py
+++ b/tests/tests/tier0/bluechi-job-cancel/python/start_and_cancel.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import time
+import unittest
+
+from dasbus.error import DBusError
+
+from bluechi.api import Node, Job
+
+node_name_foo = "node-foo"
+service_simple = "simple.service"
+
+
+class TestStartAndCancel(unittest.TestCase):
+
+    def _get_unit_state(self, node: Node, service: str) -> str:
+        prop = node.get_unit_property(service, "org.freedesktop.systemd1.Unit", "ActiveState")
+        return prop.get_string()
+
+    def test_start_and_cancel(self):
+        node_foo = Node(node_name_foo)
+        job_path = node_foo.start_unit(service_simple, "replace")
+        assert job_path != ""
+
+        # delay job assertions a bit
+        time.sleep(0.5)
+
+        job = Job(job_path)
+        assert job.node == node_foo.name
+        assert job.state in ["waiting", "running"]
+        assert self._get_unit_state(node_foo, service_simple) == "activating"
+
+        job.cancel()
+
+        # after cancelling:
+        # - the job should be removed - so we expect another call to fail
+        # - the started unit should still be activating (canceling job won't stop it)
+        time.sleep(0.5)
+        with self.assertRaises(DBusError):
+            job.state
+        assert self._get_unit_state(node_foo, service_simple) == "activating"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechi-job-cancel/systemd/requesting.service
+++ b/tests/tests/tier0/bluechi-job-cancel/systemd/requesting.service
@@ -1,7 +1,0 @@
-[Unit]
-Wants=bluechi-proxy@node-bar_simple.service
-After=bluechi-proxy@node-bar_simple.service
-
-[Service]
-ExecStart=/bin/true
-RemainAfterExit=yes

--- a/tests/tests/tier0/bluechi-job-cancel/systemd/requesting.service
+++ b/tests/tests/tier0/bluechi-job-cancel/systemd/requesting.service
@@ -1,0 +1,7 @@
+[Unit]
+Wants=bluechi-proxy@node-bar_simple.service
+After=bluechi-proxy@node-bar_simple.service
+
+[Service]
+ExecStart=/bin/true
+RemainAfterExit=yes

--- a/tests/tests/tier0/bluechi-job-cancel/systemd/simple.service
+++ b/tests/tests/tier0/bluechi-job-cancel/systemd/simple.service
@@ -3,5 +3,6 @@ Description=Just sleeping
 
 [Service]
 Type=simple
+ExecStartPre=/bin/sleep 20
 ExecStart=/bin/true
 RemainAfterExit=yes

--- a/tests/tests/tier0/bluechi-job-cancel/systemd/simple.service
+++ b/tests/tests/tier0/bluechi-job-cancel/systemd/simple.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Just sleeping
+
+[Service]
+Type=simple
+ExecStart=/bin/true
+RemainAfterExit=yes

--- a/tests/tests/tier0/bluechi-job-cancel/test_bluechi_job_cancel.py
+++ b/tests/tests/tier0/bluechi-job-cancel/test_bluechi_job_cancel.py
@@ -6,56 +6,27 @@ from typing import Dict
 from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
 from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
 from bluechi_test.test import BluechiTest
-from bluechi_test.util import assemble_bluechi_dep_service_name, assemble_bluechi_proxy_service_name
 
 
 node_foo_name = "node-foo"
-node_bar_name = "node-bar"
-
-requesting_service = "requesting.service"
 simple_service = "simple.service"
-
-
-def verify_proxy_start(foo: BluechiAgentMachine, bar: BluechiAgentMachine):
-    assert foo.wait_for_unit_state_to_be(requesting_service, "active")
-    bluechi_proxy_service = assemble_bluechi_proxy_service_name(node_bar_name, simple_service)
-    assert foo.wait_for_unit_state_to_be(bluechi_proxy_service, "active")
-
-    assert bar.wait_for_unit_state_to_be(simple_service, "active")
-    bluechi_dep_service = assemble_bluechi_dep_service_name(simple_service)
-    assert bar.wait_for_unit_state_to_be(bluechi_dep_service, "active")
-
-
-def verify_proxy_stop(foo: BluechiAgentMachine, bar: BluechiAgentMachine):
-    assert foo.wait_for_unit_state_to_be(requesting_service, "inactive")
-    bluechi_proxy_service = assemble_bluechi_proxy_service_name(node_bar_name, simple_service)
-    assert foo.wait_for_unit_state_to_be(bluechi_proxy_service, "inactive")
-
-    assert bar.wait_for_unit_state_to_be(simple_service, "active")
-    bluechi_dep_service = assemble_bluechi_dep_service_name(simple_service)
-    assert bar.wait_for_unit_state_to_be(bluechi_dep_service, "inactive")
 
 
 def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
     foo = nodes[node_foo_name]
-    bar = nodes[node_bar_name]
 
     source_dir = os.path.join(".", "systemd")
     target_dir = os.path.join("/", "etc", "systemd", "system")
 
-    foo.copy_systemd_service(requesting_service, source_dir, target_dir)
-    bar.copy_systemd_service(simple_service, source_dir, target_dir)
+    foo.copy_systemd_service(simple_service, source_dir, target_dir)
+    assert foo.wait_for_unit_state_to_be(simple_service, "inactive")
 
-    assert foo.wait_for_unit_state_to_be(requesting_service, "inactive")
-    assert bar.wait_for_unit_state_to_be(simple_service, "inactive")
-
-    ctrl.bluechictl.start_unit(node_foo_name, requesting_service)
-    verify_proxy_start(foo, bar)
-    ctrl.bluechictl.stop_unit(node_foo_name, requesting_service)
-    verify_proxy_stop(foo, bar)
+    result, output = ctrl.run_python(os.path.join("python", "start_and_cancel.py"))
+    if result != 0:
+        raise Exception(output)
 
 
-def test_proxy_service_stop_requesting(
+def test_bluechi_job_cancel(
         bluechi_test: BluechiTest,
         bluechi_ctrl_default_config: BluechiControllerConfig,
         bluechi_node_default_config: BluechiAgentConfig):
@@ -63,13 +34,9 @@ def test_proxy_service_stop_requesting(
     node_foo_cfg = bluechi_node_default_config.deep_copy()
     node_foo_cfg.node_name = node_foo_name
 
-    node_bar_cfg = bluechi_node_default_config.deep_copy()
-    node_bar_cfg.node_name = node_bar_name
-
-    bluechi_ctrl_default_config.allowed_node_names = [node_foo_name, node_bar_name]
+    bluechi_ctrl_default_config.allowed_node_names = [node_foo_name]
 
     bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
     bluechi_test.add_bluechi_agent_config(node_foo_cfg)
-    bluechi_test.add_bluechi_agent_config(node_bar_cfg)
 
     bluechi_test.run(exec)

--- a/tests/tests/tier0/bluechi-job-cancel/test_bluechi_job_cancel.py
+++ b/tests/tests/tier0/bluechi-job-cancel/test_bluechi_job_cancel.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+from typing import Dict
+
+from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.test import BluechiTest
+from bluechi_test.util import assemble_bluechi_dep_service_name, assemble_bluechi_proxy_service_name
+
+
+node_foo_name = "node-foo"
+node_bar_name = "node-bar"
+
+requesting_service = "requesting.service"
+simple_service = "simple.service"
+
+
+def verify_proxy_start(foo: BluechiAgentMachine, bar: BluechiAgentMachine):
+    assert foo.wait_for_unit_state_to_be(requesting_service, "active")
+    bluechi_proxy_service = assemble_bluechi_proxy_service_name(node_bar_name, simple_service)
+    assert foo.wait_for_unit_state_to_be(bluechi_proxy_service, "active")
+
+    assert bar.wait_for_unit_state_to_be(simple_service, "active")
+    bluechi_dep_service = assemble_bluechi_dep_service_name(simple_service)
+    assert bar.wait_for_unit_state_to_be(bluechi_dep_service, "active")
+
+
+def verify_proxy_stop(foo: BluechiAgentMachine, bar: BluechiAgentMachine):
+    assert foo.wait_for_unit_state_to_be(requesting_service, "inactive")
+    bluechi_proxy_service = assemble_bluechi_proxy_service_name(node_bar_name, simple_service)
+    assert foo.wait_for_unit_state_to_be(bluechi_proxy_service, "inactive")
+
+    assert bar.wait_for_unit_state_to_be(simple_service, "active")
+    bluechi_dep_service = assemble_bluechi_dep_service_name(simple_service)
+    assert bar.wait_for_unit_state_to_be(bluechi_dep_service, "inactive")
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    foo = nodes[node_foo_name]
+    bar = nodes[node_bar_name]
+
+    source_dir = os.path.join(".", "systemd")
+    target_dir = os.path.join("/", "etc", "systemd", "system")
+
+    foo.copy_systemd_service(requesting_service, source_dir, target_dir)
+    bar.copy_systemd_service(simple_service, source_dir, target_dir)
+
+    assert foo.wait_for_unit_state_to_be(requesting_service, "inactive")
+    assert bar.wait_for_unit_state_to_be(simple_service, "inactive")
+
+    ctrl.bluechictl.start_unit(node_foo_name, requesting_service)
+    verify_proxy_start(foo, bar)
+    ctrl.bluechictl.stop_unit(node_foo_name, requesting_service)
+    verify_proxy_stop(foo, bar)
+
+
+def test_proxy_service_stop_requesting(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiAgentConfig):
+
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = node_foo_name
+
+    node_bar_cfg = bluechi_node_default_config.deep_copy()
+    node_bar_cfg.node_name = node_bar_name
+
+    bluechi_ctrl_default_config.allowed_node_names = [node_foo_name, node_bar_name]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+    bluechi_test.add_bluechi_agent_config(node_bar_cfg)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
implemented job cancel and added integration test for job cancelling
    
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/793
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/792

Implemented cancelling a job that has been created. Due to possible race conditions, e.g. when the events of the job being canceled are propagated and processed faster than handling the job cancel callack, success is replied to the caller as soon as the request to the agent has been submitted. Errors only lead to logs in bluechi.

Implemented an integration test to verify that a job can be canceled via the DBus API provided by BlueChi. The test also uses various job attributes.
