### PR TITLE
Add integration test for unsupported option

### DIFF
--- a/tests/tests/tier0/bluechi-unsupported-option-error/main.fmf
+++ b/tests/tests/tier0/bluechi-unsupported-option-error/main.fmf
@@ -1,0 +1,4 @@
+summary: Test if bluechi-controller, bluechi-agent, bluechi-proxy and
+    bluechictl show help and return error when unsupported command line
+    option is provided
+id: e07fc44e-2bf8-4798-a24e-cba796c10e10

--- a/tests/tests/tier0/bluechi-unsupported-option-error/test_unsupported_option_error.py
+++ b/tests/tests/tier0/bluechi-unsupported-option-error/test_unsupported_option_error.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from typing import Dict, List
+
+from bluechi_test.test import BluechiTest
+from bluechi_test.machine import BluechiControllerMachine, BluechiAgentMachine
+from bluechi_test.config import BluechiControllerConfig
+
+
+def check_output(machine: BluechiControllerMachine, cmd: str, out_list: List[str]) -> bool:
+    re, out = machine.exec_run(cmd)
+
+    assert re != 0
+    for item in out_list:
+        assert item in out
+
+
+def check_help_option(ctrl: BluechiControllerMachine, _: Dict[str, BluechiAgentMachine]):
+    executables = [
+        '/usr/libexec/bluechi-controller',
+        '/usr/libexec/bluechi-agent',
+        '/usr/libexec/bluechi-proxy',
+        '/usr/bin/bluechictl'
+    ]
+
+    for executable in executables:
+        check_output(ctrl, f"{executable} -Q", ["Usage", "invalid option"])
+        check_output(ctrl, f"{executable} --QWERTY", ["Usage", "unrecognized option"])
+
+
+def test_help_option_provided(bluechi_test: BluechiTest, bluechi_ctrl_default_config: BluechiControllerConfig):
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(check_help_option)


### PR DESCRIPTION
Adds integration test, which checks that controller, agent, proxy and
bluechictl show help and return error when an unsupported command line
option is passed to them.

Signed-off-by: Martin Perina <mperina@redhat.com>
