### PR TITLE
Fix finding process listening on a port

### DIFF
--- a/tests/bluechi_test/container_scripts/cmd-on-port.sh
+++ b/tests/bluechi_test/container_scripts/cmd-on-port.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# The script takes only one parameter, which should be the port number
+if [ -z "$1" ]; then
+    exit 1
+fi
+
+PID="$(lsof -i:$1 -t)"
+
+if [ -z "$PID" ]; then
+    # No process listens on the specified port
+    exit 2
+fi
+
+# Return the full command line of the process listening on the specified port/protocol
+ps -hww -o args -p ${PID}


### PR DESCRIPTION
Use custom script to find full process command line listening on a
specific port instead of just lsof, because lsof can return only
limited number of characters of a process command line, which is not
enough to determine if bluechi-controller/agent listen of a port when
valgrind is enabled for their execution.

Signed-off-by: Martin Perina <mperina@redhat.com>
