### PR TITLE
Fix multihost tests

### DIFF
--- a/tests/bluechi_test/client.py
+++ b/tests/bluechi_test/client.py
@@ -179,7 +179,10 @@ class SSHClient(Client):
             LOGGER.debug(
                 f"Executed command '{command}' with result '{result}' and output '{output}' and error '{err}'"
             )
-            return result, output
+
+            # concatenate stderr and stdout so exec_run of SSHClient
+            # outputs the same content as ContainerClient
+            return result, err + output
         finally:
             if stdin is not None:
                 stdin.close()

--- a/tests/bluechi_test/machine.py
+++ b/tests/bluechi_test/machine.py
@@ -171,16 +171,20 @@ class BluechiMachine:
             # This message is relevant for `finish` phase, where code coverage report is being created
             LOGGER.info("bluechilib directory not found, proceeding")
             return
-        ret, _ = self.exec_run("mkdir /tmp/bluechi_machine_lib")
-        if ret == 0:
-            # If the directory was successfully created, then fill it with files
-            # If not - it must already exist
+
+        machine_lib_dir = "/tmp/bluechi_machine_lib"
+        _, output = self.client.exec_run(f"[ -d {machine_lib_dir} ] && echo 'exists'")
+        if output != "exists":
+            self.exec_run(f"mkdir {machine_lib_dir}")
             for filename in os.listdir(source_dir):
                 source_path = os.path.join(source_dir, filename)
                 if os.path.isfile(source_path) and source_path.endswith(".py"):
                     content = read_file(source_path)
-                    target_dir = os.path.join("/", "tmp", "bluechi_machine_lib")
-                    self.create_file(target_dir, filename, content)
+                    target_dir = os.path.join("/", "tmp", machine_lib_dir)
+
+                    # Use client directly to bypass the tracking mechanism
+                    # We don't want to clean up the bluechi_machine_lib files once created
+                    self.client.create_file(target_dir, filename, content)
 
     def wait_for_bluechi_agent(self):
         should_wait = True

--- a/tests/bluechi_test/test.py
+++ b/tests/bluechi_test/test.py
@@ -443,14 +443,14 @@ class BluechiSSHTest(BluechiTest):
             machine.systemctl.stop_unit(service, check_result=False)
             machine.systemctl.reset_failed_for_unit(service, check_result=False)
 
-        LOGGER.info("Removing created files...")
-        cmd_rm_created_files = "rm " + " ".join(machine.created_files)
-        machine.client.exec_run(cmd_rm_created_files)
-
         LOGGER.info("Restoring changed files...")
         for changed_file in machine.changed_files:
             backup_file = changed_file + BluechiMachine.backup_file_suffix
             machine.client.exec_run(f"mv {backup_file} {changed_file}")
+
+        LOGGER.info("Removing created files...")
+        cmd_rm_created_files = "rm " + " ".join(machine.created_files)
+        machine.client.exec_run(cmd_rm_created_files)
 
         # ensure changed systemd services are reloaded
         machine.systemctl.daemon_reload()

--- a/tests/tests/tier0/bluechi-invalid-port/test_agent_invalid_port.py
+++ b/tests/tests/tier0/bluechi-invalid-port/test_agent_invalid_port.py
@@ -15,6 +15,7 @@ def exec(ctrl: BluechiControllerMachine, _: Dict[str, BluechiAgentMachine]):
     assert ctrl.wait_for_unit_state_to_be("bluechi-controller", "active")
 
     original_cfg = ctrl.config.deep_copy()
+    original_cfg.file_name = "zzz-ctrl.conf"
 
     # port contains an 'O' instead of a '0'
     new_cfg = original_cfg.deep_copy()


### PR DESCRIPTION
Even after changing the SELinux policy back to permissive mode (https://github.com/eclipse-bluechi/bluechi/pull/885), quite a lot of integration tests on multihost mode were still failing. This PR contains multiple commits tackling these issues:

#### Use different file name for ctrl config

#### concatenate stderr and stdout in sshclient
The client for the podman container seems to concatenate stderr and stdout in its output parameter. In the SSH client stderr and stdout are different return variables. In order to not break the `exec_run` API of the Client class and still get a uniform behavior of both clients, lets concat stderr and stdout in the SSH client.

#### actively check if bluechi_machine_lib exists

In order to avoid failing mkdir calls on subsequent tests for the bluechi_machine_lib, an active check is being made. If it doesn't exist yet, we create the directory and the library files. These files are not tracked and thus not deleted after a test. This way, we only create the lib once.

#### switch order of restoring created and changed files

When creating files, we first keep track of them in the list for newly created ones. If a file is already in that list and another file with the same path (dir+name) is created we keep create a backup and track it.
For clean-up we need to reverse that order - first restore tracked backup files and then remove created files. This ensures that there are no dangling files.

---

1) Example run with test failures:
http://artifacts.osci.redhat.com/testing-farm/c028903c-1611-4a93-be04-686594d8a210/

2) Example run after fixes: 
http://artifacts.osci.redhat.com/testing-farm/754765a9-2181-462a-b4e3-688adf697743/
The flaky propagate test failed, unfortunately. This will be tackled in https://github.com/eclipse-bluechi/bluechi/issues/874)