### PR TITLE
Use latest tmt version 1.32

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Install unpackaged python libraries from PyPi
         run: |
-          pip install "tmt[provision]==1.30" "tmt[report-junit]==1.30" podman pytest pyyaml paramiko
+          pip install "tmt[provision]>=1.32.1" "tmt[report-junit]>=1.32.1" podman pytest pyyaml paramiko
 
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,4 +3,4 @@ junit-xml >= 1.9
 pytest >= 7.3.1
 podman >= 4.5.0
 strato-skipper >= 2.0.2
-tmt >= 1.22
+tmt >= 1.32.1


### PR DESCRIPTION
Issue https://github.com/teemtee/tmt/issues/2673 was fixed in tmt 1.32, so we
can remove pinning to version 1.30

Signed-off-by: Martin Perina <mperina@redhat.com>
