### PR TITLE
Use flake8 from bluechi virtual env

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -119,8 +119,10 @@ jobs:
 
       - name: Run flake8
         run: |
-          find doc/ -name '*.py' | xargs flake8
-          find tests/ -name '*.py' | xargs flake8
+          source /opt/bluechi-env/bin/activate
+          flake8 doc
+          flake8 tests
+          deactivate
 
 
 


### PR DESCRIPTION
As as part of https://github.com/eclipse-bluechi/bluechi/pull/856 flake8
is installed into /opt/bluechi-env, so we need to use that virtual env
for python linter job in GH.

Signed-off-by: Martin Perina <mperina@redhat.com>
