### PR TITLE
integration tests: python machine lib

### DIFF
--- a/src/client/method-metrics.c
+++ b/src/client/method-metrics.c
@@ -53,6 +53,7 @@ static int match_start_unit_job_metrics_signal(
                unit,
                micros_to_millis(job_measured_time),
                micros_to_millis(unit_net_start_time));
+        fflush(stdout);
 
         return 0;
 }
@@ -74,6 +75,7 @@ static int match_agent_job_metrics_signal(sd_bus_message *m, UNUSED void *userda
                method,
                unit,
                micros_to_millis(systemd_job_time));
+        fflush(stdout);
         return 0;
 }
 

--- a/tests/bluechi_machine_lib/bluechictl.py
+++ b/tests/bluechi_machine_lib/bluechictl.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import copy
+import signal
+import subprocess
+import threading
+import time
+import tempfile
+from typing import List, Pattern, Set, Tuple
+
+
+bluechictl_executable = ["/usr/bin/bluechictl"]
+
+
+class FileFollower:
+    def __init__(self, file_name):
+        self.pos = 0
+        self.file_name = file_name
+        self.file_desc = None
+
+    def __enter__(self):
+        self.file_desc = open(self.file_name, mode='r')
+        return self
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        if (exception_type):
+            print(f"Exception raised: excpetion_type='{exception_type}', "
+                  f"exception_value='{exception_value}', exception_traceback: {exception_traceback}")
+        if self.file_desc:
+            self.file_desc.close()
+
+    def __iter__(self):
+        while self.new_lines():
+            self.seek()
+            line = self.file_desc.read().split('\n')[0]
+            yield line
+
+            self.pos += len(line) + 1
+
+    def seek(self):
+        self.file_desc.seek(self.pos)
+
+    def new_lines(self):
+        self.seek()
+        return '\n' in self.file_desc.read()
+
+
+class EventEvaluator:
+    def process_line(self, line: str) -> None:
+        pass
+
+    def processing_finished(self) -> bool:
+        pass
+
+
+class SimpleEventEvaluator(EventEvaluator):
+    def __init__(self, expected_patterns: Set[Pattern]):
+        self.expected_patterns = copy.copy(expected_patterns)
+
+    def process_line(self, line: str) -> None:
+        for pattern in copy.copy(self.expected_patterns):
+            if pattern.match(line):
+                print(f"Matched line '{line}'")
+                self.expected_patterns.remove(pattern)
+                break
+
+    def processing_finished(self) -> bool:
+        return len(self.expected_patterns) == 0
+
+
+class BackgroundRunner:
+    def __init__(self, args: List, evaluator: EventEvaluator, timeout: int = 10):
+        self.command = bluechictl_executable + args
+        self.evaluator = evaluator
+        self.thread = threading.Thread(target=self.process_events)
+        self.failsafe_thread = threading.Thread(target=self.timeout_guard, daemon=True)
+        self.bluechictl_proc = None
+        self.timeout = timeout
+
+    def process_events(self):
+        print("Starting process_events")
+        with tempfile.NamedTemporaryFile() as out_file:
+            try:
+                self.bluechictl_proc = subprocess.Popen(self.command, stdout=out_file, bufsize=1)
+
+                with FileFollower(out_file.name) as bluechictl_out:
+                    finished = False
+                    while self.bluechictl_proc.poll() is None and not finished:
+                        for line in bluechictl_out:
+                            print(f"Evaluating line '{line}'")
+                            self.evaluator.process_line(line)
+                            if self.evaluator.processing_finished():
+                                print("BluechiCtl output evaluation successfully finished")
+                                finished = True
+                                break
+
+                        # Wait for the new output from bluechictl monitor
+                        time.sleep(0.5)
+            finally:
+                print("Finalizing process")
+                if self.bluechictl_proc:
+                    self.bluechictl_proc.send_signal(signal.SIGINT)
+                    self.bluechictl_proc.wait()
+                    self.bluechictl_proc = None
+
+    def timeout_guard(self):
+        time.sleep(self.timeout)
+        print(f"Waiting for expected output in {self.command} has timed out")
+        self.bluechictl_proc.send_signal(signal.SIGINT)
+        self.bluechictl_proc.wait()
+
+    def start(self):
+        print("Starting thread...")
+        self.thread.start()
+        self.failsafe_thread.start()
+
+    def stop(self):
+        self.thread.join()
+
+
+class BluechiCtl:
+    def run(self, args: List) -> Tuple[str, str]:
+        command = bluechictl_executable + args
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        print(f"Executing of command '{process.args}' started")
+        return process.communicate()
+
+    def metrics_listen(self) -> Tuple[str, str]:
+        return self.run(["metrics", "listen"])
+
+    def metrics_enable(self) -> Tuple[str, str]:
+        return self.run(["metrics", "enable"])
+
+    def metrics_disable(self) -> Tuple[str, str]:
+        return self.run(["metrics", "disable"])
+
+    def unit_start(self, node, unit) -> Tuple[str, str]:
+        return self.run(["start", node, unit])
+
+    def unit_stop(self, node, unit) -> Tuple[str, str]:
+        return self.run(["stop", node, unit])

