### PR TITLE
Make Agent Register request asynchronous

### DIFF
--- a/src/agent/agent.h
+++ b/src/agent/agent.h
@@ -48,7 +48,8 @@ typedef struct JobTracker JobTracker;
 typedef enum {
         AGENT_CONNECTION_STATE_DISCONNECTED,
         AGENT_CONNECTION_STATE_CONNECTED,
-        AGENT_CONNECTION_STATE_RETRY
+        AGENT_CONNECTION_STATE_RETRY,
+        AGENT_CONNECTION_STATE_CONNECTING
 } AgentConnectionState;
 
 struct Agent {
@@ -80,6 +81,8 @@ struct Agent {
         sd_bus *api_bus;
         sd_bus *systemd_dbus;
         sd_bus *peer_dbus;
+
+        sd_bus_slot *register_call_slot;
 
         bool metrics_enabled;
         sd_bus_slot *metrics_slot;

--- a/src/libbluechi/bus/bus.c
+++ b/src/libbluechi/bus/bus.c
@@ -77,13 +77,14 @@ sd_bus *peer_bus_open(sd_event *event, const char *dbus_description, const char 
 
 int peer_bus_close(sd_bus *peer_dbus) {
         if (peer_dbus != NULL) {
+                bc_log_debug("Closing peer bus");
                 int r = sd_bus_detach_event(peer_dbus);
                 if (r < 0) {
                         bc_log_errorf("Failed to detach bus from event: %s", strerror(-r));
                         return r;
                 }
 
-                sd_bus_flush_close_unref(peer_dbus);
+                sd_bus_close_unref(peer_dbus);
         }
 
         return 0;


### PR DESCRIPTION
The "Register" agent->controller method call could get stuck when the IP address configured as ControllerHost does not exist. This timeout of about 2 seconds could completely occupy the event loop and would not allow other calls on the DBus API of the Agent.

Making the "Register" method call asynchronous we allow the event loop to stay unoccupied and be able to accept SwitchController request.

Resolves: #950 
Resolves: #966 