### PR TITLE
Update GH actions to latest versions

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Build manifest
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       apispec: ${{ steps.filter.outputs.apispec }}
     steps:
       - name: Detect changed files
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -99,7 +99,7 @@ jobs:
           submodules: 'true'
 
       - name: Running markdown lint
-        uses: DavidAnson/markdownlint-cli2-action@v9
+        uses: DavidAnson/markdownlint-cli2-action@v15
 
 
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
           tar czf bluechi-${{ env.BLUECHI_VERSION }}.tar.gz bluechi-${{ env.BLUECHI_VERSION }}/
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           generate_release_notes: true


### PR DESCRIPTION
Update GH actions to latest versions to mitigate warning:

    Node.js 16 actions are deprecated. Please update the following
    actions to use Node.js 20

Signed-off-by: Martin Perina <mperina@redhat.com>
