### PR TITLE
Test that bluechictl monitor receives UnitCreated/UnitRemoved signals

### DIFF
--- a/src/client/method-status.c
+++ b/src/client/method-status.c
@@ -168,27 +168,27 @@ static int parse_unit_status_response_from_message(sd_bus_message *m, unit_info_
 static void print_info_header(size_t name_col_width) {
         size_t i = 0;
 
-        fprintf(stderr, "UNIT");
+        fprintf(stdout, "UNIT");
         for (i = PRINT_TAB_SIZE + name_col_width; i > PRINT_TAB_SIZE; i -= PRINT_TAB_SIZE) {
-                fprintf(stderr, "\t");
+                fprintf(stdout, "\t");
         }
 
-        fprintf(stderr, "| LOADED\t| ACTIVE\t| SUBSTATE\t| FREEZERSTATE\t| ENABLED\t|\n");
+        fprintf(stdout, "| LOADED\t| ACTIVE\t| SUBSTATE\t| FREEZERSTATE\t| ENABLED\t|\n");
         for (i = PRINT_TAB_SIZE + name_col_width; i > PRINT_TAB_SIZE; i -= PRINT_TAB_SIZE) {
-                fprintf(stderr, "--------");
+                fprintf(stdout, "--------");
         }
-        fprintf(stderr, "----------------");
-        fprintf(stderr, "----------------");
-        fprintf(stderr, "----------------");
-        fprintf(stderr, "----------------");
-        fprintf(stderr, "----------------\n");
+        fprintf(stdout, "----------------");
+        fprintf(stdout, "----------------");
+        fprintf(stdout, "----------------");
+        fprintf(stdout, "----------------");
+        fprintf(stdout, "----------------\n");
 }
 
 #define PRINT_AND_ALIGN(x)                                       \
         do {                                                     \
-                fprintf(stderr, "| %s\t", unit_info->x);         \
+                fprintf(stdout, "| %s\t", unit_info->x);         \
                 if (!unit_info->x || strlen(unit_info->x) < 6) { \
-                        fprintf(stderr, "\t");                   \
+                        fprintf(stdout, "\t");                   \
                 }                                                \
         } while (0)
 
@@ -201,11 +201,11 @@ static void print_unit_info(unit_info_t *unit_info, size_t name_col_width) {
                 return;
         }
 
-        fprintf(stderr, "%s", unit_info->id);
+        fprintf(stdout, "%s", unit_info->id);
         name_col_width -= unit_info->id ? strlen(unit_info->id) : 0;
         name_col_width += PRINT_TAB_SIZE;
         for (i = PRINT_TAB_SIZE + name_col_width; i > PRINT_TAB_SIZE; i -= PRINT_TAB_SIZE) {
-                fprintf(stderr, "\t");
+                fprintf(stdout, "\t");
         }
 
         PRINT_AND_ALIGN(load_state);
@@ -214,7 +214,7 @@ static void print_unit_info(unit_info_t *unit_info, size_t name_col_width) {
         PRINT_AND_ALIGN(freezer_state);
         PRINT_AND_ALIGN(unit_file_state);
 
-        fprintf(stderr, "|\n");
+        fprintf(stdout, "|\n");
 }
 
 static size_t get_max_name_len(char **units, size_t units_count) {

--- a/tests/tests/tier0/bluechictl-monitor-unit-created-removed/main.fmf
+++ b/tests/tests/tier0/bluechictl-monitor-unit-created-removed/main.fmf
@@ -1,0 +1,2 @@
+summary: Test that bluechictl monitor can receive UnitCreated and UnitRemoved signals
+id: 1becd1cf-6f07-4bbb-9b16-ec438bbb6c22

--- a/tests/tests/tier0/bluechictl-monitor-unit-created-removed/python/monitor.py
+++ b/tests/tests/tier0/bluechictl-monitor-unit-created-removed/python/monitor.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import signal
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+
+node_name_foo = "node-foo"
+
+service_simple = "simple.service"
+
+
+class FileFollower:
+    def __init__(self, file_name):
+        self.pos = 0
+        self.file_name = file_name
+        self.file_desc = None
+
+    def __enter__(self):
+        self.file_desc = open(self.file_name, mode='r')
+        return self
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        if exception_type or exception_type or exception_traceback:
+            print(f"Exception raised: exception_type='{exception_type}', "
+                  f"exception_value='{exception_value}', exception_traceback: {exception_traceback}")
+        if self.file_desc:
+            self.file_desc.close()
+
+    def __iter__(self):
+        while self.new_lines():
+            self.seek()
+            line = self.file_desc.read().split('\n')[0]
+            yield line
+
+            self.pos += len(line) + 1
+
+    def seek(self):
+        self.file_desc.seek(self.pos)
+
+    def new_lines(self):
+        self.seek()
+        return '\n' in self.file_desc.read()
+
+
+class TestMonitorSpecificNodeAndUnit(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.bluechictl_proc = None
+
+        self.created = False
+        self.removed = False
+
+    def run_command(self, args, shell=True, **kwargs):
+        process = subprocess.Popen(
+                args,
+                shell=shell,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                **kwargs)
+        print(f"Executing of command '{process.args}' started")
+        out, err = process.communicate()
+
+        out = out.decode("utf-8")
+        err = err.decode("utf-8")
+
+        print(
+            f"Executing of command '{process.args}' finished with result '{process.returncode}', "
+            f"stdout '{out}', stderr '{err}'")
+
+        return process.returncode, out, err
+
+    def timeout_guard(self):
+        time.sleep(10)
+        print(f"Loop timeout - UnitRemoved signal for service '{service_simple}' on node '{node_name_foo}' "
+              f"was not successfully received on time")
+        self.bluechictl_proc.send_signal(signal.SIGINT)
+        self.bluechictl_proc.wait()
+
+    def process_events(self):
+        out_file = None
+
+        with tempfile.NamedTemporaryFile() as out_file:
+            try:
+                self.bluechictl_proc = subprocess.Popen(
+                    ["/usr/bin/bluechictl", "monitor", f"{node_name_foo}", f"{service_simple}"],
+                    stdout=out_file,
+                    bufsize=1)
+
+                with FileFollower(out_file.name) as bluechictl_out:
+                    events_received = False
+                    while not events_received and self.bluechictl_proc.poll() is None:
+                        for line in bluechictl_out:
+                            print(f"Evaluating line '{line}'")
+                            if not self.created and "Unit created (reason: real)" in line:
+                                print(f"Received UnitCreated signal for service '{service_simple}' "
+                                      f"on node '{node_name_foo}'")
+                                self.created = True
+
+                            elif self.created and not self.removed and "Unit removed (reason: real)" in line:
+                                print(f"Received UnitRemoved signal for service '{service_simple}' "
+                                      f"on node '{node_name_foo}'")
+                                self.removed = True
+                                events_received = True
+                                break
+
+                            else:
+                                print(f"Ignoring line '{line}'")
+
+                        # Wait for the new output from bluechictl monitor
+                        time.sleep(0.5)
+            finally:
+                if self.bluechictl_proc:
+                    self.bluechictl_proc.send_signal(signal.SIGINT)
+                    self.bluechictl_proc.wait()
+                    self.bluechictl_proc = None
+
+    def test_monitor_specific_node_and_unit(self):
+        t = threading.Thread(target=self.process_events)
+        # mark the failsafe thread as daemon so it stops when the main process stops
+        failsafe_thread = threading.Thread(target=self.timeout_guard, daemon=True)
+        t.start()
+        failsafe_thread.start()
+
+        # Running bluechictl status on inactive unit should raise UnitCreated and UnitRemoved signals
+        res, out, _ = self.run_command(f"bluechictl status {node_name_foo} {service_simple}")
+        assert res == 0
+        assert "inactive" in out
+
+        t.join()
+
+        assert self.created
+        assert self.removed
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechictl-monitor-unit-created-removed/systemd/simple.service
+++ b/tests/tests/tier0/bluechictl-monitor-unit-created-removed/systemd/simple.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Run a simple service
+
+[Service]
+Type=simple
+ExecStart=/bin/true
+RemainAfterExit=yes

--- a/tests/tests/tier0/bluechictl-monitor-unit-created-removed/test_bluechictl_monitor_unit_created_removed.py
+++ b/tests/tests/tier0/bluechictl-monitor-unit-created-removed/test_bluechictl_monitor_unit_created_removed.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
+
+node_name_foo = "node-foo"
+service_simple = "simple.service"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    node_foo = nodes[node_name_foo]
+    node_foo.copy_systemd_service(service_simple)
+    assert node_foo.wait_for_unit_state_to_be(service_simple, "inactive")
+
+    result, output = ctrl.run_python(os.path.join("python", "monitor.py"))
+
+
+def test_bluechictl_monitor_unit_created_removed(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiAgentConfig):
+
+    bluechi_node_default_config.node_name = node_name_foo
+    bluechi_ctrl_default_config.allowed_node_names = [bluechi_node_default_config.node_name]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_agent_config(bluechi_node_default_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Adds a test, which verifies that bluechictl monitor is able to receive  UnitCreated and UnitRemoved signals.

Fixes: https://github.com/eclipse-bluechi/bluechi/issues/784
Signed-off-by: Martin Perina <mperina@redhat.com>
