### PR TITLE
Use Eclipse branding and trademarks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Eclipse BlueChi
+# Contributing to Eclipse BlueChi&trade;
 
 Thank you for your interest in Eclipse BlueChi.
 

--- a/README.developer.md
+++ b/README.developer.md
@@ -1,5 +1,5 @@
 
-# BlueChi
+# Eclipse BlueChi&trade;
 
 - [Development](#development)
   - [Environment Setup](#environment-setup)

--- a/README.maintainer.md
+++ b/README.maintainer.md
@@ -1,4 +1,4 @@
-# BlueChi
+# Eclipse BlueChi&trade;
 
 ## Creating a new release
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <!-- markdownlint-disable-file MD041 -->
 ![BlueChi logo](https://raw.githubusercontent.com/eclipse-bluechi/bluechi/main/logo/bluechi-logo-horiz.png)
 
-# BlueChi: A systemd service controller for multi-node environments
+# Eclipse BlueChi&trade; : A systemd service controller for multi-node environments
 
 [![Copr build status](https://copr.fedorainfracloud.org/coprs/g/centos-automotive-sig/bluechi-snapshot/package/bluechi/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/g/centos-automotive-sig/bluechi-snapshot/package/bluechi/)
 [![Integration Tests](https://github.com/eclipse-bluechi/bluechi/actions/workflows/integration-tests.yml/badge.svg?branch=main)](https://github.com/eclipse-bluechi/bluechi/actions/workflows/integration-tests.yml)
 [![Unit Tests](https://github.com/eclipse-bluechi/bluechi/actions/workflows/unit-tests.yml/badge.svg?branch=main)](https://github.com/eclipse-bluechi/bluechi/actions/workflows/unit-tests.yml)
 [![Coverage Status](https://coveralls.io/repos/github/eclipse-bluechi/bluechi/badge.svg?branch=main)](https://coveralls.io/github/eclipse-bluechi/bluechi?branch=main)
 
-BlueChi (formerly know as hirte) is a systemd service controller intended for
+Eclipse BlueChi&trade; (formerly know as hirte) is a systemd service controller intended for
 multi-node environments with a predefined number of nodes and with a focus on
 highly regulated ecosystems such as those requiring functional safety.
 Potential use cases can be found in domains such as transportation, where

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,4 @@
-# BlueChi's documentation pages
+# Eclipse BlueChi&trade; documentation pages
 
 Here are stored the source for BlueChi's documentation.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,5 +1,4 @@
-BlueChi's documentation pages
-===========================
+# BlueChi's documentation pages
 
 Here are stored the source for BlueChi's documentation.
 
@@ -7,42 +6,40 @@ This documentation is built using [mkdocs](https://www.mkdocs.org/) and thus
 relies on [markdown](https://daringfireball.net/projects/markdown/) for its
 syntax.
 
-Building the doc locally
-------------------------
+## Building the doc locally
 
 We recommend using python's virtual environment to build the doc locally should
 you need or want to.
 
 Install python's virtualenvwrapper:
 
-``
+```shell
 dnf install python3-virtualenvwrapper
-``
+```
 
 Initiate the virtual environment:
 
-``
+```shell
 mkvirtualenv mkdocs
-``
+```
 
-..Note: you may have to restart your shell for this command to become available.
+**Note:** you may have to restart your shell for this command to become available.
 
 Install the dependencies used for building the documentation:
 
-``
+```shell
 pip install -r requirements.txt
-``
+```
 
 You can then preview the documentation using:
 
-``
+```shell
 mkdocs serve -f doc/mkdocs.yml
-``
+```
 
-..Note: we recommend that you run `mkdocs` from the top level directory.
+**Note**: we recommend that you run `mkdocs` from the top level directory.
 
-Some quick command for virtualenvwrapper
-----------------------------------------
+## Some quick command for virtualenvwrapper
 
 * Create a new virtual environment: `mkvirtualenv`
 

--- a/doc/docs/api/examples.md
+++ b/doc/docs/api/examples.md
@@ -7,7 +7,7 @@ There are a number of bindings for the D-Bus protocol for a range of programming
 
 The following sections demonstrate how the D-Bus API of BlueChi can be interacted with using bindings from different programming languages by showing small snippets.
 
-!!! Note
+!!! note
 
     All snippets require to be run on the machine where BlueChi is running. The only exception is the example for [monitoring the connection status of the agent](#monitor-the-connection-on-the-managed-node), which has to be executed on the managed node where the BlueChi agent is running.
 
@@ -25,9 +25,9 @@ The following sections demonstrate how the D-Bus API of BlueChi can be interacte
 
     --8<-- "api-examples/rust/setup.md"
 
-!!! Note
+!!! note
 
-        Depending on the setup of BlueChi root privileges might be needed when running the samples.
+    Depending on the setup of BlueChi root privileges might be needed when running the samples.
 
 ## Getting information
 

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -1,8 +1,8 @@
-# BlueChi
+# Eclipse BlueChi&trade;
 
-## What is BlueChi?
+## What is Eclipse BlueChi?
 
-BlueChi (formerly known as hirte) is a deterministic multi-node service controller.
+Eclipse BlueChi (formerly known as hirte) is a deterministic multi-node service controller.
 
 BlueChi can manage the states of different services across multiple nodes with a
 focus on highly regulated industries, such as those requiring functional safety.

--- a/doc/man/bluechi-agent.1.md
+++ b/doc/man/bluechi-agent.1.md
@@ -10,7 +10,7 @@ bluechi-agent - Agent managing services on the local machine
 
 ## DESCRIPTION
 
-BlueChi is a systemd service controller intended for multi-node environment with a predefined number of nodes and with a focus on highly regulated environment such as those requiring functional safety (for example in cars).
+Eclipse BlueChi™ is a systemd service controller intended for multi-node environment with a predefined number of nodes and with a focus on highly regulated environment such as those requiring functional safety (for example in cars).
 
 A `bluechi-agent` establishes a peer-to-peer connection to `bluechi` and exposes its API to manage systemd units on it.
 

--- a/doc/man/bluechi-controller.1.md
+++ b/doc/man/bluechi-controller.1.md
@@ -10,7 +10,7 @@ bluechi-controller - Controller of services across agents
 
 ## DESCRIPTION
 
-BlueChi is a systemd service controller intended for multi-nodes environments with a predefined number of nodes and with a focus on highly regulated environment such as those requiring functional safety (for example in cars).
+Eclipse BlueChi™ is a systemd service controller intended for multi-nodes environments with a predefined number of nodes and with a focus on highly regulated environment such as those requiring functional safety (for example in cars).
 
 The bluechi controller offers its public API on the local DBus and uses the DBus APIs provided by all connected `bluechi-agents` to manage systemd services on those remote systems.
 

--- a/doc/man/bluechi-proxy.1.md
+++ b/doc/man/bluechi-proxy.1.md
@@ -10,7 +10,7 @@ bluechi-proxy - Proxy requesting services on other agents
 
 ## DESCRIPTION
 
-BlueChi is a service orchestrator tool intended for multi-node devices
+Eclipse BlueChi™ is a service orchestrator tool intended for multi-node devices
 (e.g.: edge devices) clusters with a predefined number of nodes and
 with a focus on highly regulated environment such as those requiring
 functional safety (for example in cars).

--- a/doc/man/bluechictl.1.md
+++ b/doc/man/bluechictl.1.md
@@ -10,7 +10,7 @@ bluechictl - Simple command line tool to interact with the public D-Bus API of b
 
 ## DESCRIPTION
 
-A simple command line tool that uses the public D-Bus API provided by `bluechi` to manage services on all connected `bluechi-agents` and retrieve information from them.
+A simple command line tool that uses the public D-Bus API provided by Eclipse BlueChi™ to manage services on all connected `bluechi-agents` and retrieve information from them.
 
 **bluechictl [OPTIONS]**
 

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -4,7 +4,7 @@ repo_url: https://github.com/eclipse-bluechi/bluechi
 repo_name: bluechi
 edit_uri: blob/main/doc/docs/
 
-copyright: © Red Hat
+copyright: Copyright Contributors to the Eclipse BlueChi project
 nav:
   - Home: index.md
   - Architecture: architecture.md
@@ -47,6 +47,16 @@ theme:
   features:
     - content.code.copy
     - navigation.indexes
+  custom_dir: overrides
+
+extra:
+  social:
+    - icon: fontawesome/regular/envelope
+      link: https://accounts.eclipse.org/mailing-list/bluechi-dev
+      name: Developer mailing list
+    - icon: fontawesome/brands/github
+      link: https://github.com/eclipse-bluechi/bluechi
+      name: GitHub
 
 extra_javascript:
   - assets/js/tab-sync.js

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: BlueChi Documentation
+site_name: Eclipse BlueChi&trade;
 
 repo_url: https://github.com/eclipse-bluechi/bluechi
 repo_name: bluechi

--- a/doc/overrides/main.html
+++ b/doc/overrides/main.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block footer %}
+  <!-- Add original footer content -->
+  {{ super() }}
+  <!-- Add custom footer -->
+  <footer class="md-footer">
+    <div class="md-footer-meta">
+        <div class="md-footer-meta__inner md-grid">
+            <div class="md-copyright">&nbsp;</div>
+            <div class="md-copyright">
+                <a href="https://eclipse.org/" target="_blank" rel="noopener">Eclipse Foundation</a>
+                &nbsp;|&nbsp;
+                <a href="https://eclipse.org/legal/privacy.php" target="_blank" rel="noopener">Privacy Policy</a>
+                &nbsp;|&nbsp;
+                <a href="https://eclipse.org/legal/termsofuse.php" target="_blank" rel="noopener">Terms of Use</a>
+                &nbsp;|&nbsp;
+                <a href="https://eclipse.org/legal/copyright.php" target="_blank" rel="noopener">Copyright Agent</a>
+                &nbsp;|&nbsp;
+                <a href="https://eclipse.org/legal/" target="_blank" rel="noopener">Legal</a>
+                &nbsp;|&nbsp;
+                <a href="https://github.com/eclipse-bluechi/bluechi?tab=LGPL-2.1-1-ov-file#readme" target="_blank" rel="noopener">License</a>
+                &nbsp;|&nbsp;
+                <a href="https://eclipse.org/security/" target="_blank" rel="noopener">Report a Vulnerability</a>
+            </div>
+            <div class="md-copyright">&nbsp;</div>
+        </div>
+    </div>
+  </footer>
+{% endblock %}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable-file MD013 -->
-# BlueChi integration test
+# Eclipse BlueChi&trade; integration tests
 
 ## Installation
 


### PR DESCRIPTION
- **Use standard instead of alternate markdown syntax**
- **Use project formal name in first and all prominent references**
- **Add social links to the footer**
- **Add links required by Eclipse to website footer**
- **Add trade mark to man pages**
