### PR TITLE
Emit ControllerAddress changed signal in SwitchController method

### DIFF
--- a/src/agent/agent.h
+++ b/src/agent/agent.h
@@ -56,9 +56,13 @@ struct Agent {
 
         bool systemd_user;
         char *name;
+        char *api_bus_service_name;
+
         char *host;
         int port;
         char *controller_address;
+        char *assembled_controller_address;
+
         long heartbeat_interval_msec;
         long controller_heartbeat_threshold_msec;
 
@@ -69,11 +73,6 @@ struct Agent {
         uint64_t disconnect_timestamp;
         uint64_t disconnect_timestamp_monotonic;
 
-        char *orch_addr;
-        char *api_bus_service_name;
-
-        bool metrics_enabled;
-
         SocketOptions *peer_socket_options;
 
         sd_event *event;
@@ -82,6 +81,7 @@ struct Agent {
         sd_bus *systemd_dbus;
         sd_bus *peer_dbus;
 
+        bool metrics_enabled;
         sd_bus_slot *metrics_slot;
 
         LIST_HEAD(SystemdRequest, outstanding_requests);
@@ -110,7 +110,7 @@ void agent_unref(Agent *agent);
 
 bool agent_set_port(Agent *agent, const char *port);
 bool agent_set_host(Agent *agent, const char *host);
-bool agent_set_orch_address(Agent *agent, const char *address);
+bool agent_set_assembled_controller_address(Agent *agent, const char *address);
 bool agent_set_name(Agent *agent, const char *name);
 bool agent_set_heartbeat_interval(Agent *agent, const char *interval_msec);
 void agent_set_systemd_user(Agent *agent, bool systemd_user);

--- a/src/agent/main.c
+++ b/src/agent/main.c
@@ -161,7 +161,7 @@ int main(int argc, char *argv[]) {
                 return EXIT_FAILURE;
         }
 
-        if (opt_address && !agent_set_orch_address(agent, opt_address)) {
+        if (opt_address && !agent_set_assembled_controller_address(agent, opt_address)) {
                 return EXIT_FAILURE;
         }
 

--- a/src/controller/meson.build
+++ b/src/controller/meson.build
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-# orch build configuration
+# controller build configuration
 
-orch_src = [
+ctrl_src = [
     'controller.h',
     'controller.c',
     'node.h',
@@ -23,7 +23,7 @@ orch_src = [
 
 executable(
   'bluechi-controller',
-  orch_src,
+  ctrl_src,
   dependencies: [
     systemd_dep,
     inih_dep,

--- a/src/controller/test/controller/meson.build
+++ b/src/controller/test/controller/meson.build
@@ -9,7 +9,7 @@ controller_src = [
 
 # setup controller test src files to include in compilation
 controller_test_src = []
-foreach src : orch_src
+foreach src : ctrl_src
     # skip main to avoid duplicate main function error
     if src == 'main.c'
         continue


### PR DESCRIPTION
Relates to: https://github.com/eclipse-bluechi/bluechi/pull/964

The changed signal for the agents ControllerAddress property was emitted only in the agent_reconnect function when a change in the address has been detected. This, however, led to the agent first emitting a status disconnected signal and then the address changed signal when the SwitchAddress API has been called. The order of these signals should be reversed.
The address changed signal is now also emitted inside the SwitchController API function which changes the address. In order to get the up-to-date value in the orch_addr field, the new value is set here as well.
The ControllerAddress property changed signal will still be emitted in the reconnect function to ensure any change in the address due to name resolution is considered.

