### PR TITLE
added peer ip to node

### DIFF
--- a/data/org.eclipse.bluechi.Controller.xml
+++ b/data/org.eclipse.bluechi.Controller.xml
@@ -34,14 +34,15 @@
     <!-- 
       ListNodes:
       @nodes: A list of all nodes:
-        - The node name
-        - The object path of the node
-        - the current state of that node, either online or offline
+        - node name
+        - object path of the node
+        - current state of that node, either online or offline
+        - IP of the connected node 
       
       List all nodes managed by BlueChi regardless if they are offline or online.
     -->
     <method name="ListNodes">
-      <arg name="nodes" type="a(sos)" direction="out" />
+      <arg name="nodes" type="a(soss)" direction="out" />
     </method>
 
     <!-- 

--- a/data/org.eclipse.bluechi.Node.xml
+++ b/data/org.eclipse.bluechi.Node.xml
@@ -232,6 +232,16 @@
     </property>
 
     <!-- 
+      PeerIp:
+
+      The current IP of the connected node.
+      The address might be set even though the node is still offline since a call to org.eclipse.bluechi.Controller.Register hasn't been made.
+    -->
+    <property name="PeerIp" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false" />
+    </property>
+
+    <!-- 
       LastSeenTimestamp:
 
       A timestamp indicating when the last connection test (e.g. via heartbeat) was successful.

--- a/doc/api-examples/c/list-nodes.c
+++ b/doc/api-examples/c/list-nodes.c
@@ -32,7 +32,7 @@ int main() {
                 return r;
         }
 
