### PR TITLE
Remove ANSI escape sequences from command outputs

### DIFF
--- a/tests/bluechi_test/client.py
+++ b/tests/bluechi_test/client.py
@@ -10,6 +10,7 @@ import pathlib
 import tarfile
 from typing import IO, Any, Dict, Iterator, Optional, Tuple, Union
 
+from bluechi_test import util
 from paramiko import SFTP, AutoAddPolicy, RSAKey
 from paramiko import SSHClient as ParamikoSSH
 from podman import PodmanClient
@@ -96,6 +97,10 @@ class ContainerClient(Client):
         if not raw_output and output:
             # When using tty is enabled, podman uses CRLF line ends, so we need to convert to LF
             output = output.replace(b"\r", b"").decode("utf-8").strip()
+
+            # some command return colored output using ANSI escape sequence, but this cause issues in tmt, so we need
+            # to remove them before logging
+            output = util.remove_control_chars(output)
 
         LOGGER.debug(
             f"Executed command '{command}' with result '{result}' and output '{output}'"

--- a/tests/bluechi_test/util.py
+++ b/tests/bluechi_test/util.py
@@ -5,6 +5,7 @@
 
 import logging
 import random
+import re
 import signal
 import socket
 import string
@@ -47,6 +48,26 @@ def get_random_name(name_length: int) -> str:
     # choose from all lowercase letter
     letters = string.ascii_lowercase
     return "".join(random.choice(letters) for _ in range(name_length))
+
+
+_ANSI_SEQUENCE = re.compile(
+    r"""
+    \x1B  # ESC
+    (?:   # 7-bit C1 Fe (except CSI)
+        [@-Z\\-_]
+    |     # or [ for CSI, followed by a control sequence
+        \[
+        [0-?]*  # Parameter bytes
+        [ -/]*  # Intermediate bytes
+        [@-~]   # Final byte
+    )
+""",
+    re.VERBOSE,
+)
+
+
+def remove_control_chars(value: str) -> str:
+    return _ANSI_SEQUENCE.sub("", value)
 
 
 # timeout for setting up tests in s


### PR DESCRIPTION
Some commands, which are executed as a part of tests (for example
"systemctl is-enabled"), return output containing ANSI escape sequence.
Unfortunately tmt 1.37.0 started to check valid characters as a part of
junit report and those character caused failures. So this patch removes
ANSI escape sequences from logged data, so report in tmt 1.37.0 is
created successfully.

Signed-off-by: Martin Perina <mperina@redhat.com>
