### PR TITLE
Fix flaky bluechictl status watch test

### DIFF
--- a/src/client/method-status.c
+++ b/src/client/method-status.c
@@ -240,9 +240,9 @@ static void print_unit_info(unit_info_t *unit_info, size_t name_col_width) {
         PRINT_AND_ALIGN(sub_state);
         PRINT_AND_ALIGN(freezer_state);
         PRINT_AND_ALIGN(unit_file_state);
-        fflush(stdout);
-
         fprintf(stdout, "|\n");
+
+        fflush(stdout);
 }
 
 static size_t get_max_name_len(char **units, size_t units_count) {


### PR DESCRIPTION
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/946
    
Apparently, when directly printing after flushing stdout occasionally results in the last print unit line for bluechictl status watch being buffered. This leads to the bluechictl status watch integration test being stuck and failing.
By switching the print and flush - so the flush is last - this seems to be resolved.