### PR TITLE
Fix to get peer ip address

### DIFF
--- a/src/client/method-status.c
+++ b/src/client/method-status.c
@@ -540,14 +540,14 @@ static void print_nodes(Nodes *nodes, bool clear_screen) {
         }
 
         /* print monitor header */
-        printf("%-30.30s| %-10.10s| %-15.15s| %-28.28s\n", "NODE", "STATE", "IP", "LAST SEEN");
+        printf("%-30.30s| %-10.10s| %-24.24s| %-28.28s\n", "NODE", "STATE", "IP", "LAST SEEN");
         printf("==========================================================================================\n");
 
         Node *curr = NULL;
         Node *next = NULL;
         LIST_FOREACH_SAFE(nodes, curr, next, nodes->nodes) {
                 _cleanup_free_ char *last_seen = node_connection_fmt_last_seen(curr->connection);
-                printf("%-30.30s| %-10.10s| %-15.15s| %-28.28s\n",
+                printf("%-30.30s| %-10.10s| %-24.24s| %-28.28s\n",
                        curr->connection->name,
                        curr->connection->state,
                        curr->connection->ip,

--- a/src/controller/node.c
+++ b/src/controller/node.c
@@ -645,7 +645,7 @@ bool node_set_agent_bus(Node *node, sd_bus *bus) {
         // If getting peer IP fails, only log and proceed as normal.
         _cleanup_free_ char *peer_ip = NULL;
         uint16_t peer_port = 0;
-        r = get_peer_address(node->agent_bus, false, &peer_ip, &peer_port);
+        r = get_peer_address(node->agent_bus, &peer_ip, &peer_port);
         if (r < 0) {
                 bc_log_errorf("Failed to get peer IP: %s", strerror(-r));
         } else {

--- a/src/libbluechi/bus/bus.h
+++ b/src/libbluechi/bus/bus.h
@@ -18,4 +18,4 @@ sd_bus *system_bus_open(sd_event *event);
 sd_bus *systemd_bus_open(sd_event *event);
 sd_bus *user_bus_open(sd_event *event);
 
-int get_peer_address(sd_bus *bus, bool ipv6, char **ret_address, uint16_t *ret_port);
+int get_peer_address(sd_bus *bus, char **ret_address, uint16_t *ret_port);


### PR DESCRIPTION
If we try to read the IP address from a struct sockaddr_in while getpeername() filled it with struct sockaddr_in6 information, we are actually reading the sin6_flowinfo part of the struct sockaddr_in6. That flow information is usually zero, unless the connection is explicitely flagged with a flow ID. So we would read a zeroed IP address.

Reference: https://stackoverflow.com/a/25640794

AS-IS
```
root@42dot-ak7:~# bluechictl status
NODE                          | STATE     | IP             | LAST SEEN
==========================================================================================
ak7_master_main               | online    | 0.0.0.0        | now
ak7_master_sub                | online    | 0.0.0.0        | now
```
TO-BE
```
root@42dot-ak7:~# bluechictl status
NODE                          | STATE     | IP                      | LAST SEEN
==========================================================================================
ak7_master_main               | online    | ::ffff:192.168.16.103   | now
ak7_master_sub                | online    | ::ffff:192.168.16.104   | now
```