### PR TITLE
Fix when running test with tmt.discover.prune=true

### DIFF
--- a/tests/tests/main.fmf
+++ b/tests/tests/main.fmf
@@ -7,6 +7,7 @@ test: |
     --log-cli-date-format="%Y-%m-%d %H:%M:%S%z" \
     --log-cli-format="%(asctime)s,%(msecs)03d %(levelname)-7s [%(name)s] %(message)s (%(module)s:%(lineno)d)"
 
+# Require the whole tree (no pruning)
 require:
   - type: file
     pattern:

--- a/tests/tests/main.fmf
+++ b/tests/tests/main.fmf
@@ -6,3 +6,8 @@ test: |
     --log-cli-level=${LOG_LEVEL} \
     --log-cli-date-format="%Y-%m-%d %H:%M:%S%z" \
     --log-cli-format="%(asctime)s,%(msecs)03d %(levelname)-7s [%(name)s] %(message)s (%(module)s:%(lineno)d)"
+
+require:
+  - type: file
+    pattern:
+      - /


### PR DESCRIPTION
when tmt prune enabled, below items will not be transfered

  - bluechi/tests/scripts
  - bluechi/tests/containers
  - bluechi/tests/bluechi_machine_lib
  - bluechi/tests/bluechi_test