### PR TITLE
Make ps command available for tests on nodes

### DIFF
--- a/tests/containers/integration-test-base
+++ b/tests/containers/integration-test-base
@@ -6,6 +6,7 @@ RUN dnf upgrade --refresh --nodocs -y && \
             lcov \
             lsof \
             policycoreutils-python-utils \
+            procps-ng \
             python3-dasbus \
             selinux-policy \
             systemd \

--- a/tests/scripts/tests-setup.sh
+++ b/tests/scripts/tests-setup.sh
@@ -42,6 +42,7 @@ function setup_worker(){
                 lcov \
                 lsof \
                 policycoreutils-python-utils \
+                procps-ng \
                 python3-dasbus \
                 selinux-policy \
                 systemd \


### PR DESCRIPTION
Add procps-ng package to preinstalled packages, so ps command can be
used to return full command line when detecting which process uses
specific port.

Signed-off-by: Martin Perina <mperina@redhat.com>
