### PR TITLE
Added KillUnit API

### DIFF
--- a/data/org.eclipse.bluechi.Node.xml
+++ b/data/org.eclipse.bluechi.Node.xml
@@ -97,12 +97,28 @@
     </method>
 
     <!--
+      KillUnit:
+      @name: The name of the unit to kill
+      @who: One of [main, control, all]
+      @signal: Unix signal number
+
+      Kills processes of a unit on a node. 
+      If the who parameter is set to main, only the main process of a unit is killed. If control is used, then only the control process of the unit is
+    killed. And if all is used, all processes are killed.
+    -->
+    <method name="KillUnit">
+      <arg name="name" type="s" direction="in" />
+      <arg name="who" type="s" direction="in" />
+      <arg name="signal" type="i" direction="in" />
+    </method>
+
+    <!--
       GetUnitProperties:
       @name: The name of unit
       @interface: The interface name
-      @props: The  as key-value pair with the name of the property as key
+      @props: The properties as key-value pair with the name of the property as key
 
-      Returns the current  for a named unit on the node. The returned  are the same as you would get in the systemd  apis.
+      Returns the current for a named unit on the node. The returned are the same as you would get in the systemd apis.
     -->
     <method name="GetUnitProperties">
       <arg name="name" type="s" direction="in" />
@@ -132,7 +148,7 @@
       @runtime: Specify if the changes should persist after reboot or not
       @keyvalues: A list of the new values as key-value pair with the key being the name of the property
 
-      Set named . If runtime is true the property changes do not persist across reboots.
+      Set named properties. If runtime is true the property changes do not persist across reboots.
     -->
     <method name="SetUnitProperties">
       <arg name="name" type="s" direction="in" />
@@ -241,7 +257,6 @@
     <method name="ResetFailedUnit">
       <arg name="name" type="s" direction="in" />
     </method>
-
 
     <!--
       Name:

--- a/data/org.eclipse.bluechi.internal.Agent.xml
+++ b/data/org.eclipse.bluechi.internal.Agent.xml
@@ -32,6 +32,11 @@
       <arg name="mode" type="s" direction="in" />
       <arg name="jobid" type="u" direction="in" />
     </method>
+    <method name="KillUnit">
+      <arg name="name" type="s" direction="in" />
+      <arg name="who" type="s" direction="in" />
+      <arg name="signal" type="i" direction="in" />
+    </method>
     <method name="GetUnitProperties">
       <arg name="name" type="s" direction="in" />
       <arg name="interface" type="s" direction="in" />

--- a/doc/docs/api/description.md
+++ b/doc/docs/api/description.md
@@ -181,6 +181,11 @@ Object path: `/org/eclipse/bluechi/node/$name`
     `DisableUnitFiles()` is similar to `EnableUnitFiles()` but
     disables the specified units by removing all symlinks to them in /etc/ and /run/
 
+  * `KillUnit(in s name, in s who, in i signal)`
+
+    Kills processes of a unit on a node.
+    If the who parameter is set to main, only the main process of a unit is killed. If control is used, then only the control process of the unit is killed. And if all is used, all processes are killed.
+
   * `GetUnitProperties(in s name, in s interface, out a{sv} props)`
 
     Returns the current properties for a named unit on the node. The returned properties are the same as you would
@@ -341,6 +346,12 @@ This is the main interface that the node implements and that is used by the cont
   * `ReloadUnit(in s name, in s mode, in u id)`
 
   * `RestartUnit(in s name, in s mode, in u id)`
+
+  * `ResetFailed()`
+
+  * `ResetFailedUnit(in  s name)`
+
+  * `KillUnit(in s name, in s who, in i signal)`
 
   * `GetUnitProperties(in name, out a{sv} props)`
 

--- a/doc/man/bluechictl.1.md
+++ b/doc/man/bluechictl.1.md
@@ -30,6 +30,21 @@ Print current bluechictl version
 
 Performs one of the listed lifecycle operations on the given systemd unit for the `bluechi-agent`.
 
