### PR TITLE
Use `/usr/bin/test` command instead of shell evaluation

### DIFF
--- a/tests/bluechi_test/machine.py
+++ b/tests/bluechi_test/machine.py
@@ -42,8 +42,8 @@ class BluechiMachine:
     def create_file(self, target_dir: str, file_name: str, content: str) -> None:
         target_file = os.path.join(target_dir, file_name)
         try:
-            _, output = self.client.exec_run(f"[ -f {target_file} ] && echo 'exists'")
-            if output == "exists":
+            res, _ = self.client.exec_run(f"/usr/bin/test -f {target_file}")
+            if res == 0:
                 self._track_changed_file(target_dir, file_name)
             else:
                 self.created_files.append(os.path.join(target_dir, file_name))
@@ -173,8 +173,8 @@ class BluechiMachine:
             return
 
         machine_lib_dir = "/tmp/bluechi_machine_lib"
-        _, output = self.client.exec_run(f"[ -d {machine_lib_dir} ] && echo 'exists'")
-        if output != "exists":
+        res, _ = self.client.exec_run(f"/usr/bin/test -d {machine_lib_dir}")
+        if res != 0:
             self.exec_run(f"mkdir {machine_lib_dir}")
             for filename in os.listdir(source_dir):
                 source_path = os.path.join(source_dir, filename)


### PR DESCRIPTION
Replace direct shell evaluation with `/usr/bin/test` command to bypass
confusing output in logs:

shell evaluation output:
```
  Executed command '[ -f /etc/bluechi/controller.conf.d/ctrl.conf ] && echo 'exists'' with result '2' and output '[: missing ']''
```

/usr/bin/test command output:
```
  Executed command '/usr/bin/test -f /etc/bluechi/controller.conf.d/ctrl.conf' with result '1' and output 'b'''
```

Signed-off-by: Martin Perina <mperina@redhat.com>