-        r = sd_bus_message_enter_container(result, SD_BUS_TYPE_ARRAY, "(sos)");
+        r = sd_bus_message_enter_container(result, SD_BUS_TYPE_ARRAY, "(soss)");
         if (r < 0) {
                 fprintf(stderr, "Failed to open result array: %s\n", strerror(-r));
                 sd_bus_unref(bus);
@@ -44,8 +44,9 @@ int main() {
                 const char *name = NULL;
                 const char *path = NULL;
                 const char *state = NULL;
+                const char *ip = NULL;
 
-                r = sd_bus_message_read(result, "(sos)", &name, &path, &state);
+                r = sd_bus_message_read(result, "(soss)", &name, &path, &ip);
                 if (r < 0) {
                         fprintf(stderr, "Failed to read node information: %s\n", strerror(-r));
                         sd_bus_unref(bus);

--- a/doc/api-examples/python/list-nodes.py
+++ b/doc/api-examples/python/list-nodes.py
@@ -6,7 +6,7 @@ import dasbus.connection
 
 bus = dasbus.connection.SystemMessageBus()
 
-NodeInfo = namedtuple("NodeInfo", ["name", "object_path", "status"])
+NodeInfo = namedtuple("NodeInfo", ["name", "object_path", "status", "peer_ip"])
 
 controller = bus.get_proxy("org.eclipse.bluechi", "/org/eclipse/bluechi")
 nodes = controller.ListNodes()

--- a/doc/api-examples/rust/list-nodes.rs
+++ b/doc/api-examples/rust/list-nodes.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Duration::from_millis(5000),
     );
 
-    let (nodes,): (Vec<(String, dbus::Path, String)>,) =
+    let (nodes,): (Vec<(String, dbus::Path, String, String)>,) =
         bluechi.method_call("org.eclipse.bluechi.Controller", "ListNodes", ())?;
 
     for (name, _, status) in nodes {

--- a/doc/bluechi-examples/ListAllNodes.py
+++ b/doc/bluechi-examples/ListAllNodes.py
@@ -4,5 +4,5 @@
 from bluechi.api import Controller
 
 for node in Controller().list_nodes():
-    # node[name, obj_path, status]
+    # node[name, obj_path, status, peer_ip]
     print(f"Node: {node[0]}, State: {node[2]}")

--- a/doc/docs/api/description.md
+++ b/doc/docs/api/description.md
@@ -27,9 +27,9 @@ Note that some properties also come with change events, so you can easily track 
     Creates a new monitor object, which can be used to monitor the state of selected units on the nodes. The monitor
     object returned will automatically be closed if the calling peer disconnects from the bus.
 
-  * `ListNodes(out a(sos) nodes)`
+  * `ListNodes(out a(soss) nodes)`
 
-    Returns information (name, object_path and status) of all known nodes.
+    Returns information (name, object_path, status and peer IP) of all known nodes.
 
   * `GetNode(in s name, out o path)`
 
@@ -209,6 +209,12 @@ Object path: `/org/eclipse/bluechi/node/$name`
   * `Status` - `s`
 
     Status of the node, currently one of: `online`, `offline`. Emits changed when this changes.
+  
+  * `PeerIp` - `s`
+
+    IP of the node.
+    The address might be set even though the node is still offline since a call to
+    org.eclipse.bluechi.Controller.Register hasn't been made.
 
   * `LastSeenTimestamp` - `t`
 

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -50,7 +50,6 @@ DBUS_PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
 
 
 class ApiBase:
-
     def __init__(
         self,
         interface: str,
@@ -241,13 +240,14 @@ class Controller(ApiBase):
             name,
         )
 
-    def list_nodes(self) -> List[Tuple[str, ObjPath, str]]:
+    def list_nodes(self) -> List[Tuple[str, ObjPath, str, str]]:
         """
           ListNodes:
         @nodes: A list of all nodes:
-          - The node name
-          - The object path of the node
-          - the current state of that node, either online or offline
+          - node name
+          - object path of the node
+          - current state of that node, either online or offline
+          - IP of the connected node
 
         List all nodes managed by BlueChi regardless if they are offline or online.
         """
@@ -781,10 +781,9 @@ class Node(ApiBase):
             runtime,
         )
 
-    def enable_unit_files(self, files: List[str], runtime: bool, force: bool) -> Tuple[
-        bool,
-        List[Tuple[str, str, str]],
-    ]:
+    def enable_unit_files(
+        self, files: List[str], runtime: bool, force: bool
+    ) -> Tuple[bool, List[Tuple[str, str, str]],]:
         """
           EnableUnitFiles:
         @files: A list of units to enable
@@ -992,6 +991,16 @@ class Node(ApiBase):
         The name of the node.
         """
         return self.get_proxy().Name
+
+    @property
+    def peer_ip(self) -> str:
+        """
+          PeerIp:
+
+        The current IP of the connected node.
+        The address might be set even though the node is still offline since a call to org.eclipse.bluechi.Controller.Register hasn't been made.
+        """
+        return self.get_proxy().PeerIp
 
     @property
     def status(self) -> str:

--- a/src/controller/controller.c
+++ b/src/controller/controller.c
@@ -650,12 +650,13 @@ static int controller_method_list_units(sd_bus_message *m, void *userdata, UNUSE
  ************************************************************************/
 
 static int controller_method_list_encode_node(sd_bus_message *reply, Node *node) {
-        int r = sd_bus_message_open_container(reply, SD_BUS_TYPE_STRUCT, "sos");
+        int r = sd_bus_message_open_container(reply, SD_BUS_TYPE_STRUCT, "soss");
         if (r < 0) {
                 return r;
         }
 
-        r = sd_bus_message_append(reply, "sos", node->name, node->object_path, node_get_status(node));
+        r = sd_bus_message_append(
+                        reply, "soss", node->name, node->object_path, node_get_status(node), node->peer_ip);
         if (r < 0) {
                 return r;
         }
@@ -676,7 +677,7 @@ static int controller_method_list_nodes(sd_bus_message *m, void *userdata, UNUSE
                                 strerror(-r));
         }
 
-        r = sd_bus_message_open_container(reply, SD_BUS_TYPE_ARRAY, "(sos)");
+        r = sd_bus_message_open_container(reply, SD_BUS_TYPE_ARRAY, "(soss)");
         if (r < 0) {
                 return sd_bus_reply_method_errorf(
                                 reply,
@@ -929,7 +930,7 @@ static int controller_property_get_log_target(
 static const sd_bus_vtable controller_vtable[] = {
         SD_BUS_VTABLE_START(0),
         SD_BUS_METHOD("ListUnits", "", NODE_AND_UNIT_INFO_STRUCT_ARRAY_TYPESTRING, controller_method_list_units, 0),
-        SD_BUS_METHOD("ListNodes", "", "a(sos)", controller_method_list_nodes, 0),
+        SD_BUS_METHOD("ListNodes", "", "a(soss)", controller_method_list_nodes, 0),
         SD_BUS_METHOD("GetNode", "s", "o", controller_method_get_node, 0),
         SD_BUS_METHOD("CreateMonitor", "", "o", controller_method_create_monitor, 0),
         SD_BUS_METHOD("SetLogLevel", "s", "", controller_method_set_log_level, 0),

--- a/src/controller/node.h
+++ b/src/controller/node.h
@@ -51,6 +51,7 @@ struct Node {
 
         char *name; /* NULL for not yet registered nodes */
         char *object_path;
+        char *peer_ip;
 
         LIST_HEAD(AgentRequest, outstanding_requests);
         LIST_HEAD(ProxyMonitor, proxy_monitors);

--- a/src/libbluechi/bus/bus.c
+++ b/src/libbluechi/bus/bus.c
@@ -288,3 +288,46 @@ sd_bus *user_bus_open(sd_event *event) {
 
         return steal_pointer(&bus);
 }
+
+
+int get_peer_address(sd_bus *bus, bool ipv6, char **ret_address, uint16_t *ret_port) {
+        int fd = sd_bus_get_fd(bus);
+        if (fd < 0) {
+                bc_log_errorf("Failed to file descriptor from bus: %s", strerror(-fd));
+                return fd;
+        }
+
+        if (ipv6) {
+                struct sockaddr_in6 addr = { 0 };
+                socklen_t len = sizeof(addr);
+                int r = getpeername(fd, (struct sockaddr *) &addr, &len);
+                if (r < 0) {
+                        bc_log_errorf("Failed to get peer ipv6 address: %s", strerror(errno));
+                        return -errno;
+                }
+                if (ret_address != NULL) {
+                        *ret_address = typesafe_inet_ntop6(&addr);
+                }
+                if (ret_port != NULL) {
+                        *ret_port = ntohs(addr.sin6_port);
+                }
+
+                return 0;
+        }
+
+        struct sockaddr_in addr = { 0 };
+        socklen_t len = sizeof(addr);
+        int r = getpeername(fd, (struct sockaddr *) &addr, &len);
+        if (r < 0) {
+                bc_log_errorf("Failed to get peer ipv4 address: %s", strerror(errno));
+                return -errno;
+        }
+        if (ret_address != NULL) {
+                *ret_address = typesafe_inet_ntop4(&addr);
+        }
+        if (ret_port != NULL) {
+                *ret_port = ntohs(addr.sin_port);
+        }
+
+        return 0;
+}

--- a/src/libbluechi/bus/bus.h
+++ b/src/libbluechi/bus/bus.h
@@ -1,7 +1,9 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 #pragma once
 
+#include <netdb.h>
 #include <netinet/in.h>
+#include <stdbool.h>
 #include <systemd/sd-bus.h>
 
 
@@ -11,3 +13,5 @@ sd_bus *peer_bus_open_server(sd_event *event, const char *dbus_description, cons
 sd_bus *system_bus_open(sd_event *event);
 sd_bus *systemd_bus_open(sd_event *event);
 sd_bus *user_bus_open(sd_event *event);
+
+int get_peer_address(sd_bus *bus, bool ipv6, char **ret_address, uint16_t *ret_port);

--- a/tests/tests/tier0/bluechi-anonymous-node/python/node_foo_not_connected.py
+++ b/tests/tests/tier0/bluechi-anonymous-node/python/node_foo_not_connected.py
@@ -14,6 +14,7 @@ class TestNodeFooNotConnected(unittest.TestCase):
         assert len(nodes) == 1
         assert nodes[0][0] == "everyone-but-foo"
         assert nodes[0][2] == "offline"
+        assert nodes[0][3] == ""
 
 
 if __name__ == "__main__":

--- a/tests/tests/tier0/bluechi-node-property-peer-ip/main.fmf
+++ b/tests/tests/tier0/bluechi-node-property-peer-ip/main.fmf
@@ -1,0 +1,2 @@
+summary: Test if node peer ip is set correctly for a connected and disconnected node
+id: 34d54fa9-c5fe-40f5-8623-d98254d47d98

--- a/tests/tests/tier0/bluechi-node-property-peer-ip/python/has_node_ip.py
+++ b/tests/tests/tier0/bluechi-node-property-peer-ip/python/has_node_ip.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from bluechi.api import Node
+
+
+class TestNodeHasPeerIP(unittest.TestCase):
+
+    def test_node_has_peer_ip(self):
+        n = Node("node-foo")
+        assert n.peer_ip != ""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechi-node-property-peer-ip/python/is_node_connected.py
+++ b/tests/tests/tier0/bluechi-node-property-peer-ip/python/is_node_connected.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import time
+import unittest
+
+from bluechi.api import Node
+
+
+class TestNodeIsConnected(unittest.TestCase):
+
+    def test_node_is_connected(self):
+        n = Node("node-foo")
+        assert n.status == "online"
+
+        # verify that the last seen timestamp is updated with each heartbeat
+        timestamp = n.last_seen_timestamp
+        time.sleep(2)
+        assert n.last_seen_timestamp > timestamp
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechi-node-property-peer-ip/test_bluechi_property_peer_ip.py
+++ b/tests/tests/tier0/bluechi-node-property-peer-ip/test_bluechi_property_peer_ip.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+from typing import Dict
+
+from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.test import BluechiTest
+
+node_foo_name = "node-foo"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    node_foo = nodes[node_foo_name]
+
+    result, output = ctrl.run_python(os.path.join("python", "is_node_connected.py"))
+    if result != 0:
+        raise Exception(output)
+
+    # If node is connected, expect it to have an IP
+    result, output = ctrl.run_python(os.path.join("python", "has_node_ip.py"))
+    if result != 0:
+        raise Exception(output)
+
+    node_foo.systemctl.stop_unit("bluechi-agent.service")
+
+    result, output = ctrl.run_python(os.path.join("python", "is_node_connected.py"))
+    if result == 0:
+        raise Exception(f"Expected bluechi-agent {node_foo_name} to be offline, but was online")
+
+    # If node is disconnected, expect it to have no IP
+    result, output = ctrl.run_python(os.path.join("python", "has_node_ip.py"))
+    if result == 0:
+        raise Exception(f"Expected bluechi-agent {node_foo_name} to no IP when offline, but still has")
+
+
+def test_bluechi_node_status(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiAgentConfig):
+
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = node_foo_name
+
+    bluechi_ctrl_default_config.allowed_node_names = [node_foo_name]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/701

By using getpeername, the IP (and Port) can be resolved from the file descriptor on the agent bus. The IP is then set on the node on the controller-side) and made available via D-Bus property . It also updates the  API to include the IP.