+### **bluechictl** [*kill*] [*agent*] [*unit*]
+
+Kills the processes of (i.e. sends a signal to) the specified unit on the chosen node. 
+
+**Options:**
+
+**--kill-whom**
+    Enum defining which processes of the unit are killed.
+    Needs to be one of [all, main, control]. Default: all
+
+**--signal**
+    The signal sent to kill the processes of the unit.
+    Default: 15 (SIGTERM)
+
+
 ### **bluechictl** [*enable*] [*agent*] [*unit1*,*...*]
 
 Enable the list of systemd unit files for the `bluechi-agent`.

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -1778,6 +1778,14 @@ static const sd_bus_vtable internal_agent_vtable[] = {
         SD_BUS_METHOD("DisableMetrics", "", "", agent_method_disable_metrics, 0),
         SD_BUS_METHOD("SetLogLevel", "s", "", agent_method_set_log_level, 0),
         SD_BUS_METHOD("JobCancel", "u", "", agent_method_job_cancel, 0),
+        SD_BUS_METHOD("EnableUnitFiles", "asbb", "ba(sss)", agent_method_passthrough_to_systemd, 0),
+        SD_BUS_METHOD("DisableUnitFiles", "asb", "a(sss)", agent_method_passthrough_to_systemd, 0),
+        SD_BUS_METHOD("Reload", "", "", agent_method_passthrough_to_systemd, 0),
+        SD_BUS_METHOD("ResetFailed", "", "", agent_method_passthrough_to_systemd, 0),
+        SD_BUS_METHOD("ResetFailedUnit", "s", "", agent_method_passthrough_to_systemd, 0),
+        SD_BUS_METHOD("KillUnit", "ssi", "", agent_method_passthrough_to_systemd, 0),
+        SD_BUS_METHOD("StartDep", "s", "", agent_method_start_dep, 0),
+        SD_BUS_METHOD("StopDep", "s", "", agent_method_stop_dep, 0),
         SD_BUS_SIGNAL_WITH_NAMES("JobDone", "us", SD_BUS_PARAM(id) SD_BUS_PARAM(result), 0),
         SD_BUS_SIGNAL_WITH_NAMES("JobStateChanged", "us", SD_BUS_PARAM(id) SD_BUS_PARAM(state), 0),
         SD_BUS_SIGNAL_WITH_NAMES(
@@ -1794,13 +1802,6 @@ static const sd_bus_vtable internal_agent_vtable[] = {
                         0),
         SD_BUS_SIGNAL_WITH_NAMES("UnitRemoved", "s", SD_BUS_PARAM(unit), 0),
         SD_BUS_SIGNAL("Heartbeat", "", 0),
-        SD_BUS_METHOD("StartDep", "s", "", agent_method_start_dep, 0),
-        SD_BUS_METHOD("StopDep", "s", "", agent_method_stop_dep, 0),
-        SD_BUS_METHOD("EnableUnitFiles", "asbb", "ba(sss)", agent_method_passthrough_to_systemd, 0),
-        SD_BUS_METHOD("DisableUnitFiles", "asb", "a(sss)", agent_method_passthrough_to_systemd, 0),
-        SD_BUS_METHOD("Reload", "", "", agent_method_passthrough_to_systemd, 0),
-        SD_BUS_METHOD("ResetFailed", "", "", agent_method_passthrough_to_systemd, 0),
-        SD_BUS_METHOD("ResetFailedUnit", "s", "", agent_method_passthrough_to_systemd, 0),
         SD_BUS_VTABLE_END
 };
 

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -885,9 +885,9 @@ class Node(ApiBase):
           GetUnitProperties:
         @name: The name of unit
         @interface: The interface name
-        @props: The  as key-value pair with the name of the property as key
+        @props: The properties as key-value pair with the name of the property as key
 
-        Returns the current  for a named unit on the node. The returned  are the same as you would get in the systemd  apis.
+        Returns the current for a named unit on the node. The returned are the same as you would get in the systemd apis.
         """
         return self.get_proxy().GetUnitProperties(
             name,
@@ -908,6 +908,23 @@ class Node(ApiBase):
             name,
             interface,
             property,
+        )
+
+    def kill_unit(self, name: str, who: str, signal: Int32) -> None:
+        """
+            KillUnit:
+          @name: The name of the unit to kill
+          @who: One of [main, control, all]
+          @signal: Unix signal number
+
+          Kills processes of a unit on a node.
+          If the who parameter is set to main, only the main process of a unit is killed. If control is used, then only the control process of the unit is
+        killed. And if all is used, all processes are killed.
+        """
+        self.get_proxy().KillUnit(
+            name,
+            who,
+            signal,
         )
 
     def list_unit_files(self) -> List[Tuple[str, str]]:
@@ -1014,7 +1031,7 @@ class Node(ApiBase):
         @runtime: Specify if the changes should persist after reboot or not
         @keyvalues: A list of the new values as key-value pair with the key being the name of the property
 
-        Set named . If runtime is true the property changes do not persist across reboots.
+        Set named properties. If runtime is true the property changes do not persist across reboots.
         """
         self.get_proxy().SetUnitProperties(
             name,

--- a/src/client/meson.build
+++ b/src/client/meson.build
@@ -15,7 +15,9 @@ client_src = [
   'method-metrics.c',
   'method-monitor.c',
   'method-unit-actions.c',
-  'method-status.c'
+  'method-status.c',
+  'method-kill.c',
+  'usage.c',
 ]
 
 executable(

--- a/src/client/method-help.c
+++ b/src/client/method-help.c
@@ -5,11 +5,12 @@
  */
 #include "method-help.h"
 #include "client.h"
+#include "usage.h"
 
 void usage_bluechi() {
-        printf("bluechictl is a convenience CLI tool to interact with bluechi\n");
-        printf("Usage: bluechictl COMMAND\n\n");
-        printf("Available command:\n");
+        usage_print_header();
+        usage_print_usage("bluechictl [command]");
+        printf("Available commands:\n");
         printf("  - help: shows this help message\n");
         printf("    usage: help\n");
         printf("  - list-unit-files: returns the list of systemd service files installed on a specific or on all nodes\n");
@@ -30,6 +31,8 @@ void usage_bluechi() {
         printf("    usage: restart nodename unitname\n");
         printf("  - reset-failed: reset failed node on all node or all units on a specific node or specidec units on a node \n");
         printf("    usage: reset-failed [nodename] [unit1, unit2 ...]\n");
+        printf("  - kill: kills processes of a specific unit on the given node\n");
+        printf("    usage: kill [nodename] [unit] [--kill-whom=all|main|control] [--signal=<number>]\n");
         printf("  - enable: enables the specified systemd files on a specific node\n");
         printf("    usage: enable nodename unitfilename...\n");
         printf("  - disable: disables the specified systemd files on a specific node\n");

--- a/src/client/method-kill.c
+++ b/src/client/method-kill.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright Contributors to the Eclipse BlueChi project
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+#include "method-kill.h"
+#include "client.h"
+#include "usage.h"
+
+#include "libbluechi/common/opt.h"
+#include "libbluechi/common/parse-util.h"
+
+
+static int method_kill_unit_on(
+                Client *client, const char *node_name, const char *unit_name, const char *whom, uint32_t signal) {
+
+        int r = 0;
+        _cleanup_sd_bus_error_ sd_bus_error error = SD_BUS_ERROR_NULL;
+        _cleanup_sd_bus_message_ sd_bus_message *result = NULL;
+
+        r = assemble_object_path_string(NODE_OBJECT_PATH_PREFIX, node_name, &client->object_path);
+        if (r < 0) {
+                return r;
+        }
+
+        r = sd_bus_call_method(
+                        client->api_bus,
+                        BC_INTERFACE_BASE_NAME,
+                        client->object_path,
+                        NODE_INTERFACE,
+                        "KillUnit",
+                        &error,
+                        &result,
+                        "ssi",
+                        unit_name,
+                        whom,
+                        signal);
+        if (r < 0) {
+                fprintf(stderr, "Failed to issue method call for KillUnit: %s\n", error.message);
+                return r;
+        }
+
+        return 0;
+}
+
+static const char *default_whom = "all";
+static const char *default_signal = "15";
+
+// Based on values listed for KillUnit
+// https://www.freedesktop.org/wiki/Software/systemd/dbus/
+static const char *whom_values[] = { "all", "control", "main", NULL };
+
+static bool is_whom_value_valid(const char *v) {
+        for (int i = 0; whom_values[i]; i++) {
+                if (whom_values[i] && streq(whom_values[i], v)) {
+                        return true;
+                }
+        }
+        return false;
+}
+
+int method_kill(Command *command, UNUSED void *userdata) {
+        const char *whom = command_get_option(command, ARG_KILL_WHOM_SHORT);
+        if (whom == NULL) {
+                whom = default_whom;
+        }
+        if (!is_whom_value_valid(whom)) {
+                fprintf(stderr, "Value '%s' of option --%s is invalid\n", whom, ARG_KILL_WHOM);
+                return -EINVAL;
+        }
+
+        uint32_t sig = 0;
+        const char *signal = command_get_option(command, ARG_SIGNAL_SHORT);
+        if (signal == NULL) {
+                signal = default_signal;
+        }
+        if (!parse_linux_signal(signal, &sig)) {
+                fprintf(stderr, "Value '%s' of option --%s is invalid\n", signal, ARG_SIGNAL);
+                return -EINVAL;
+        }
+
+        return method_kill_unit_on(userdata, command->opargv[0], command->opargv[1], whom, sig);
+}
+
+void usage_method_kill() {
+        usage_print_header();
+        usage_print_description("Kill (i.e. send a signal to) the processes of a unit");
+        usage_print_usage("bluechictl kill [nodename] [unit] [options]");
+        printf("Available options:\n");
+        printf("  --%s \t shows this help message\n", ARG_HELP);
+        printf("  --%s \t Enum defining which processes of the unit are killed.\n", ARG_KILL_WHOM);
+        printf("\t\t Needs to be one of [all, main, control]. Default: '%s'\n", default_whom);
+        printf("  --%s \t The signal sent to kill the processes of the unit. Default: '%s'\n",
+               ARG_SIGNAL,
+               default_signal);
+}

--- a/src/client/method-kill.h
+++ b/src/client/method-kill.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright Contributors to the Eclipse BlueChi project
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+#pragma once
+
+#include "libbluechi/cli/command.h"
+
+int method_kill(Command *command, void *userdata);
+void usage_method_kill();

--- a/src/client/usage.c
+++ b/src/client/usage.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright Contributors to the Eclipse BlueChi project
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+#include <stdio.h>
+
+void usage_print_header() {
+        printf("bluechictl is a convenience CLI tool to interact with bluechi\n");
+        printf("\n");
+}
+
+void usage_print_description(const char *description) {
+        printf("Description: \n");
+        printf("  %s\n", description);
+        printf("\n");
+}
+
+void usage_print_usage(const char *usage) {
+        printf("Usage: \n");
+        printf("  %s\n", usage);
+        printf("\n");
+}

--- a/src/client/usage.h
+++ b/src/client/usage.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright Contributors to the Eclipse BlueChi project
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+#pragma once
+
+void usage_print_header();
+void usage_print_description(const char *description);
+void usage_print_usage(const char *usage);

--- a/src/controller/node.c
+++ b/src/controller/node.c
@@ -84,6 +84,7 @@ static const sd_bus_vtable node_vtable[] = {
         SD_BUS_METHOD("EnableUnitFiles", "asbb", "ba(sss)", node_method_passthrough_to_agent, 0),
         SD_BUS_METHOD("DisableUnitFiles", "asb", "a(sss)", node_method_passthrough_to_agent, 0),
         SD_BUS_METHOD("Reload", "", "", node_method_passthrough_to_agent, 0),
+        SD_BUS_METHOD("KillUnit", "ssi", "", node_method_passthrough_to_agent, 0),
         SD_BUS_METHOD("SetLogLevel", "s", "", node_method_set_log_level, 0),
         SD_BUS_PROPERTY("Name", "s", NULL, offsetof(Node, name), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("Status", "s", node_property_get_status, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),

--- a/src/libbluechi/common/opt.h
+++ b/src/libbluechi/common/opt.h
@@ -54,6 +54,12 @@
 #define ARG_NO_RELOAD "no-reload"
 #define ARG_NO_RELOAD_SHORT 1002
 
+#define ARG_KILL_WHOM "kill-whom"
+#define ARG_KILL_WHOM_SHORT 1003
+
+#define ARG_SIGNAL "signal"
+#define ARG_SIGNAL_SHORT 1004
+
 #define ARG_WATCH "watch"
 #define ARG_WATCH_SHORT 'w'
 #define ARG_WATCH_SHORT_S "w"

--- a/src/libbluechi/common/parse-util.c
+++ b/src/libbluechi/common/parse-util.c
@@ -44,3 +44,20 @@ bool parse_port(const char *in, uint16_t *ret) {
         *ret = (uint16_t) l;
         return true;
 }
+
+bool parse_linux_signal(const char *in, uint32_t *ret) {
+        if (in == NULL || strlen(in) == 0) {
+                return false;
+        }
+
+        bool r = false;
+        long l = 0;
+        r = parse_long(in, &l);
+
+        if (!r || l < MIN_SIGNAL_VALUE || l > MAX_SIGNAL_VALUE) {
+                return false;
+        }
+
+        *ret = (uint32_t) l;
+        return true;
+}

--- a/src/libbluechi/common/parse-util.h
+++ b/src/libbluechi/common/parse-util.h
@@ -10,3 +10,8 @@
 
 bool parse_long(const char *in, long *ret);
 bool parse_port(const char *in, uint16_t *ret);
+
+#define MIN_SIGNAL_VALUE 1
+#define MAX_SIGNAL_VALUE 31
+
+bool parse_linux_signal(const char *in, uint32_t *ret);

--- a/src/libbluechi/test/common/parse-util_test.c
+++ b/src/libbluechi/test/common/parse-util_test.c
@@ -62,6 +62,30 @@ bool test_parse_port(const char *input, bool expected_return, uint16_t expected_
         return true;
 }
 
+bool test_parse_linux_signal(const char *input, bool expected_return, uint32_t expected_result) {
+        _cleanup_free_ char *msg = NULL;
+
+        uint32_t res = 0;
+        bool ret = parse_linux_signal(input, &res);
+        if ((ret != expected_return) || (res != expected_result)) {
+                ret = asprintf(&msg,
+                               "FAILED: %s\n\tInput: '%s'\n\tExpected: Return=%d, Result=%d\n\tGot: Return=%d, Result=%d\n",
+                               __FUNCTION_NAME__,
+                               input,
+                               expected_return,
+                               expected_result,
+                               ret,
+                               res);
+        }
+
+        if (msg != NULL) {
+                fprintf(stderr, "%s", msg);
+                return false;
+        }
+        return true;
+}
+
+
 int main() {
         bool result = true;
 
@@ -84,6 +108,16 @@ int main() {
         result = result && test_parse_port("-2", false, 0);
         result = result && test_parse_port("65.536", false, 0);
 
+        result = result && test_parse_linux_signal(NULL, false, 0);
+        result = result && test_parse_linux_signal("", false, 0);
+        result = result && test_parse_linux_signal("foo", false, 0);
+        result = result && test_parse_linux_signal("0", false, 0);
+        result = result && test_parse_linux_signal("1", true, 1);
+        result = result && test_parse_linux_signal("15", true, 15);
+        result = result && test_parse_linux_signal("31", true, 31);
+        result = result && test_parse_linux_signal("32", false, 0);
+        result = result && test_parse_linux_signal("-2", false, 0);
+        result = result && test_parse_linux_signal("65.536", false, 0);
 
         if (!result) {
                 return EXIT_FAILURE;

--- a/tests/bluechi_test/bluechictl.py
+++ b/tests/bluechi_test/bluechictl.py
@@ -149,6 +149,28 @@ class BluechiCtl:
             expected_result,
         )
 
+    def kill_unit(
+        self,
+        node_name: str,
+        unit_name: str,
+        whom: str = "",
+        signal: str = "",
+        check_result: bool = True,
+        expected_result: int = 0,
+    ) -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
+        cmd = f"kill {node_name} {unit_name}"
+        if whom != "":
+            cmd = cmd + f" --kill-whom={whom}"
+        if signal != "":
+            cmd = cmd + f" --signal={signal}"
+
+        return self._run(
+            f"Killing unit {unit_name} on node {node_name} with whom='{whom}' and signal='{signal}'",
+            cmd,
+            check_result,
+            expected_result,
+        )
+
     def stop_unit(
         self,
         node_name: str,

--- a/tests/tests/tier0/bluechi-kill-unit/main.fmf
+++ b/tests/tests/tier0/bluechi-kill-unit/main.fmf
@@ -1,0 +1,2 @@
+summary: Test killing processes of (i.e. sending a signal to) a units on a node.
+id: 0051e95c-7bdf-4171-af91-d9e1fd16e90f

--- a/tests/tests/tier0/bluechi-kill-unit/test_bluechi_kill_unit.py
+++ b/tests/tests/tier0/bluechi-kill-unit/test_bluechi_kill_unit.py
@@ -1,0 +1,57 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import logging
+from typing import Dict
+
+from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
+from bluechi_test.service import Option, Section, SimpleRemainingService
+from bluechi_test.test import BluechiTest
+
+LOGGER = logging.getLogger(__name__)
+NODE_FOO = "node-foo"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    node_foo = nodes[NODE_FOO]
+
+    sleep_service = SimpleRemainingService(name="sleep.service")
+    sleep_service.set_option(Section.Service, Option.ExecStart, "/bin/sleep 1000")
+    node_foo.install_systemd_service(sleep_service)
+
+    # killing all processes should succeed
+    ctrl.bluechictl.start_unit(NODE_FOO, sleep_service.name)
+    assert node_foo.wait_for_unit_state_to_be(sleep_service.name, "active")
+    ctrl.bluechictl.kill_unit(NODE_FOO, sleep_service.name, whom="all", signal="9")
+    assert node_foo.wait_for_unit_state_to_be(sleep_service.name, "failed")
+
+    # there is only a main process when ExecStart= is run
+    # so killing the control process should fail, but killing main process succeeds
+    ctrl.bluechictl.start_unit(NODE_FOO, sleep_service.name)
+    assert node_foo.wait_for_unit_state_to_be(sleep_service.name, "active")
+    _, output = ctrl.bluechictl.kill_unit(
+        NODE_FOO, sleep_service.name, whom="control", signal="9", check_result=False
+    )
+    assert "No control process to kill" in output
+    assert node_foo.wait_for_unit_state_to_be(sleep_service.name, "active")
+    ctrl.bluechictl.kill_unit(NODE_FOO, sleep_service.name, whom="main", signal="9")
+    assert node_foo.wait_for_unit_state_to_be(sleep_service.name, "failed")
+
+
+def test_bluechi_kill_unit(
+    bluechi_test: BluechiTest,
+    bluechi_node_default_config: BluechiAgentConfig,
+    bluechi_ctrl_default_config: BluechiControllerConfig,
+):
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = NODE_FOO
+
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO]
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/938

The KillUnit API has been implemented, forwarding the API call to systemd. For bluechictl, the command kill has been implemented to mirror the systemctl kill command - including the command options. It also added integration tests for the new KillUnit functionality.