### PR TITLE
Change selinux policy to permissive

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -53,7 +53,10 @@ jobs:
     targets:
       # Run integration tests on Fedora using CS9 containers, because running integrations tests on CS9 using CS9
       # containers is very flaky
-      - fedora-rawhide-x86_64
+      # 
+      # This can be set to fedora-rawhide as soon as the following issue gets resolved:
+      # https://github.com/containers/podman/issues/22422
+      - fedora-latest-stable-x86_64
 
   - job: tests
     trigger: pull_request
@@ -68,7 +71,10 @@ jobs:
     targets:
       # Run integration tests on Fedora using CS9 containers, because running integrations tests on CS9 using CS9
       # containers is very flaky
-      - fedora-rawhide-x86_64
+      # 
+      # This can be set to fedora-rawhide as soon as the following issue gets resolved:
+      # https://github.com/containers/podman/issues/22422
+      - fedora-latest-stable-x86_64
 
   - job: copr_build
     trigger: commit

--- a/selinux/bluechi.te
+++ b/selinux/bluechi.te
@@ -25,6 +25,9 @@ corenet_port(bluechi_port_t)
 type bluechi_agent_port_t;
 corenet_port(bluechi_agent_port_t)
 
+permissive bluechi_t;
+permissive bluechi_agent_t;
+
 
 ########################################
 #

--- a/tests/scripts/tests-setup.sh
+++ b/tests/scripts/tests-setup.sh
@@ -110,7 +110,8 @@ function setup_container_test(){
         -t $BLUECHI_IMAGE_NAME \
         .
     if [[ $? -ne 0 ]]; then
-        exit 1
+        echo "podman build failed"
+        exit 123
     fi
 
     if [ "$(systemctl --user is-active podman.socket)" != "active" ]; then


### PR DESCRIPTION
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/879
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/883
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/884

This is a temporary fix to get BlueChi with its SELinux policy to work again as it is currently broken. As soon as the policy is refined (https://github.com/eclipse-bluechi/bluechi/issues/883) this change can be reversed and the policy enforced again.

It also includes a (temporary) workaround for https://github.com/containers/podman/issues/22422 to use the latest stable fedora instead of rawhide (for now).