--- a/tests/tests/tier0/bluechictl-metrics/main.fmf
+++ b/tests/tests/tier0/bluechictl-metrics/main.fmf
@@ -1,0 +1,2 @@
+summary: Test bluechictl metrics functionality
+id: 1683b338-e649-46b3-9888-e04c8aaa06cd

--- a/tests/tests/tier0/bluechictl-metrics/python/bluechictl_metrics.py
+++ b/tests/tests/tier0/bluechictl-metrics/python/bluechictl_metrics.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import re
+import unittest
+
+from bluechi_machine_lib.bluechictl import BackgroundRunner, BluechiCtl, SimpleEventEvaluator
+
+node_foo_name = "node-foo"
+service_simple = "simple.service"
+
+
+class TestBluechictlMetrics(unittest.TestCase):
+
+    def setUp(self) -> None:
+        signal_agent_metrics_start_pat = re.compile(r"^.*Agent systemd StartUnit job.*")
+        signal_agent_metrics_stop_pat = re.compile(r"^.*Agent systemd StopUnit job.*")
+        signal_controller_metrics_pat = re.compile(r"^.*BlueChi job gross measured time.*")
+        expected_patterns = {signal_agent_metrics_start_pat,
+                             signal_agent_metrics_stop_pat,
+                             signal_controller_metrics_pat}
+        args = ["metrics", "listen"]
+        self.evaluator = SimpleEventEvaluator(expected_patterns)
+        self.bgrunner = BackgroundRunner(args, self.evaluator)
+        self.bluechictl = BluechiCtl()
+
+    def test_bluechictl_metrics(self):
+        self.bluechictl.metrics_enable()
+        self.bgrunner.start()
+        self.bluechictl.unit_start(node_foo_name, service_simple)
+        self.bluechictl.unit_stop(node_foo_name, service_simple)
+        self.bgrunner.stop()
+        assert self.evaluator.processing_finished()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechictl-metrics/test_bluechictl_metrics.py
+++ b/tests/tests/tier0/bluechictl-metrics/test_bluechictl_metrics.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import logging
+from typing import Dict
+
+from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.service import SimpleRemainingService
+from bluechi_test.test import BluechiTest
+
+LOGGER = logging.getLogger(__name__)
+
+node_foo_name = "node-foo"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    foo = nodes[node_foo_name]
+    service = SimpleRemainingService()
+
+    foo.install_systemd_service(service)
+    assert foo.wait_for_unit_state_to_be(service.name, "inactive")
+
+    result, output = ctrl.run_python(os.path.join("python", "bluechictl_metrics.py"))
+    assert result == 0
+
+
+def test_bluechictl_metrics(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig,
+        bluechi_node_default_config: BluechiAgentConfig):
+
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = node_foo_name
+
+    bluechi_ctrl_default_config.allowed_node_names = [node_foo_name]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Adding python machine lib with bluechictl background runner for integration tests. This allows sharing code between python scripts run on testing machine (container/ssh).

Also adding `bluechictl metrics listen` test

Fixes: #783 