### PR TITLE
Use the GitHub Action of TF for multihost

### DIFF
--- a/.github/workflows/multihost-tests.yml
+++ b/.github/workflows/multihost-tests.yml
@@ -51,12 +51,12 @@ jobs:
           python3 -m pip install tft-cli
 
       - name: Start Integration Tests on testing farm
-        run: |
-          testing-farm version
-          TESTING_FARM_API_TOKEN=${{ secrets.TESTING_FARM_API_TOKEN }} testing-farm request \
-            --path tests \
-            --git-ref ${{ github.ref_name }} \
-            --git-url https://github.com/eclipse-bluechi/bluechi.git \
-            --compose ${{ inputs.composes }} \
-            --plan multihost \
-            --pipeline-type tmt-multihost
+        uses: sclorg/testing-farm-as-github-action@v2.2.0
+        with:
+          api_key: ${{ secrets.TESTING_FARM_API_TOKEN }}
+          git_url: https://github.com/eclipse-bluechi/bluechi.git
+          git_ref: ${{ github.ref_name }}
+          tmt_path: tests
+          tmt_plan_regex: multihost
+          compose: ${{ inputs.composes }}
+          pipeline_settings: {"type": "tmt-multihost"}

--- a/.github/workflows/multihost-tests.yml
+++ b/.github/workflows/multihost-tests.yml
@@ -42,6 +42,7 @@ jobs:
           api_key: ${{ secrets.TESTING_FARM_API_TOKEN }}
           git_url: https://github.com/eclipse-bluechi/bluechi.git
           git_ref: ${{ github.ref_name }}
+          tf_scope: private
           tmt_path: tests
           tmt_plan_regex: multihost
           compose: ${{ inputs.composes }}

--- a/.github/workflows/multihost-tests.yml
+++ b/.github/workflows/multihost-tests.yml
@@ -34,22 +34,8 @@ jobs:
   ghrelease:
     name: Run Integration Tests on testing farm in multihost mode
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/bluechi/build-base:latest
 
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: 'true'
-
-      - name: Install testing farm CLI
-        run: |
-          python3 -m ensurepip --default-pip
-          python3 -m pip install --upgrade pip
-          python3 -m pip install tft-cli
-
       - name: Start Integration Tests on testing farm
         uses: sclorg/testing-farm-as-github-action@v2.2.0
         with:

--- a/.github/workflows/multihost-tests.yml
+++ b/.github/workflows/multihost-tests.yml
@@ -59,4 +59,4 @@ jobs:
           tmt_path: tests
           tmt_plan_regex: multihost
           compose: ${{ inputs.composes }}
-          pipeline_settings: {"type": "tmt-multihost"}
+          pipeline_settings: '{"type": "tmt-multihost"}'


### PR DESCRIPTION
The option to define pipeline settings, incl. multihost, has been added in a recent release of the testing farm github action:
https://github.com/sclorg/testing-farm-as-github-action/releases/tag/v2.2.0