### PR TITLE
Upgrade python black dep

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -158,6 +158,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m ensurepip --default-pip
+          python3 -m pip install -r requirements.txt
           python3 -m pip install -r src/bindings/generator/requirements.txt
           pip install wheel
           dnf install -y python3-gobject

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,7 @@ jobs:
           dnf install python3-gobject
           python3 -m ensurepip --default-pip
           python3 -m pip install --upgrade pip setuptools wheel build
+          python3 -m pip install -r requirements.txt
           python3 -m pip install -r src/bindings/generator/requirements.txt
 
       - name: Generate python bindings

--- a/build-scripts/generate-bindings.sh
+++ b/build-scripts/generate-bindings.sh
@@ -16,6 +16,7 @@ function python(){
     template_dir=$BINDINGS_DIR"/python/templates/"
     output_file_path=$BINDINGS_DIR"/python/bluechi/api.py"
     python3 "$generator" "$data_dir" "$template_dir" "$output_file_path"
+    isort "$output_file_path"
     black "$output_file_path"
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # NOTE: containers/build-base image needs to be rebuilt after changing this file!
 
 # Try to keep linter package versions aligned with latest Fedora RPM versions
-black==24.1.1
+black==24.3.0
 flake8==6.0.0
 isort==5.13.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,3 @@ extend-ignore = E203,E701
 
 [isort]
 profile = black
-

--- a/src/bindings/generator/requirements.txt
+++ b/src/bindings/generator/requirements.txt
@@ -1,3 +1,2 @@
 Jinja2 >= 3.1.2
-black >= 23.3.0
 dasbus >= 1.7

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -8,21 +8,22 @@
 
 from __future__ import annotations
 
-from typing import Callable, Tuple, Dict, List, Any
+from typing import Any, Callable, Dict, List, Tuple
+
 from dasbus.typing import (
     Bool,
-    Double,
-    Str,
-    Int,
     Byte,
+    Double,
+    Int,
     Int16,
-    UInt16,
     Int32,
-    UInt32,
     Int64,
-    UInt64,
     ObjPath,
+    Str,
     Structure,
+    UInt16,
+    UInt32,
+    UInt64,
 )
 
 # File has been renamed to UnixFD in following PR included in v1.7
@@ -32,14 +33,12 @@ try:
 except ImportError:
     from dasbus.typing import UnixFD
 
-from dasbus.client.proxy import InterfaceProxy, ObjectProxy
-from dasbus.connection import MessageBus, SystemMessageBus, SessionMessageBus
-
 import gi
+from dasbus.client.proxy import InterfaceProxy, ObjectProxy
+from dasbus.connection import MessageBus, SessionMessageBus, SystemMessageBus
 
 gi.require_version("GLib", "2.0")
 from gi.repository.GLib import Variant  # noqa: E402
-
 
 BC_DEFAULT_PORT = 842
 BC_DEFAULT_HOST = "127.0.0.1"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,4 @@
-black >= 22.8.0
 flake8 >= 6.0.0
-isort >= 5.13.0
 junit-xml >= 1.9
 pytest >= 7.3.1
 podman >= 4.5.0


### PR DESCRIPTION
Upgraded python black from 24.1.1. to 24.3.0 to mitigate https://github.com/eclipse-bluechi/bluechi/security/dependabot/1

Also, in order to use the same formatting and linting tool version everywhere, only the requirements.txt in the root directory lists these tools.