### PR TITLE
controller: Proactively disconnect node based on heartbeat

### DIFF
--- a/config/agent/agent.conf
+++ b/config/agent/agent.conf
@@ -26,7 +26,7 @@
 #ControllerAddress=
 
 #
-# Defines the interval between two heartbeat signals sent to bluechi in milliseconds.
+# Defines the interval between two heartbeat signals sent to bluechi in milliseconds. A value of 0 disables it.
 #HeartbeatInterval=2000
 
 #

--- a/config/controller/controller.conf
+++ b/config/controller/controller.conf
@@ -17,6 +17,16 @@
 #ControllerPort=842
 
 #
+# Defines the interval for which the bluechi-controller periodically checks the connectivity of all nodes based on
+# the received heartbeat signals sent to bluechi-agent to bluechi-controller, in milliseconds.
+#HeartbeatInterval=0
+
+#
+# Defines the threshold to actively disconnect nodes based on the time difference from the last received heartbeat
+# signal from the respective bluechi-agent. In milliseconds.
+#NodeHeartbeatThreshold=6000
+
+#
 # The level used for logging. Supported values are: DEBUG, INFO, WARN and ERROR.
 #LogLevel=INFO
 

--- a/doc/man/bluechi-controller.conf.5.md
+++ b/doc/man/bluechi-controller.conf.5.md
@@ -27,6 +27,14 @@ A comma separated list of unique bluechi-agent names. It's mandatory to set the 
 in the list can connect to `bluechi-controller'. These names are defined in the agent's configuration file under `NodeName`
 option (see `bluechi-agent.conf(5)`).
 
+#### **HeartbeatInterval** (long)
+
+The interval to periodically check node's connectivity based on heartbeat signals sent to bluechi, in milliseconds. A value of 0 disables it.
+
+#### **NodeHeartbeatThreshold** (long)
+
+The threshold in milliseconds to determine whether a node is disconnected. If the node's last heartbeat signal was received before this threshold, bluechi assumes that the node is down or the connection was cut off and performs a disconnect.
+
 #### **LogLevel** (string)
 
 The level used for logging. Supported values are:

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -187,7 +187,8 @@ static int agent_setup_heartbeat_timer(Agent *agent) {
         assert(agent);
 
         if (agent->heartbeat_interval_msec <= 0) {
-                bc_log_warnf("Heartbeat disabled since interval is '%d', ", agent->heartbeat_interval_msec);
+                bc_log_warnf("Heartbeat disabled since configured interval '%d' is <=0",
+                             agent->heartbeat_interval_msec);
                 return 0;
         }
 

--- a/src/client/method-status.c
+++ b/src/client/method-status.c
@@ -488,8 +488,8 @@ static char *node_connection_fmt_last_seen(NodeConnection *con) {
         }
 
         struct timespec t;
-        t.tv_sec = (time_t) con->last_seen;
-        t.tv_nsec = 0;
+        t.tv_sec = (time_t) con->last_seen / USEC_PER_SEC;
+        t.tv_nsec = (long) (con->last_seen % USEC_PER_SEC) * NSEC_PER_USEC;
         return get_formatted_log_timestamp_for_timespec(t, false);
 }
 

--- a/src/controller/controller.h
+++ b/src/controller/controller.h
@@ -19,6 +19,8 @@ struct Controller {
 
         uint16_t port;
         char *api_bus_service_name;
+        long heartbeat_interval_msec;
+        long heartbeat_threshold_msec;
 
         sd_event *event;
         sd_event_source *node_connection_source;

--- a/src/controller/node.c
+++ b/src/controller/node.c
@@ -787,7 +787,7 @@ bool node_set_agent_bus(Node *node, sd_bus *bus) {
                         bc_log_errorf("Failed to emit status property changed: %s", strerror(-r));
                 }
 
-                sd_bus_match_signal(
+                r = sd_bus_match_signal(
                                 bus,
                                 NULL,
                                 NULL,

--- a/src/controller/node.h
+++ b/src/controller/node.h
@@ -62,7 +62,7 @@ struct Node {
         LIST_HEAD(ProxyDependency, proxy_dependencies);
 
         struct hashmap *unit_subscriptions;
-        time_t last_seen;
+        uint64_t last_seen;
 
         bool is_shutdown;
 };
@@ -71,6 +71,7 @@ Node *node_new(Controller *controller, const char *name);
 Node *node_ref(Node *node);
 void node_unref(Node *node);
 void node_shutdown(Node *node);
+void node_disconnect(Node *node);
 
 const char *node_get_status(Node *node);
 

--- a/src/libbluechi/common/cfg.c
+++ b/src/libbluechi/common/cfg.c
@@ -507,5 +507,18 @@ int cfg_controller_def_conf(struct config *config) {
                 return result;
         }
 
+        if ((result = cfg_set_value(
+                             config, CFG_HEARTBEAT_INTERVAL, CONTROLLER_DEFAULT_HEARTBEAT_INTERVAL_MSEC)) !=
+            0) {
+                return result;
+        }
+
+        if ((result = cfg_set_value(
+                             config,
+                             CFG_HEARTBEAT_THRESHOLD,
+                             CONTROLLER_DEFAULT_NODE_HEARTBEAT_THRESHOLD_MSEC)) != 0) {
+                return result;
+        }
+
         return 0;
 }

--- a/src/libbluechi/common/cfg.h
+++ b/src/libbluechi/common/cfg.h
@@ -20,6 +20,7 @@
 #define CFG_NODE_NAME "NodeName"
 #define CFG_ALLOWED_NODE_NAMES "AllowedNodeNames"
 #define CFG_HEARTBEAT_INTERVAL "HeartbeatInterval"
+#define CFG_HEARTBEAT_THRESHOLD "NodeHeartbeatThreshold"
 #define CFG_IP_RECEIVE_ERRORS "IPReceiveErrors"
 #define CFG_TCP_KEEPALIVE_TIME "TCPKeepAliveTime"
 #define CFG_TCP_KEEPALIVE_INTERVAL "TCPKeepAliveInterval"

--- a/src/libbluechi/common/protocol.h
+++ b/src/libbluechi/common/protocol.h
@@ -10,6 +10,7 @@
 /* Time constants */
 #define USEC_PER_SEC 1000000
 #define USEC_PER_MSEC 1000
+#define NSEC_PER_USEC 1000
 
 /* Configuration defaults */
 #define BC_DEFAULT_PORT "842"
@@ -26,6 +27,8 @@
 #define BC_DEFAULT_DBUS_TIMEOUT ((uint64_t) (USEC_PER_SEC * 30))
 /* Application-level heartbeat interval */
 #define AGENT_DEFAULT_HEARTBEAT_INTERVAL_MSEC "2000"
+#define CONTROLLER_DEFAULT_HEARTBEAT_INTERVAL_MSEC "0"
+#define CONTROLLER_DEFAULT_NODE_HEARTBEAT_THRESHOLD_MSEC "6000"
 
 
 /* BlueChi DBus service names */

--- a/tests/bluechi_test/config.py
+++ b/tests/bluechi_test/config.py
@@ -32,6 +32,8 @@ class BluechiControllerConfig(BluechiConfig):
         name: str = "bluechi-controller",
         port: str = "8420",
         allowed_node_names: List[str] = [],
+        heartbeat_interval: str = "0",
+        node_heartbeat_threshold: str = "6000",
         log_level: str = "DEBUG",
         log_target: str = "journald",
         log_is_quiet: bool = False,
@@ -41,6 +43,8 @@ class BluechiControllerConfig(BluechiConfig):
         self.name = name
         self.port = port
         self.allowed_node_names = allowed_node_names
+        self.heartbeat_interval = heartbeat_interval
+        self.node_heartbeat_threshold = node_heartbeat_threshold
         self.log_level = log_level
         self.log_target = log_target
         self.log_is_quiet = log_is_quiet
@@ -53,6 +57,8 @@ class BluechiControllerConfig(BluechiConfig):
         return f"""[bluechi-controller]
 ControllerPort={self.port}
 AllowedNodeNames={allowed_node_names}
+HeartbeatInterval={self.heartbeat_interval}
+NodeHeartbeatThreshold={self.node_heartbeat_threshold}
 LogLevel={self.log_level}
 LogTarget={self.log_target}
 LogIsQuiet={self.log_is_quiet}

--- a/tests/tests/tier0/bluechi-heartbeat-disabled/main.fmf
+++ b/tests/tests/tier0/bluechi-heartbeat-disabled/main.fmf
@@ -1,0 +1,3 @@
+summary: Test if default configuration of controller disables periodic heartbeat of
+    the controller
+id: a04517f6-8be1-468b-8dc0-f9674690f73f

--- a/tests/tests/tier0/bluechi-heartbeat-disabled/python/is_node_connected.py
+++ b/tests/tests/tier0/bluechi-heartbeat-disabled/python/is_node_connected.py
@@ -1,0 +1,35 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import time
+import unittest
+
+from dasbus.typing import Variant
+
+from bluechi.api import Node
+
+
+class TestNodeIsConnected(unittest.TestCase):
+    def test_node_is_connected(self):
+
+        def on_state_change(state: Variant):
+            assert False
+
+        n = Node("node-foo")
+        assert n.status == "online"
+
+        n.on_status_changed(on_state_change)
+        timestamp = n.last_seen_timestamp
+
+        # verify that the node remains connected and LastSeenTimespamp is not
+        # updated after more than NodeHeartbeatThreshold seconds have elapsed
+        time.sleep(10)
+
+        assert n.status == "online"
+        assert n.last_seen_timestamp == timestamp
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechi-heartbeat-disabled/test_bluechi_heartbeat_disabled.py
+++ b/tests/tests/tier0/bluechi-heartbeat-disabled/test_bluechi_heartbeat_disabled.py
@@ -1,0 +1,36 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+from typing import Dict
+
+from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
+from bluechi_test.test import BluechiTest
+
+node_foo_name = "node-foo"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    result, output = ctrl.run_python(os.path.join("python", "is_node_connected.py"))
+    if result != 0:
+        raise Exception(output)
+
+
+def test_bluechi_heartbeat_disabled(
+    bluechi_test: BluechiTest,
+    bluechi_ctrl_default_config: BluechiControllerConfig,
+    bluechi_node_default_config: BluechiAgentConfig,
+):
+
+    bluechi_ctrl_default_config.allowed_node_names = [node_foo_name]
+
+    bluechi_node_default_config.node_name = node_foo_name
+    bluechi_node_default_config.heartbeat_interval = "0"
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_agent_config(bluechi_node_default_config)
+
+    bluechi_test.run(exec)

--- a/tests/tests/tier0/bluechi-heartbeat-node-disconnected/main.fmf
+++ b/tests/tests/tier0/bluechi-heartbeat-node-disconnected/main.fmf
@@ -1,0 +1,3 @@
+summary: Test if the node gets disconnected when did not receive heartbeat since
+    threshold from node
+id: 0b087ba3-25fc-46b0-9c01-31bc2edf5209

--- a/tests/tests/tier0/bluechi-heartbeat-node-disconnected/python/is_node_disconnected.py
+++ b/tests/tests/tier0/bluechi-heartbeat-node-disconnected/python/is_node_disconnected.py
@@ -1,0 +1,43 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import time
+import unittest
+
+from dasbus.loop import EventLoop
+from dasbus.typing import Variant
+
+from bluechi.api import Node
+
+
+class TestNodeIsDisconnected(unittest.TestCase):
+
+    node_state = None
+    timestamp = None
+
+    def test_node_is_disconnected(self):
+        loop = EventLoop()
+
+        def on_state_change(state: Variant):
+            self.timestamp = round(time.time() * 1000000)
+            self.node_state = state.get_string()
+            loop.quit()
+
+        n = Node("node-foo")
+        assert n.status == "online"
+
+        n.on_status_changed(on_state_change)
+        timestamp = n.last_seen_timestamp
+
+        loop.run()
+
+        # verify that the node is disconnected after more than
+        # NodeHeartbeatThreshold seconds have elapsed
+        assert self.timestamp - timestamp > 6000000
+        assert self.node_state == "offline"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechi-heartbeat-node-disconnected/test_bluechi_heartbeat_node_disconnected.py
+++ b/tests/tests/tier0/bluechi-heartbeat-node-disconnected/test_bluechi_heartbeat_node_disconnected.py
@@ -1,0 +1,37 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+from typing import Dict
+
+from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
+from bluechi_test.test import BluechiTest
+
+node_foo_name = "node-foo"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    result, output = ctrl.run_python(os.path.join("python", "is_node_disconnected.py"))
+    if result != 0:
+        raise Exception(output)
+
+
+def test_bluechi_heartbeat_node_disconnected(
+    bluechi_test: BluechiTest,
+    bluechi_ctrl_default_config: BluechiControllerConfig,
+    bluechi_node_default_config: BluechiAgentConfig,
+):
+
+    bluechi_ctrl_default_config.allowed_node_names = [node_foo_name]
+    bluechi_ctrl_default_config.heartbeat_interval = "2000"
+
+    bluechi_node_default_config.node_name = node_foo_name
+    bluechi_node_default_config.heartbeat_interval = "0"
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_agent_config(bluechi_node_default_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
This PR is an update of https://github.com/eclipse-bluechi/bluechi/pull/870

The main difference is that the code is simplified by using microseconds in last_seen instead of the struct timespec.
It updates last_seen in node_method_register() to prevent the node disconnecting right now when last_seen is 0 or too old.
Additionally, it handles disconnected nodes by calling node_disconnected() instead of controller_remove_node(). Otherwise an error will occur.
```
bluechi-controller: ../git/src/controller/node.c:123: unit_subscriptions_clear: Assertion `LIST_IS_EMPTY(usubs->subs)' failed.
```

Fixes: https://github.com/eclipse-bluechi/bluechi/issues/857