### PR TITLE
Replace bluechi-controller by bluechi-agent in docs

### DIFF
--- a/doc/docs/getting_started/single_node.md
+++ b/doc/docs/getting_started/single_node.md
@@ -41,7 +41,7 @@ AllowedNodeNames=<hostname>
 
 $ cat /etc/bluechi/agent.conf.d/1.conf
 
-[bluechi-controller]
+[bluechi-agent]
 ControllerPort=2020
 ```
 


### PR DESCRIPTION
This commit fixes the single node getting started documentation with the bluechi-agent header in the agent.conf.d file