### PR TITLE
fixed URL in rpm spec

### DIFF
--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -14,7 +14,9 @@ Version:	@VERSION@
 Release:	@RELEASE@%{?dist}
 Summary:	A systemd service controller for multi-nodes environments
 License:	LGPL-2.1-or-later AND CC0-1.0
-URL:		https://github.com/containers/bluechi
+URL:		https://github.com/eclipse-bluechi/bluechi
+Vendor:		Eclipse BlueChi
+Packager:	Red Hat
 Source0:	%{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
 # Required to apply the patch


### PR DESCRIPTION
Fixed URL in RPM spec to point to eclipse-bluechi organization instead of containers. Also, added Vendor and Packager field.