### PR TITLE
Added workflow to create SBOMs for BlueChi

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,75 @@
+name: Software Bill of Materials
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/bluechi/build-base:latest
+    env:
+      ARTIFACTS_DIR: /tmp/bluechi-artifacts
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+          ref: ${{ github.ref_name }}
+
+      - name: Mark source directory as safe
+        run: |
+          git config --global --add safe.directory $(pwd)
+
+      - name: Perform build
+        run: |
+          ./build-scripts/build-rpm.sh $ARTIFACTS_DIR
+
+      - name: Create DNF repository
+        run: |
+          createrepo_c $ARTIFACTS_DIR
+      
+      - name: Install RPMs and dependencies
+        run: |
+          dnf install python3-dasbus -y
+          dnf install --repo bluechi-rpms \
+            --repofrompath bluechi-rpms,file://$ARTIFACTS_DIR \
+            --nogpgcheck \
+            --nodocs \
+            bluechi-controller \
+            bluechi-agent \
+            bluechi-ctl \
+            bluechi-selinux \
+            python3-bluechi \
+            -y
+      
+      - name: Install SBOM4RPMs
+        run: | 
+          python3 -m ensurepip --default-pip
+          python3 -m pip install sbom4rpms
+      
+      - name: Run SBOM analysis
+        run: |
+          mkdir -p /tmp/sboms/
+          
+          sbom4rpms \
+            --rpm-dir=$ARTIFACTS_DIR \
+            --sbom-dir=/tmp/bluechi-sboms \
+            --git-dir=./ \
+            --sbom-format=spdx \
+            --collect-dependencies
+
+          sbom4rpms \
+            --rpm-dir=$ARTIFACTS_DIR \
+            --sbom-dir=/tmp/bluechi-sboms \
+            --sbom-format=cyclonedx
+      
+      - name: Upload SBOMs
+        uses: actions/upload-artifact@v4
+        with:
+          name: bluechi-sboms
+          path: /tmp/bluechi-sboms
+          
+


### PR DESCRIPTION
By using [sbom4rpms](https://github.com/engelmi/sbom4rpm) (an early version) on the built BlueChi RPMs, runtime dependencies can be resolved, collected and put into SPDX or CycloneDX SBOM format. 
This PR adds a new workflow to generate those. It is triggered only manually for now since it takes quite a while to finish (~15min) on a publish GitHub runner.

Example run with `bluechi-sboms` as artifact:
GH Action: https://github.com/engelmi/bluechi/actions/runs/8801089769
Artifacts: [bluechi-sboms.zip](https://github.com/eclipse-bluechi/bluechi/files/15077842/bluechi-sboms.zip)

