### PR TITLE
Add watch option for bluechi status

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -116,8 +116,8 @@ int client_create_message_new_method_call(
         int r = 0;
         _cleanup_sd_bus_message_ sd_bus_message *outgoing_message = NULL;
 
-        free_and_null(client->object_path) r = assemble_object_path_string(
-                        NODE_OBJECT_PATH_PREFIX, node_name, &client->object_path);
+        free_and_null(client->object_path);
+        r = assemble_object_path_string(NODE_OBJECT_PATH_PREFIX, node_name, &client->object_path);
         if (r < 0) {
                 return r;
         }

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -116,7 +116,8 @@ int client_create_message_new_method_call(
         int r = 0;
         _cleanup_sd_bus_message_ sd_bus_message *outgoing_message = NULL;
 
-        r = assemble_object_path_string(NODE_OBJECT_PATH_PREFIX, node_name, &client->object_path);
+        free_and_null(client->object_path) r = assemble_object_path_string(
+                        NODE_OBJECT_PATH_PREFIX, node_name, &client->object_path);
         if (r < 0) {
                 return r;
         }

--- a/tests/tests/tier0/bluechictl-status-watch-service/main.fmf
+++ b/tests/tests/tier0/bluechictl-status-watch-service/main.fmf
@@ -1,0 +1,2 @@
+summary: Test client watch option by running in the controller container "bluechictl status" of a spasific node in the agent container and watching the status change when the service is down and up
+id: bb9d4394-bd53-4d36-b8ba-ee91697c4810

--- a/tests/tests/tier0/bluechictl-status-watch-service/python/bluechictl_status_watch.py
+++ b/tests/tests/tier0/bluechictl-status-watch-service/python/bluechictl_status_watch.py
@@ -1,0 +1,39 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import re
+import unittest
+
+from bluechi_machine_lib.bluechictl import BackgroundRunner, SimpleEventEvaluator
+
+from bluechi.api import Node
+
+node_foo_name = "node-foo"
+simple_service = "simple.service"
+
+
+class TestBluechictlStatusWatch(unittest.TestCase):
+
+    def setUp(self) -> None:
+        service_status_active = re.compile(r"^" + simple_service + ".* active")
+        service_status_inactive = re.compile(r"^" + simple_service + ".* inactive")
+        expected_patterns = {service_status_active, service_status_inactive}
+        args = ["status", node_foo_name, simple_service, "-w"]
+        self.evaluator = SimpleEventEvaluator(expected_patterns)
+        self.bgrunner = BackgroundRunner(args, self.evaluator)
+
+    def test_bluechictl_status_watch(self):
+        self.bgrunner.start()
+        node = Node(node_foo_name)
+        node.stop_unit(simple_service, "replace")
+        node.start_unit(simple_service, "replace")
+        node.stop_unit(simple_service, "replace")
+
+        self.bgrunner.stop()
+        assert self.evaluator.processing_finished()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechictl-status-watch-service/test_bluechictl_status_watch_service.py
+++ b/tests/tests/tier0/bluechictl-status-watch-service/test_bluechictl_status_watch_service.py
@@ -1,0 +1,42 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+from typing import Dict
+
+from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
+from bluechi_test.service import Option, Section, SimpleRemainingService
+from bluechi_test.test import BluechiTest
+
+NODE_FOO = "node-foo"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    node_foo = nodes[NODE_FOO]
+    service = SimpleRemainingService()
+    service.set_option(Section.Service, Option.ExecStart, "/bin/true")
+
+    node_foo.install_systemd_service(service)
+    ctrl.bluechictl.daemon_reload_node(NODE_FOO)
+    ctrl.bluechictl.start_unit(NODE_FOO, service.name)
+
+    result, _ = ctrl.run_python(os.path.join("python", "bluechictl_status_watch.py"))
+    assert result == 0
+
+
+def test_bluechictl_status_watch_service(
+    bluechi_test: BluechiTest,
+    bluechi_node_default_config: BluechiAgentConfig,
+    bluechi_ctrl_default_config: BluechiControllerConfig,
+):
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = NODE_FOO
+
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO]
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.run(exec)


### PR DESCRIPTION
This PR will add watch option for 'bluechi status'. I added monitor for the units that are requested to be watch. And every time the status of the service changed the screen is cleared and every the new status is printed .

Related: https://github.com/eclipse-bluechi/bluechi/issues/706