### PR TITLE
Fix bluechictl status watch

### DIFF
--- a/data/org.eclipse.bluechi.Node.xml
+++ b/data/org.eclipse.bluechi.Node.xml
@@ -272,7 +272,7 @@
 
     <!--
       GetDefaultTarget:
-      @defaulttarget the default target.
+      @defaulttarget The default target.
 
       Get the default value of the system to boot into.
     -->
@@ -282,16 +282,16 @@
 
     <!--
       SetDefaultTarget:
-      @defaulttarget the default target.
-      @force bollean value of force.
-      @out the result of the method.
+      @defaulttarget The default target.
+      @force Boolean value of force.
+      @out The result of the method.
 
       Set the default value of the system to boot into.
     -->
     <method name="SetDefaultTarget">
       <arg name="defaulttarget" type="s" direction="in" />
       <arg name="force" type="b" direction="in" />
-      <arg name="out" type="a(sss)" direction="out" />  
+      <arg name="out" type="a(sss)" direction="out" />
     </method>
 
     <!--

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -902,7 +902,7 @@ class Node(ApiBase):
     def get_default_target(self) -> str:
         """
           GetDefaultTarget:
-        @defaulttarget the default target.
+        @defaulttarget The default target.
 
         Get the default value of the system to boot into.
         """
@@ -1056,9 +1056,9 @@ class Node(ApiBase):
     ) -> List[Tuple[str, str, str]]:
         """
           SetDefaultTarget:
-        @defaulttarget the default target.
-        @force bollean value of force.
-        @out the result of the method.
+        @defaulttarget The default target.
+        @force Boolean value of force.
+        @out The result of the method.
 
         Set the default value of the system to boot into.
         """

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -63,7 +63,7 @@ const Method methods[] = {
         { "status",          0, ARG_ANY, OPT_WATCH,                               method_status,             usage_method_status             },
         { "set-loglevel",    1, 2,       OPT_NONE,                                method_set_loglevel,       usage_method_set_loglevel       },
         { "get-default",     1, 1,       OPT_NONE,                                method_get_default_target, usage_method_get_default_target },
-        { "set-default",     2, 3,       OPT_NONE,                                method_set_default_target, usage_method_set_default_target },
+        { "set-default",     2, 2,       OPT_NONE,                                method_set_default_target, usage_method_set_default_target },
         { "version",         0, 0,       OPT_NONE,                                method_version,            usage_bluechi                   },
         { NULL,              0, 0,       0,                                       NULL,                      NULL                            }
 };

--- a/src/libbluechi/common/protocol.h
+++ b/src/libbluechi/common/protocol.h
@@ -7,10 +7,7 @@
 
 #include <errno.h>
 
-/* Time constants */
-#define USEC_PER_SEC 1000000
-#define USEC_PER_MSEC 1000
-#define NSEC_PER_USEC 1000
+#include "time-util.h"
 
 /* Configuration defaults */
 #define BC_DEFAULT_PORT "842"
@@ -124,8 +121,3 @@ typedef enum UnitActiveState {
 
 const char *active_state_to_string(UnitActiveState s);
 UnitActiveState active_state_from_string(const char *s);
-
-/* Constants */
-#define SYMBOL_WILDCARD "*"
-#define SYMBOL_GLOB_ALL '*'
-#define SYMBOL_GLOB_ONE '?'

--- a/src/libbluechi/common/string-util.h
+++ b/src/libbluechi/common/string-util.h
@@ -9,7 +9,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "protocol.h"
+/* Constants */
+#define SYMBOL_WILDCARD "*"
+#define SYMBOL_GLOB_ALL '*'
+#define SYMBOL_GLOB_ONE '?'
 
 #define streq(a, b) (strcmp((a), (b)) == 0)
 #define strneq(a, b, n) (strncmp((a), (b), (n)) == 0)

--- a/src/libbluechi/common/time-util.h
+++ b/src/libbluechi/common/time-util.h
@@ -10,6 +10,9 @@
 #include <stdlib.h>
 
 #define USEC_INFINITY UINT64_MAX
+#define USEC_PER_SEC 1000000
+#define USEC_PER_MSEC 1000
+#define NSEC_PER_USEC 1000
 
 static const uint64_t sec_to_microsec_multiplier = 1000000;
 static const double microsec_to_millisec_multiplier = 1e-3;

--- a/src/libbluechi/test/common/time-util/timespec_to_micros_test.c
+++ b/src/libbluechi/test/common/time-util/timespec_to_micros_test.c
@@ -8,7 +8,6 @@
 #include <limits.h>
 #include <stdlib.h>
 
-#include "libbluechi/common/protocol.h"
 #include "libbluechi/common/time-util.h"
 
 int main() {

--- a/tests/bluechi_test/bluechictl.py
+++ b/tests/bluechi_test/bluechictl.py
@@ -189,7 +189,7 @@ class BluechiCtl:
         check_result: bool = True,
         expected_result: int = 0,
     ) -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
-        cmd = f"set-default {node_name} {target} true"
+        cmd = f"set-default {node_name} {target}"
         return self._run(
             f"SetDefaultTarget of node {node_name} ",
             cmd,


### PR DESCRIPTION
This PR addresses two issues:

- Moved string and time constants to respective util files
- Use force flag and name validation in bluechictl set-default
  Relates to: https://github.com/eclipse-bluechi/bluechi/issues/944    
  The bluechictl set-default command used for the force option a separate CLI parameter with true/false values. This is a bit brittle and doesn't take into account other truthy values. Using the already defined --force option results in a much clearer usage of this command. In addition, when passing unit name other than a .target it failed with a rather cryptic error message from systemd. Therefore, lets do a pre-validation inside bluechictl before submitting any request and provide a proper error message.     
- Fix updating PeerIP on node dis-/connect
  In bluechictl, the PeerIP was fetched only initially. This resulted in the PeerIP not being updated when the connection state changed. By fetching the PeerIP property on each connection state change this is fixed. 
