### PR TITLE
Make controller/agent config properly logged on startup

### DIFF
--- a/src/agent/main.c
+++ b/src/agent/main.c
@@ -139,7 +139,7 @@ int main(int argc, char *argv[]) {
 
         bc_log_init(agent->config);
         _cleanup_free_ const char *dumped_cfg = cfg_dump(agent->config);
-        bc_log_debug_with_data("Final configuration used", "\n%s", dumped_cfg);
+        bc_log_debugf("Final configuration used:\n%s", dumped_cfg);
 
         if (!agent_apply_config(agent)) {
                 return EXIT_FAILURE;

--- a/src/controller/main.c
+++ b/src/controller/main.c
@@ -91,7 +91,7 @@ int main(int argc, char *argv[]) {
 
         bc_log_init(controller->config);
         _cleanup_free_ const char *dumped_cfg = cfg_dump(controller->config);
-        bc_log_debug_with_data("Final configuration used", "\n%s", dumped_cfg);
+        bc_log_debugf("Final configuration used:\n%s", dumped_cfg);
 
         if (!controller_apply_config(controller)) {
                 return EXIT_FAILURE;


### PR DESCRIPTION
Previously the configuration was sent to the journal inside DATA field,
but this field is not being printed in journalctl. To make the
configuration visible in logs, it needs to be included within MESSAGE
field.

Signed-off-by: Martin Perina <mperina@redhat.com>
