### PR TITLE
Add an API method to switch controller for agent

### DIFF
--- a/data/org.eclipse.bluechi.Agent.xml
+++ b/data/org.eclipse.bluechi.Agent.xml
@@ -40,6 +40,17 @@
       <arg name="unit" type="s" direction="in" />
     </method>
 
+    <!--
+      SwitchController:
+      @dbus_address: SD Bus address used to connect to the BlueChi controller
+
+      SwitchController() changes SD Bus address used to connect to the BlueChi controller and
+      triggers a reconnect to the BlueChi controller with the new address.
+    -->
+    <method name="SwitchController">
+      <arg name="dbus_address" type="s" direction="in" />
+    </method>
+
 
     <!-- 
       Status:
@@ -79,6 +90,16 @@
     -->
     <property name="DisconnectTimestamp" type="t" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false" />
+    </property>
+
+    <!--
+      ControllerAddress:
+
+      SD Bus address used to connect to the BlueChi controller.
+      On any change, a signal is emitted on the org.freedesktop.DBus.Properties interface.
+    -->
+    <property name="ControllerAddress" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true" />
     </property>
 
   </interface>

--- a/doc/docs/api/description.md
+++ b/doc/docs/api/description.md
@@ -276,6 +276,10 @@ interface.
 
     When a proxy is not needed anymore it is being removed on the node and a `ProxyRemoved` is emitted to notify the controller.
 
+  * `SwitchController(in s controller_address)`
+
+    Set the new controller address for bluechi-agent node and trigger a reconnect to the controller with the new address.
+
 ### interface org.eclipse.bluechi.Metrics
 
 This interface provides signals for collecting metrics. It is created by calling `EnableMetrics` on the `org.eclipse.bluechi.Controller` interface and removed by calling `DisableMetrics`.

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -50,6 +50,7 @@ DBUS_PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
 
 
 class ApiBase:
+
     def __init__(
         self,
         interface: str,
@@ -822,9 +823,10 @@ class Node(ApiBase):
             runtime,
         )
 
-    def enable_unit_files(
-        self, files: List[str], runtime: bool, force: bool
-    ) -> Tuple[bool, List[Tuple[str, str, str]],]:
+    def enable_unit_files(self, files: List[str], runtime: bool, force: bool) -> Tuple[
+        bool,
+        List[Tuple[str, str, str]],
+    ]:
         """
           EnableUnitFiles:
         @files: A list of units to enable

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -132,6 +132,47 @@ class Agent(ApiBase):
             unit,
         )
 
+    def switch_controller(self, dbus_address: str) -> None:
+        """
+          SwitchController:
+        @dbus_address: SD Bus address used to connect to the BlueChi controller
+
+        SwitchController() changes SD Bus address used to connect to the BlueChi controller and
+        triggers a reconnect to the BlueChi controller with the new address.
+        """
+        self.get_proxy().SwitchController(
+            dbus_address,
+        )
+
+    @property
+    def controller_address(self) -> str:
+        """
+          ControllerAddress:
+
+        SD Bus address used to connect to the BlueChi controller.
+        On any change, a signal is emitted on the org.freedesktop.DBus.Properties interface.
+        """
+        return self.get_proxy().ControllerAddress
+
+    def on_controller_address_changed(self, callback: Callable[[Variant], None]):
+        """
+          ControllerAddress:
+
+        SD Bus address used to connect to the BlueChi controller.
+        On any change, a signal is emitted on the org.freedesktop.DBus.Properties interface.
+        """
+
+        def on_properties_changed(
+            interface: str,
+            changed_props: Dict[str, Variant],
+            invalidated_props: Dict[str, Variant],
+        ) -> None:
+            value = changed_props.get("ControllerAddress")
+            if value is not None:
+                callback(value)
+
+        self.get_properties_proxy().PropertiesChanged.connect(on_properties_changed)
+
     @property
     def disconnect_timestamp(self) -> UInt64:
         """


### PR DESCRIPTION
This PR is related with #819.

This adds an API method to set the ControllerAddress= which triggers a disconnect in the agent, and a property to emits a signal that the address has been changed.

Also fixes errors detected by Lint to check apispec.