### PR TITLE
Make integration test timeouts configurable

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -97,11 +97,14 @@ jobs:
           tmt lint
           cd ..
 
+      # Enable local provisioning as this is considered dangerous since tmt v1.38.0
+      # see https://github.com/teemtee/tmt/pull/3282
       - name: Run integration tests
         id: run-tests
         run: |
           cd tests
-          tmt run -v \
+          tmt --feeling-safe \
+            run -v \
             -eCONTAINER_USED=integration-test-local \
             -eWITH_COVERAGE=1 \
             -eLOG_LEVEL=DEBUG \

--- a/.packit.yml
+++ b/.packit.yml
@@ -1,5 +1,4 @@
 ---
-
 upstream_project_url: https://github.com/eclipse-bluechi/bluechi
 issue_repository: https://github.com/eclipse-bluechi/bluechi
 specfile_path: bluechi.spec
@@ -54,11 +53,14 @@ jobs:
     labels:
       - standard
     env:
+      # Enable local provisioning as this is considered dangerous since tmt v1.38.0
+      # see https://github.com/teemtee/tmt/pull/3282
+      TMT_FEELING_SAFE: 1
       INSTALL_DEPS: "yes"
     targets:
       # Run integration tests on Fedora using CS9 containers, because running integrations tests on CS9 using CS9
       # containers is very flaky
-      # 
+      #
       # This can be set to fedora-rawhide as soon as the following issue gets resolved:
       # https://github.com/containers/podman/issues/22422
       - fedora-latest-stable-x86_64
@@ -68,13 +70,16 @@ jobs:
     labels:
       - valgrind
     env:
+      # Enable local provisioning as this is considered dangerous since tmt v1.38.0
+      # see https://github.com/teemtee/tmt/pull/3282
+      TMT_FEELING_SAFE: 1
       INSTALL_DEPS: "yes"
       WITH_VALGRIND: "1"
 
   - job: copr_build
     trigger: commit
     branch: main
-    owner: '@centos-automotive-sig'
+    owner: "@centos-automotive-sig"
     project: bluechi-snapshot
     notifications:
       failure_comment:

--- a/tests/README.md
+++ b/tests/README.md
@@ -150,6 +150,19 @@ execution result directory, for example:
 
 `/var/tmp/tmt/run-001/plans/tier0/report/default-0/report`
 
+## Changing timeouts for integration tests
+
+In some cases it might be necessary to adjust the default timeouts that are used in different steps of an integration tests execution cycle. The currently available environment variables as well as their default values are:
+
+```shell
+# in seconds
+TIMEOUT_TEST_SETUP=20
+TIMEOUT_TEST_RUN=45
+TIMEOUT_COLLECT_TEST_RESULTS=20
+```
+
+These can be set either in the `environment` section of the tmt plan or using the `-e` option when running tmt, e.g. `-eTIMEOUT_TEST_SETUP=40`.
+
 ## Developing integration tests
 
 ### Code Style

--- a/tests/bluechi_test/fixtures.py
+++ b/tests/bluechi_test/fixtures.py
@@ -69,6 +69,33 @@ def machines_ssh_password() -> str:
     return _get_env_value("SSH_PASSWORD", "")
 
 
+def _safely_parse_int(input: str, default: int) -> int:
+    if input.isdigit():
+        return int(input)
+    return default
+
+
+@pytest.fixture(scope="session")
+def timeout_test_setup() -> int:
+    """Returns the timeout for setting up the test setup"""
+
+    return _safely_parse_int(_get_env_value("TIMEOUT_TEST_SETUP", ""), 20)
+
+
+@pytest.fixture(scope="session")
+def timeout_test_run() -> int:
+    """Returns the timeout for executing the actual test"""
+
+    return _safely_parse_int(_get_env_value("TIMEOUT_TEST_RUN", ""), 45)
+
+
+@pytest.fixture(scope="session")
+def timeout_collecting_test_results() -> int:
+    """Returns the timeout for collecting all test results"""
+
+    return _safely_parse_int(_get_env_value("TIMEOUT_COLLECT_TEST_RESULTS", ""), 20)
+
+
 def _read_topology() -> Dict[str, Any]:
     """
     Returns the parsed YAML for the tmt guest topology:
@@ -216,6 +243,9 @@ def bluechi_test(
     additional_ports: dict,
     machines_ssh_user: str,
     machines_ssh_password: str,
+    timeout_test_setup: int,
+    timeout_test_run: int,
+    timeout_collecting_test_results: int,
 ) -> BluechiTest:
 
     if is_multihost_run:
@@ -227,6 +257,9 @@ def bluechi_test(
             tmt_test_data_dir,
             run_with_valgrind,
             run_with_coverage,
+            timeout_test_setup,
+            timeout_test_run,
+            timeout_collecting_test_results,
         )
 
     return BluechiContainerTest(
@@ -238,5 +271,8 @@ def bluechi_test(
         tmt_test_data_dir,
         run_with_valgrind,
         run_with_coverage,
+        timeout_test_setup,
+        timeout_test_run,
+        timeout_collecting_test_results,
         additional_ports,
     )

--- a/tests/bluechi_test/util.py
+++ b/tests/bluechi_test/util.py
@@ -70,14 +70,6 @@ def remove_control_chars(value: str) -> str:
     return _ANSI_SEQUENCE.sub("", value)
 
 
-# timeout for setting up tests in s
-TIMEOUT_SETUP = 20
-# timeout for running tests in s
-TIMEOUT_TEST = 45
-# timeout for collecting test results in s
-TIMEOUT_GATHER = 20
-
-
 class Timeout:
     def __init__(self, seconds=1, error_message="Timeout"):
         self.seconds = seconds


### PR DESCRIPTION
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/969
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/971

Depending on platforms, the default timeouts used in the integration tests need to be adjusted. In order to prevent code modification, lets have the three currently available, high-level timeouts be configurable via tmt.

Local provisioning is considered dangerous since tmt v1.38.0 and causes the pipeline to fail. In order to be able to run BlueChi integration tests, lets enable it by setting the environment variable TMT_FEELING_SAFE via --feeling-safe CLI option in the GitHub workflow and via env variable in packit.
See:
https://github.com/teemtee/tmt/pull/3282
https://tmt.readthedocs.io/en/stable/overview.html#variables
