### PR TITLE
controller: Proactively disconnect node based on heartbeat

### DIFF
--- a/config/controller/controller.conf
+++ b/config/controller/controller.conf
@@ -17,6 +17,14 @@
 #ControllerPort=842
 
 #
+# Defines the interval between two heartbeat signals sent to bluechi in milliseconds.
+#HeartbeatInterval=2000
+
+#
+# Defines the threashold to actively disconnect nodes based on the time difference from the last heartbeat signal.
+#NodeHeartbeatThreshold=6000
+
+#
 # The level used for logging. Supported values are: DEBUG, INFO, WARN and ERROR.
 #LogLevel=INFO
 

--- a/doc/man/bluechi-controller.conf.5.md
+++ b/doc/man/bluechi-controller.conf.5.md
@@ -27,6 +27,14 @@ A comma separated list of unique bluechi-agent names. It's mandatory to set the 
 in the list can connect to `bluechi-controller'. These names are defined in the agent's configuration file under `NodeName`
 option (see `bluechi-agent.conf(5)`).
 
+#### **HeartbeatInterval** (long)
+
+The interval to periodically check node's connectivity based on heartbeat signals sent to bluechi, in milliseconds.
+
+#### **NodeHeartbeatThreshold** (long)
+
+The threshold in milliseconds to determine whether a node is disconnected. If the node's last heartbeat signal was received before this threshold, bluechi treats that the node has been disconnected.
+
 #### **LogLevel** (string)
 
 The level used for logging. Supported values are:

--- a/src/controller/controller.c
+++ b/src/controller/controller.c
@@ -10,6 +10,7 @@
 #include "libbluechi/bus/utils.h"
 #include "libbluechi/common/cfg.h"
 #include "libbluechi/common/common.h"
+#include "libbluechi/common/event-util.h"
 #include "libbluechi/common/parse-util.h"
 #include "libbluechi/common/time-util.h"
 #include "libbluechi/log/log.h"
@@ -276,6 +277,28 @@ bool controller_set_port(Controller *controller, const char *port_s) {
         return true;
 }
 
+bool controller_set_heartbeat_interval(Controller *controller, const char *interval_msec) {
+        long interval = 0;
+
+        if (!parse_long(interval_msec, &interval)) {
+                bc_log_errorf("Invalid heartbeat interval format '%s'", interval_msec);
+                return false;
+        }
+        controller->heartbeat_interval_msec = interval;
+        return true;
+}
+
+bool controller_set_heartbeat_threshold(Controller *controller, const char *threshold_msec) {
+        long threshold = 0;
+
+        if (!parse_long(threshold_msec, &threshold)) {
+                bc_log_errorf("Invalid heartbeat threshold format '%s'", threshold_msec);
+                return false;
+        }
+        controller->heartbeat_threshold_msec = threshold;
+        return true;
+}
+
 bool controller_parse_config(Controller *controller, const char *configfile) {
         int result = 0;
 
@@ -327,6 +350,20 @@ bool controller_apply_config(Controller *controller) {
                         }
 
                         name = strtok_r(NULL, ",", &saveptr);
+                }
+        }
+
+        const char *interval_msec = cfg_get_value(controller->config, CFG_HEARTBEAT_INTERVAL);
+        if (interval_msec) {
+                if (!controller_set_heartbeat_interval(controller, interval_msec)) {
+                        return false;
+                }
+        }
+
+        const char *threashold_msec = cfg_get_value(controller->config, CFG_HEARTBEAT_THRESHOLD);
+        if (threashold_msec) {
+                if (!controller_set_heartbeat_threshold(controller, threashold_msec)) {
+                        return false;
                 }
         }
 
@@ -442,6 +479,73 @@ static bool controller_setup_node_connection_handler(Controller *controller) {
         controller->node_connection_source = steal_pointer(&event_source);
 
         return true;
+}
+
+static int controller_reset_heartbeat_timer(Controller *controller, sd_event_source **event_source);
+
+static int controller_heartbeat_timer_callback(sd_event_source *event_source, UNUSED uint64_t usec, void *userdata) {
+        Controller *controller = (Controller *) userdata;
+        Node *node = NULL;
+        int r = 0;
+
+        LIST_FOREACH(nodes, node, controller->nodes) {
+                struct timespec now;
+                r = get_time(&now);
+                if (r < 0) {
+                        return r;
+                }
+		if (time_lessp(now, node->last_seen)) {
+			bc_log_error("Clock skew detected");
+			return -EINVAL;
+		}
+                if (time_elapsed_millis(node->last_seen,
+					controller->heartbeat_threshold_msec,
+					now)) {
+                        controller_remove_node(controller, node);
+                }
+        }
+
+        r = controller_reset_heartbeat_timer(controller, &event_source);
+        if (r < 0) {
+                bc_log_errorf("Failed to reset controller heartbeat timer: %s", strerror(-r));
+                return r;
+        }
+
+        return 0;
+}
+
+static int controller_reset_heartbeat_timer(Controller *controller, sd_event_source **event_source) {
+        return event_reset_time_relative(
+                        controller->event,
+                        event_source,
+                        CLOCK_BOOTTIME,
+                        controller->heartbeat_interval_msec * USEC_PER_MSEC,
+                        0,
+                        controller_heartbeat_timer_callback,
+                        controller,
+                        0,
+                        "controller-heartbeat-timer-source",
+                        false);
+}
+
+static int controller_setup_heartbeat_timer(Controller *controller) {
+        _cleanup_(sd_event_source_unrefp) sd_event_source *event_source = NULL;
+        int r = 0;
+
+        assert(controller);
+
+        if (controller->heartbeat_interval_msec <= 0) {
+                bc_log_warnf("Heartbeat disabled since interval is '%d', ", controller->heartbeat_interval_msec);
+                return 0;
+        }
+
+        r = controller_reset_heartbeat_timer(controller, &event_source);
+        if (r < 0) {
+                bc_log_errorf("Failed to reset controller heartbeat timer: %s", strerror(-r));
+                return r;
+        }
+
+        return sd_event_source_set_floating(event_source, true);
 }
 
 /************************************************************************
@@ -1079,6 +1183,12 @@ bool controller_start(Controller *controller) {
         }
 
         if (!controller_setup_node_connection_handler(controller)) {
+                return false;
+        }
+
+        r = controller_setup_heartbeat_timer(controller);
+        if (r < 0) {
+                bc_log_errorf("Failed to set up controller heartbeat timer: %s", strerror(-r));
                 return false;
         }
 

--- a/src/controller/controller.h
+++ b/src/controller/controller.h
@@ -19,6 +19,8 @@ struct Controller {
 
         uint16_t port;
         char *api_bus_service_name;
+        long heartbeat_interval_msec;
+        long heartbeat_threshold_msec;
 
         sd_event *event;
         sd_event_source *node_connection_source;

--- a/src/controller/node.c
+++ b/src/controller/node.c
@@ -161,7 +161,8 @@ Node *node_new(Controller *controller, const char *name) {
                 return NULL;
         }
 
-        node->last_seen = 0;
+        node->last_seen.tv_sec = 0;
+        node->last_seen.tv_nsec = 0;
 
         node->name = NULL;
         if (name) {
@@ -520,7 +521,7 @@ static int node_match_job_done(UNUSED sd_bus_message *m, UNUSED void *userdata, 
 static int node_match_heartbeat(UNUSED sd_bus_message *m, void *userdata, UNUSED sd_bus_error *error) {
         Node *node = userdata;
 
-        int r = get_time_seconds(&node->last_seen);
+        int r = clock_gettime(CLOCK_REALTIME, &node->last_seen);
         if (r < 0) {
                 bc_log_errorf("Failed to get current time on heartbeat: %s", strerror(-r));
                 return 0;
@@ -1053,7 +1054,7 @@ static int node_property_get_last_seen(
                 void *userdata,
                 UNUSED sd_bus_error *ret_error) {
         Node *node = userdata;
-        return sd_bus_message_append(reply, "t", node->last_seen);
+        return sd_bus_message_append(reply, "t", node->last_seen.tv_sec);
 }
 
 

--- a/src/controller/node.c
+++ b/src/controller/node.c
@@ -787,7 +787,7 @@ bool node_set_agent_bus(Node *node, sd_bus *bus) {
                         bc_log_errorf("Failed to emit status property changed: %s", strerror(-r));
                 }
 
-                sd_bus_match_signal(
+                r = sd_bus_match_signal(
                                 bus,
                                 NULL,
                                 NULL,

--- a/src/controller/node.h
+++ b/src/controller/node.h
@@ -62,7 +62,7 @@ struct Node {
         LIST_HEAD(ProxyDependency, proxy_dependencies);
 
         struct hashmap *unit_subscriptions;
-        time_t last_seen;
+        struct timespec last_seen;
 
         bool is_shutdown;
 };

--- a/src/libbluechi/common/cfg.h
+++ b/src/libbluechi/common/cfg.h
@@ -20,6 +20,7 @@
 #define CFG_NODE_NAME "NodeName"
 #define CFG_ALLOWED_NODE_NAMES "AllowedNodeNames"
 #define CFG_HEARTBEAT_INTERVAL "HeartbeatInterval"
+#define CFG_HEARTBEAT_THRESHOLD "NodeHeartbeatThreshold"
 #define CFG_IP_RECEIVE_ERRORS "IPReceiveErrors"
 #define CFG_TCP_KEEPALIVE_TIME "TCPKeepAliveTime"
 #define CFG_TCP_KEEPALIVE_INTERVAL "TCPKeepAliveInterval"

--- a/src/libbluechi/common/time-util.h
+++ b/src/libbluechi/common/time-util.h
@@ -14,10 +14,15 @@ static const double microsec_to_millisec_multiplier = 1e-3;
 static const double nanosec_to_microsec_multiplier = 1e-3;
 static const double nanosec_to_millisec_multiplier = 1e-6;
 static const uint64_t millis_in_second = 1000;
+static const uint64_t nanos_in_millis = 1000000;
+static const uint64_t nanos_in_second = 1000000000;
 
+int get_time(struct timespec *now);
 uint64_t get_time_micros();
 int get_time_seconds(time_t *ret_time_seconds);
 uint64_t finalize_time_interval_micros(int64_t start_time_micros);
 double micros_to_millis(uint64_t time_micros);
 char *get_formatted_log_timestamp();
 char *get_formatted_log_timestamp_for_timespec(struct timespec time, bool is_gmt);
+bool time_lessp(struct timespec a, struct timespec b);
+bool time_elapsed_millis(struct timespec start, uint64_t millis, struct timespec now);

--- a/src/libbluechi/test/common/time-util/meson.build
+++ b/src/libbluechi/test/common/time-util/meson.build
@@ -7,6 +7,7 @@ network_src = [
   'get_log_timestamp',
   'get_time_seconds',
   'micros_to_millis_test',
+  'time_elapsed_millis',
 ]
 
 foreach src : network_src

--- a/src/libbluechi/test/common/time-util/time_elapsed_millis.c
+++ b/src/libbluechi/test/common/time-util/time_elapsed_millis.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright Contributors to the Eclipse BlueChi project
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "libbluechi/common/common.h"
+#include "libbluechi/common/string-util.h"
+#include "libbluechi/common/time-util.h"
+
+bool test_time_elapsed_millis(struct timespec start, uint64_t millis,
+                              struct timespec now, bool expected_return) {
+        bool r = time_elapsed_millis(start, millis, now);
+
+        if (r == expected_return) {
+                return true;
+        }
+
+        fprintf(stdout,
+                "FAILED: time_elapsed_millis() - Expected return value %d, but got %d\n",
+                expected_return,
+                r);
+        return false;
+}
+
+int main() {
+        bool result = true;
+        struct timespec start, now;
+
+        start.tv_sec = 1;
+        start.tv_nsec = 1000000000UL - 3000000UL;
+
+        now.tv_sec = 2;
+        now.tv_nsec = 0;
+
+        result = result && test_time_elapsed_millis(start, 1, now, false);
+
+        result = result && test_time_elapsed_millis(start, 2, now, false);
+
+        result = result && test_time_elapsed_millis(start, 3, now, true);
+
+        if (result) {
+                return EXIT_SUCCESS;
+        }
+        return EXIT_FAILURE;
+}


### PR DESCRIPTION
This adds a couple of new options to controller: HeartbeatInterval and
NodeHeartbeatThreshold, which can be used to actively disconnect node
based on the last sent heartbeat.  The controller periodically checks
the last seen timestamp of nodes, and if it was sent before
NodeHeartbeatThreshold, the controller treats it as disconnected.

Fixes: #857 