### PR TITLE
Add integration test for agent controller switching 

### DIFF
--- a/tests/tests/tier0/bluechi-agent-switch-controller/main.fmf
+++ b/tests/tests/tier0/bluechi-agent-switch-controller/main.fmf
@@ -1,0 +1,2 @@
+summary: Test if the agent switches the controller successfully
+id: e07b7169-cf69-4e58-a50a-2fbc66db99f3

--- a/tests/tests/tier0/bluechi-agent-switch-controller/python/switch_controller.py
+++ b/tests/tests/tier0/bluechi-agent-switch-controller/python/switch_controller.py
@@ -1,0 +1,38 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from dasbus.loop import EventLoop
+from dasbus.typing import Variant
+
+from bluechi.api import Agent
+
+
+class TestSwitchController(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.controller_address = None
+
+    def test_switch_controller(self):
+        loop = EventLoop()
+
+        def on_controller_address_change(controller_address: Variant):
+            self.controller_address = controller_address.get_string()
+            loop.quit()
+
+        agent = Agent()
+        agent.on_controller_address_changed(on_controller_address_change)
+        agent.switch_controller("tcp:host=127.0.0.1,port=8420")
+
+        loop.run()
+
+        assert agent.controller_address == "tcp:host=127.0.0.1,port=8420"
+        assert self.controller_address == "tcp:host=127.0.0.1,port=8420"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechi-agent-switch-controller/test_bluechi_agent_switch_controller.py
+++ b/tests/tests/tier0/bluechi-agent-switch-controller/test_bluechi_agent_switch_controller.py
@@ -1,0 +1,36 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+from typing import Dict
+
+from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
+from bluechi_test.test import BluechiTest
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    node_foo = nodes["node-foo"]
+
+    result, output = node_foo.run_python(os.path.join("python", "switch_controller.py"))
+    if result != 0:
+        raise Exception(output)
+
+
+def test_bluechi_agent_switch_controller(
+    bluechi_test: BluechiTest,
+    bluechi_ctrl_default_config: BluechiControllerConfig,
+    bluechi_node_default_config: BluechiAgentConfig,
+):
+
+    bluechi_node_default_config.node_name = "node-foo"
+    bluechi_ctrl_default_config.allowed_node_names = [
+        bluechi_node_default_config.node_name
+    ]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_agent_config(bluechi_node_default_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
This PR adds an integration test for agent controller switching and fixes to report the agent's changed orch_addr.

Relates to https://github.com/eclipse-bluechi/bluechi/issues/819