### PR TITLE
Add micros to millis test

### DIFF
--- a/src/libbluechi/test/common/cfg/cfg_load_complete_configuration_test.c
+++ b/src/libbluechi/test/common/cfg/cfg_load_complete_configuration_test.c
@@ -179,6 +179,7 @@ void remove_test_directory(
                 char *default_config_file,
                 char *custom_config_file,
                 char *custom_config_directory,
+                char *cli_option_config_file,
                 char *custom_configs[]) {
 
         if (default_config_file && access(default_config_file, R_OK) == 0) {
@@ -186,6 +187,9 @@ void remove_test_directory(
         }
         if (custom_config_file && access(custom_config_file, R_OK) == 0) {
                 unlink(custom_config_file);
+        }
+        if (cli_option_config_file && access(cli_option_config_file, R_OK) == 0) {
+                unlink(cli_option_config_file);
         }
         if (custom_configs[0] && access(custom_configs[0], R_OK) == 0) {
                 unlink(custom_configs[0]);
@@ -278,6 +282,7 @@ bool test_cfg_load_complete_configuration(cfg_test_param *test_case) {
                         default_config_file,
                         custom_config_file,
                         custom_config_directory,
+                        cli_option_config_file,
                         custom_configs);
 
         return result;

--- a/src/libbluechi/test/common/time-util/meson.build
+++ b/src/libbluechi/test/common/time-util/meson.build
@@ -3,6 +3,7 @@
 network_src = [
   'get_log_timestamp',
   'get_time_seconds',
+  'micros_to_millis_test',
 ]
 
 foreach src : network_src

--- a/src/libbluechi/test/common/time-util/micros_to_millis_test.c
+++ b/src/libbluechi/test/common/time-util/micros_to_millis_test.c
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#include <assert.h>
+#include <stdlib.h>
+
+#include "libbluechi/common/time-util.h"
+
+
+int main() {
+        assert(micros_to_millis(0) == 0);
+        assert(micros_to_millis(12) == 0.012);
+        assert(micros_to_millis(UINT64_MAX) == 18446744073709552);
+        return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This PR
- adds a small unit test for `micros_to_millis` 
- fixes the cleanup in the unit test `cfg_load_complete_configuration_test`