### PR TITLE
Make skipper use build-base image for build container

### DIFF
--- a/containers/Containerfile.bluechi-rpm-build
+++ b/containers/Containerfile.bluechi-rpm-build
@@ -1,4 +1,0 @@
-FROM quay.io/bluechi/build-base:latest
-
-RUN dnf install --nodocs -y python3-devel && \
-    dnf -y clean all

--- a/containers/build-base
+++ b/containers/build-base
@@ -24,6 +24,7 @@ RUN dnf install -y dnf-plugin-config-manager && \
         meson \
         python3-html2text \
         python3-pip \
+        python3-devel \
         rpm-build \
         sed \
         selinux-policy-devel \

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -1,3 +1,4 @@
-build_container_image: bluechi-rpm-build
+build_container_image: quay.io/bluechi/build-base
+build_container_tag: latest
 make:
   makefile: Makefile.skipper


### PR DESCRIPTION
Moving Containerfile.bluechi-rpm-build to containers dir has broken skipper operation when building rpms locally.
We can remove it completely, and make skipper use the `build-base` image.