### PR TITLE
Wait until process listens on specific port

### DIFF
--- a/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/test_bluechi_change_port_with_c_cmd_option.py
+++ b/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/test_bluechi_change_port_with_c_cmd_option.py
@@ -1,14 +1,28 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from typing import Dict
 import os
+import time
+
+from typing import Dict
 
 from bluechi_test.test import BluechiTest
-from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine, BluechiMachine
 from bluechi_test.config import BluechiControllerConfig, BluechiAgentConfig
-from bluechi_test.util import read_file
+from bluechi_test.util import read_file, Timeout
 
 NODE_FOO = "node-foo"
+
+OLD_PORT = 8420
+NEW_PORT = 8421
+
+
+def cmd_on_port(machine: BluechiMachine, port: int, expected_result: int = 0, expected_command: str = None) -> None:
+    with Timeout(seconds=5, error_message=f"Timeout waiting for '{expected_command}' to listen on port '{port}'"):
+        while True:
+            res, output = machine.exec_run(f"bash /var/cmd-on-port.sh {port}")
+            if res == expected_result and expected_command in str(output):
+                break
+            time.sleep(0.2)
 
 
 def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
@@ -32,13 +46,11 @@ def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
         os.path.join(config_file_location, "ctrl_port_8421.conf"), bluechi_controller_str)
     assert ctrl.wait_for_unit_state_to_be(bluechi_controller_str, "active")
 
-    # Check if port 8421 is listening and 8420 is disconnected
-    res, output = ctrl.exec_run("bash /var/cmd-on-port.sh 8421")
-    assert res == 0
-    assert "bluechi-controller" in str(output)
-    res, output = ctrl.exec_run("bash /var/cmd-on-port.sh 8420")
-    assert res != 0
-    assert b'' == output
+    # Check if bluechi controller listens on port 8421 and not on port 8420
+    cmd_on_port(machine=ctrl, port=NEW_PORT, expected_result=0, expected_command="bluechi-controller")
+
+    _, output = ctrl.exec_run(f"bash /var/cmd-on-port.sh {OLD_PORT}")
+    assert "bluechi-controller" not in str(output)
 
     # Check if node disconnected
     result, _ = ctrl.run_python(os.path.join("python", "is_node_connected.py"))
@@ -48,10 +60,8 @@ def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
         os.path.join(config_file_location, "agent_port_8421.conf"), bluechi_agent_str)
     assert node_foo.wait_for_unit_state_to_be(bluechi_agent_str, "active")
 
-    # Check if node connected
-    res, output = node_foo.exec_run("bash /var/cmd-on-port.sh 8421")
-    assert res == 0
-    assert "bluechi-agent" in str(output)
+    # Check if bluechi-agent on node_foo is using port 8421
+    cmd_on_port(machine=node_foo, port=NEW_PORT, expected_result=0, expected_command="bluechi-agent")
 
     result, _ = ctrl.run_python(os.path.join("python", "is_node_connected.py"))
     assert not result


### PR DESCRIPTION
Valgrind can significantly increase the time between systemd reports
bluechi-controller/agent as active and time when
bluechi-controller/agent really finished start up, so it's safer to
periodically check if bluechi-controller/agent really listens on port.

Signed-off-by: Martin Perina <mperina@redhat.com>
