### PR TITLE
Report to coveralls only if integration tests passed

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -98,6 +98,7 @@ jobs:
           cd ..
 
       - name: Run integration tests
+        id: run-tests
         run: |
           cd tests
           tmt run -v \
@@ -147,12 +148,13 @@ jobs:
           path: '/var/tmp/merged.info'
 
       - name: Prepare the coverage report for coveralls
-        if: always()
+        id: prepare-coveralls-report
+        if: steps.run-tests.outcome == 'success'
         run: |
           sed 's/\/var\/tmp\/bluechi-coverage\/src/src/' /var/tmp/merged.info > /var/tmp/coveralls.info
 
       - name: Report to Coveralls
-        if: always()
+        if: steps.prepare-coveralls-report.outcome == 'success'
         uses: coverallsapp/github-action@v2.3.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The coverage report makes sense only when all tests passed. When a test fails - the pipeline tries to report to coveralls, but as long as tests are not fixed - this is not something of interest, and it creates just an additional failure.