### PR TITLE
Build container images inside CS9 container

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -14,15 +14,38 @@ on:
 jobs:
   build_container:
     runs-on: ubuntu-latest
+    container:
+      image: quay.io/centos/centos:stream9
+      options: --security-opt=seccomp:unconfined --security-opt=label:disable --device /dev/fuse
     steps:
+      # Specific steps taken from https://developers.redhat.com/blog/2019/08/14/best-practices-for-running-buildah-in-a-container#setup
+      - name: Install dependencies
+        run: |
+          dnf install \
+                  buildah \
+                  fuse-overlayfs \
+                  --exclude container-selinux \
+              -y
+
+      - name: Adjust configuration
+        run: |
+          sed -i \
+              -e 's|^#mount_program|mount_program|g' \
+              -e '/additionalimage.*/a "/var/lib/shared",' \
+              /etc/containers/storage.conf
+          mkdir -p \
+              /var/lib/shared/overlay-images \
+              /var/lib/shared/overlay-layers
+          touch /var/lib/shared/overlay-images/images.lock
+          touch /var/lib/shared/overlay-layers/layers.lock
+
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Build manifest
         run: |
+          export _BUILDAH_STARTED_IN_USERNS=""
+          export BUILDAH_ISOLATION=chroot
           ./build-scripts/build-push-containers.sh ${{ inputs.image }}
 
       - name: Push manifest o quay.io


### PR DESCRIPTION
To mitigate issues around different buildah versions between Fedora/CS9
and Ubuntu, let's build images inside CS9 container.

Signed-off-by: Martin Perina <mperina@redhat.com>
