### PR TITLE
Optimize BlueChi's systemd units on boot

### DIFF
--- a/systemd-units/bluechi-agent.service
+++ b/systemd-units/bluechi-agent.service
@@ -5,7 +5,10 @@
 [Unit]
 Description=BlueChi systemd service controller agent daemon
 Documentation=man:bluechi-agent(1) man:bluechi-agent.conf(5)
-After=network.target
+DefaultDependencies=no
+Before=basic.target shutdown.target
+After=dbus.service
+Conflicts=shutdown.target
 
 [Service]
 Type=simple

--- a/systemd-units/bluechi-controller.service
+++ b/systemd-units/bluechi-controller.service
@@ -5,7 +5,10 @@
 [Unit]
 Description=BlueChi Controller systemd service
 Documentation=man:bluechi-controller(1) man:bluechi-controller.conf(5)
-After=network.target
+DefaultDependencies=no
+Before=basic.target shutdown.target
+After=dbus.service
+Conflicts=shutdown.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
To optimize the bluechi-controller and bluechi-agent boot the After parameter was change to dbus.service

Solves: https://github.com/eclipse-bluechi/bluechi/issues/864