### PR TITLE
Improve build container script and add Python development dependencies to build-base container

### DIFF
--- a/build-scripts/build-push-containers.sh
+++ b/build-scripts/build-push-containers.sh
@@ -20,6 +20,7 @@ function build(){
         buildah bud --tag "quay.io/bluechi/$IMAGE" \
             --manifest $IMAGE \
             --arch ${arch} \
+            --build-context root_dir=${SCRIPT_DIR}/.. \
             ${CONTAINER_FILE_DIR}/${IMAGE}
     done
 }

--- a/build-scripts/build-push-containers.sh
+++ b/build-scripts/build-push-containers.sh
@@ -14,7 +14,7 @@ function push(){
 }
 
 function build(){
-    buildah manifest create $IMAGE
+    buildah manifest exists $IMAGE || buildah manifest create $IMAGE
 
     for arch in $ARCHITECTURES; do
         buildah bud --tag "quay.io/bluechi/$IMAGE" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# NOTE: build-base container image needs to be rebuilt after changing this file!
+
+# Try to keep linter package versions aligned with latest Fedora RPM versions
+black==24.1.1
+flake8==6.0.0
+isort==5.13.2
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -228,3 +228,9 @@ PUSH_MANIFEST=yes ./build-scripts/build-push-containers.sh build-base
 # Only build locally
 ./build-scripts/build-push-containers.sh build-base
 ```
+
+If you need to build only specific architecture for your local usage, you can specify it as the 2nd parameter:
+
+```shell
+./build-scripts/build-push-containers.sh build-base amd64
+```

--- a/tests/containers/build-base
+++ b/tests/containers/build-base
@@ -22,8 +22,8 @@ RUN dnf install -y dnf-plugin-config-manager && \
         lcov \
         make \
         meson \
-        python3-flake8 \
         python3-html2text \
+        python3-pip \
         rpm-build \
         sed \
         selinux-policy-devel \
@@ -32,3 +32,10 @@ RUN dnf install -y dnf-plugin-config-manager && \
         valgrind \
     -y && \
     dnf -y clean all
+
+# Install python dependencies
+COPY --from=root_dir requirements.txt .
+RUN python3 -m venv /opt/bluechi-env && \
+    . /opt/bluechi-env/bin/activate && \
+    pip install -r requirements.txt && \
+    deactivate


### PR DESCRIPTION
- **Allow to specify architecture for build-push-containers.sh**
- **Don't create manifest if it already exists locally**
- **Add isort and black to build-base container**

Signed-off-by: Martin Perina <mperina@redhat.com>
