### PR TITLE
Fix integration test race conditions

### DIFF
--- a/tests/tests/tier0/bluechi-agent-user-bus/test_bluechi_agent_user_bus.py
+++ b/tests/tests/tier0/bluechi-agent-user-bus/test_bluechi_agent_user_bus.py
@@ -42,7 +42,7 @@ def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
     assert result == 0
 
 
-def test_monitor_node_disconnect(
+def test_bluechi_agent_user_bus(
     bluechi_test: BluechiTest,
     bluechi_ctrl_default_config: BluechiControllerConfig,
     bluechi_node_default_config: BluechiAgentConfig,


### PR DESCRIPTION
This PR addresses two issues:

#### Fix proxy service propagate failure test
    
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/874
    
The proxy service propagates failure integration test has been flaky due to a race condition where either the job of the requesting service gets canceled or the requesting service maps the inactive state due to the BindsTo=. In order to account for this race condition, lets check if either case occurred.

#### ~~Fix race condition in status watch test~~
    
~~In the integration test for the bluechictl status watch command two parallel processes are run - one producing output, the second checking it. To ensure that the processing part can collect all the output from process one, a short delay is added.~~