### PR TITLE
Remove timeouts for bash exec commands from tests

### DIFF
--- a/tests/tests/tier0/bluechi-agent-user-bus/python/start_agent_as_user.py
+++ b/tests/tests/tier0/bluechi-agent-user-bus/python/start_agent_as_user.py
@@ -6,7 +6,7 @@
 import time
 import unittest
 
-from bluechi_machine_lib.util import Timeout, run_command
+from bluechi_machine_lib.util import run_command
 
 service = "org.eclipse.bluechi.Agent"
 object = "/org/eclipse/bluechi"
@@ -19,14 +19,13 @@ class TestAgentStartAsUser(unittest.TestCase):
         result, _, _ = run_command("systemctl --user start bluechi-agent")
         assert result == 0
 
-        with Timeout(5, "Timeout waiting for agent to connect to user bus"):
-            while True:
-                result, output, _ = run_command(
-                    f"busctl --user get-property {service} {object} {interface} Status"
-                )
-                if output == 's "offline"':
-                    break
-                time.sleep(0.5)
+        while True:
+            result, output, _ = run_command(
+                f"busctl --user get-property {service} {object} {interface} Status"
+            )
+            if output == 's "offline"':
+                break
+            time.sleep(0.5)
 
         result, _, _ = run_command("systemctl --user stop bluechi-agent")
         assert result == 0

--- a/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/test_bluechi_change_port_with_c_cmd_option.py
+++ b/tests/tests/tier0/bluechi-change-port-with-c-cmd-option/test_bluechi_change_port_with_c_cmd_option.py
@@ -15,7 +15,7 @@ from bluechi_test.machine import (
 )
 from bluechi_test.service import Option, Section
 from bluechi_test.test import BluechiTest
-from bluechi_test.util import Timeout, read_file
+from bluechi_test.util import read_file
 
 NODE_FOO = "node-foo"
 
@@ -29,15 +29,11 @@ def cmd_on_port(
     expected_result: int = 0,
     expected_command: str = None,
 ) -> None:
-    with Timeout(
-        seconds=5,
-        error_message=f"Timeout waiting for '{expected_command}' to listen on port '{port}'",
-    ):
-        while True:
-            res, output = machine.exec_run(f"bash /var/cmd-on-port.sh {port}")
-            if res == expected_result and expected_command in str(output):
-                break
-            time.sleep(0.2)
+    while True:
+        res, output = machine.exec_run(f"bash /var/cmd-on-port.sh {port}")
+        if res == expected_result and expected_command in str(output):
+            break
+        time.sleep(0.2)
 
 
 def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):

--- a/tests/tests/tier0/bluechi-change-port-with-p-cmd-option/test_bluechi_change_port_with_p_cmd_option.py
+++ b/tests/tests/tier0/bluechi-change-port-with-p-cmd-option/test_bluechi_change_port_with_p_cmd_option.py
@@ -15,7 +15,6 @@ from bluechi_test.machine import (
 )
 from bluechi_test.service import Option, Section
 from bluechi_test.test import BluechiTest
-from bluechi_test.util import Timeout
 
 NODE_FOO = "node-foo"
 
@@ -28,15 +27,11 @@ def cmd_on_port(
     expected_result: int = 0,
     expected_command: str = None,
 ) -> None:
-    with Timeout(
-        seconds=5,
-        error_message=f"Timeout waiting for '{expected_command}' to listen on port '{port}'",
-    ):
-        while True:
-            res, output = machine.exec_run(f"bash /var/cmd-on-port.sh {port}")
-            if res == expected_result and expected_command in str(output):
-                break
-            time.sleep(0.2)
+    while True:
+        res, output = machine.exec_run(f"bash /var/cmd-on-port.sh {port}")
+        if res == expected_result and expected_command in str(output):
+            break
+        time.sleep(0.2)
 
 
 def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):


### PR DESCRIPTION
Some tests that have timeouts for specific bash commands fail with timeout on slower hardware. As we have configurable timeouts for test setup, execution and collecting results - there is no need in timeout for specific commands.

Resolves: https://github.com/eclipse-bluechi/bluechi/issues/973