### PR TITLE
re-enable list units on all nodes integration test

### DIFF
--- a/tests/tests/tier0/bluechi-list-units-on-all-nodes/main.fmf
+++ b/tests/tests/tier0/bluechi-list-units-on-all-nodes/main.fmf
@@ -1,7 +1,3 @@
 summary: Test if bluechi list-nodes returns the same list of units from all
     nodes which can be gathered by running systemctl on each node
 id: efbf2397-de69-4f67-a8a8-b2c10bc68c13
-
-# disabled for multihost till this is solved: 
-# https://github.com/eclipse-bluechi/bluechi/issues/767
-tag: []


### PR DESCRIPTION
Since https://github.com/eclipse-bluechi/bluechi/issues/767 has been solved, the list units on all nodes integration test can be re-enabled testing farm multihost runs.