### PR TITLE
Downgrade tmt to 1.36.1

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Install unpackaged python libraries from PyPi
         run: |
-          pip install "tmt[provision]>=1.32.1" "tmt[report-junit]>=1.32.1" podman pytest pyyaml paramiko
+          pip install "tmt[provision]==1.36.1" "tmt[report-junit]==1.36.1" podman pytest pyyaml paramiko
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
           cd tests
           tmt test id --dry | grep "New id" && echo "Found integration tests with missing ID. Please generate Test-IDs." && exit 1
           cd ..
-      
+
       - name: Lint tmt tests, plans and stories
         run: |
           cd tests

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,4 +3,4 @@ junit-xml >= 1.9
 pytest >= 7.3.1
 podman >= 4.5.0
 strato-skipper >= 2.0.2
-tmt >= 1.35
+tmt == 1.36.1


### PR DESCRIPTION
After tmt 1.37.0 release inetgration tests started to fail with following error:

```
10:06:36         warn: The generated XML output is not a valid XML file or it is not valid against the XSD schema.
10:06:36         warn: Please, report this problem to project maintainers.
10:06:36         rendered XML:
```

Until this issue is solved we need to downgrade to tmt 1.36.1

Signed-off-by: Martin Perina <mperina@redhat.com>
