### PR TITLE
Increase test coverage

### DIFF
--- a/src/controller/node.c
+++ b/src/controller/node.c
@@ -29,14 +29,6 @@ static int node_method_restart_unit(sd_bus_message *m, void *userdata, UNUSED sd
 static int node_method_reload_unit(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
 static int node_method_passthrough_to_agent(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
 static int node_method_set_log_level(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error);
-static int node_property_get_nodename(
-                sd_bus *bus,
-                const char *path,
-                const char *interface,
-                const char *property,
-                sd_bus_message *reply,
-                void *userdata,
-                sd_bus_error *ret_error);
 static int node_property_get_status(
                 sd_bus *bus,
                 const char *path,
@@ -82,7 +74,7 @@ static const sd_bus_vtable node_vtable[] = {
         SD_BUS_METHOD("DisableUnitFiles", "asb", "a(sss)", node_method_passthrough_to_agent, 0),
         SD_BUS_METHOD("Reload", "", "", node_method_passthrough_to_agent, 0),
         SD_BUS_METHOD("SetLogLevel", "s", "", node_method_set_log_level, 0),
-        SD_BUS_PROPERTY("Name", "s", node_property_get_nodename, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+        SD_BUS_PROPERTY("Name", "s", NULL, offsetof(Node, name), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("Status", "s", node_property_get_status, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
         SD_BUS_PROPERTY("PeerIp", "s", node_property_get_peer_ip, 0, SD_BUS_VTABLE_PROPERTY_EXPLICIT),
         SD_BUS_PROPERTY("LastSeenTimestamp", "t", node_property_get_last_seen, 0, SD_BUS_VTABLE_PROPERTY_EXPLICIT),
@@ -1015,18 +1007,6 @@ static int node_disconnected(UNUSED sd_bus_message *message, void *userdata, UNU
         }
 
         return 0;
-}
-
-static int node_property_get_nodename(
-                UNUSED sd_bus *bus,
-                UNUSED const char *path,
-                UNUSED const char *interface,
-                UNUSED const char *property,
-                sd_bus_message *reply,
-                void *userdata,
-                UNUSED sd_bus_error *ret_error) {
-        Node *node = userdata;
-        return sd_bus_message_append(reply, "s", node->name);
 }
 
 const char *node_get_status(Node *node) {

--- a/tests/tests/tier0/bluechi-agent-get-logtarget/main.fmf
+++ b/tests/tests/tier0/bluechi-agent-get-logtarget/main.fmf
@@ -1,0 +1,2 @@
+summary: Test get logtarget from agent
+id: 8ba6d729-ccb6-43b8-ab00-95975d93c9a7

--- a/tests/tests/tier0/bluechi-agent-get-logtarget/python/agent_has_logtarget.py
+++ b/tests/tests/tier0/bluechi-agent-get-logtarget/python/agent_has_logtarget.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from bluechi.api import Agent
+
+expected_logtarget = "stderr-full"
+
+
+class TestHasLogTarget(unittest.TestCase):
+
+    def test_agent_has_logtarget(self):
+        agent = Agent()
+        assert agent.log_target == expected_logtarget
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechi-agent-get-logtarget/test_bluechi_agent_get_logtarget.py
+++ b/tests/tests/tier0/bluechi-agent-get-logtarget/test_bluechi_agent_get_logtarget.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
+
+NODE_FOO = "node-foo"
+
+expected_logtarget = "stderr-full"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    node_foo = nodes[NODE_FOO]
+
+    result, output = node_foo.run_python(os.path.join("python", "agent_has_logtarget.py"))
+    if result != 0:
+        raise Exception(f"Agent did not have expected log target '{expected_logtarget}: {output}")
+
+
+def test_bluechi_agent_get_logtarget(
+        bluechi_test: BluechiTest,
+        bluechi_node_default_config: BluechiAgentConfig, bluechi_ctrl_default_config: BluechiControllerConfig):
+
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = NODE_FOO
+    node_foo_cfg.log_target = expected_logtarget
+
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO]
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+
+    bluechi_test.run(exec)

--- a/tests/tests/tier0/bluechi-and-agent-on-same-machine/python/is_node_connected.py
+++ b/tests/tests/tier0/bluechi-and-agent-on-same-machine/python/is_node_connected.py
@@ -10,6 +10,7 @@ class TestNodeIsConnected(unittest.TestCase):
     def test_node_is_connected(self):
         n = Node("node-foo")
         assert n.status == "online"
+        assert n.name == "node-foo"
 
 
 if __name__ == "__main__":

--- a/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/python/is_node_connected.py
+++ b/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/python/is_node_connected.py
@@ -10,6 +10,7 @@ class TestNodeIsConnected(unittest.TestCase):
     def test_node_is_connected(self):
         n = Node("node-foo")
         assert n.status == "online"
+        assert n.name == "node-foo"
 
 
 if __name__ == "__main__":

--- a/tests/tests/tier0/bluechi-controller-get-logtarget/main.fmf
+++ b/tests/tests/tier0/bluechi-controller-get-logtarget/main.fmf
@@ -1,0 +1,2 @@
+summary: Test get logtarget from controller
+id: e0b5b0de-829d-4031-a436-6e99ed983065

--- a/tests/tests/tier0/bluechi-controller-get-logtarget/python/controller_has_logtarget.py
+++ b/tests/tests/tier0/bluechi-controller-get-logtarget/python/controller_has_logtarget.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from bluechi.api import Controller
+
+expected_logtarget = "stderr-full"
+
+
+class TestHasLogTarget(unittest.TestCase):
+
+    def test_controller_has_logtarget(self):
+        controller = Controller()
+        assert controller.log_target == expected_logtarget
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechi-controller-get-logtarget/test_bluechi_agent_get_logtarget.py
+++ b/tests/tests/tier0/bluechi-controller-get-logtarget/test_bluechi_agent_get_logtarget.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+from typing import Dict
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.config import BluechiControllerConfig
+
+expected_logtarget = "stderr-full"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    result, output = ctrl.run_python(os.path.join("python", "controller_has_logtarget.py"))
+    if result != 0:
+        raise Exception(f"Controller did not have expected log target '{expected_logtarget}: {output}")
+
+
+def test_bluechi_agent_get_logtarget(
+        bluechi_test: BluechiTest,
+        bluechi_ctrl_default_config: BluechiControllerConfig):
+
+    bluechi_ctrl_default_config.allowed_node_names = []
+    bluechi_ctrl_default_config.log_target = expected_logtarget
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/786
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/791
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/795

This PR consists of two commits: 
1. Added integration tests to verify that the logtarget property of the controller and agent are configured and can be retrieved via D-Bus API property.
2. The node property for its name is just forwarding a struct variable. Therefore, the function for the property getter can be replaced by a simple offsetof. In addition, the integration tests to check if a node is online are extended to check also the node name.