### PR TITLE
Propagating the failure of the requested service

### DIFF
--- a/tests/bluechi_test/service.py
+++ b/tests/bluechi_test/service.py
@@ -23,6 +23,7 @@ class Option(enum.Enum):
     Description = "Description"
     StopWhenUnneeded = "StopWhenUnneeded"
     Wants = "Wants"
+    BindsTo = "BindsTo"
 
     # Available options for Service section can be found at
     # https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Options

--- a/tests/tests/tier0/proxy-service-propagate-target-service-failure/main.fmf
+++ b/tests/tests/tier0/proxy-service-propagate-target-service-failure/main.fmf
@@ -1,0 +1,2 @@
+summary: Test Propagating the failure of the requested service by adding requested service to node-bar and the requesting to node-foo.
+id: bb9d4394-bd53-4d36-b8ba-ee91697c4850

--- a/tests/tests/tier0/proxy-service-propagate-target-service-failure/test_proxy_service_propagate_target_service_failure.py
+++ b/tests/tests/tier0/proxy-service-propagate-target-service-failure/test_proxy_service_propagate_target_service_failure.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import logging
+
+from typing import Dict
+from bluechi_test.test import BluechiTest
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
+from bluechi_test.service import Option, Section, SimpleRemainingService
+
+LOGGER = logging.getLogger(__name__)
+
+NODE_FOO = "node-foo"
+NODE_BAR = "node-bar"
+
+
+def exec(_: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+
+    node_foo = nodes[NODE_FOO]
+    node_bar = nodes[NODE_BAR]
+
+    service = SimpleRemainingService("target.service")
+    service.set_option(Section.Service, Option.ExecStart, "/bin/false")
+
+    node_bar.install_systemd_service(service)
+
+    service = SimpleRemainingService("requesting.service")
+    service.set_option(Section.Unit, Option.BindsTo, "bluechi-proxy@node-bar_target.service")
+    service.set_option(Section.Unit, Option.After, "bluechi-proxy@node-bar_target.service")
+    service.set_option(Section.Service, Option.ExecStart, "/bin/true")
+    service.set_option(Section.Service, Option.RemainAfterExit, "yes")
+
+    node_foo.install_systemd_service(service)
+
+    assert node_foo.systemctl.start_unit("requesting.service")
+    assert node_foo.wait_for_unit_state_to_be("requesting.service", "inactive")
+    assert node_bar.wait_for_unit_state_to_be("target.service", "failed")
+
+
+def test_proxy_service_propagate_target_service_failure(
+        bluechi_test: BluechiTest,
+        bluechi_node_default_config: BluechiAgentConfig, bluechi_ctrl_default_config: BluechiControllerConfig):
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = NODE_FOO
+
+    node_bar_cfg = bluechi_node_default_config.deep_copy()
+    node_bar_cfg.node_name = NODE_BAR
+
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+    bluechi_test.add_bluechi_agent_config(node_bar_cfg)
+
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO, NODE_BAR]
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Added test for failure propagation. This test will add the requesting 
service to node foo and the requested service to node bar. 
If after starting the service in node foo is in the failed state
 the propagation was successful