### PR TITLE
Changes for EPEL10 release

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -89,10 +89,18 @@ jobs:
       - centos-stream-9-ppc64le
       - centos-stream-9-s390x
       - centos-stream-9-x86_64
+      - centos-stream-10-aarch64
+      - centos-stream-10-ppc64le
+      - centos-stream-10-s390x
+      - centos-stream-10-x86_64
       - epel-9-aarch64
       - epel-9-ppc64le
       - epel-9-s390x
       - epel-9-x86_64
+      - epel-10-aarch64
+      - epel-10-ppc64le
+      - epel-10-s390x
+      - epel-10-x86_64
       - fedora-all-aarch64
       - fedora-all-i386
       - fedora-all-ppc64le

--- a/README.developer.md
+++ b/README.developer.md
@@ -33,7 +33,7 @@ In order to develop the project you need to install following dependencies.
 
 #### Prerequisites
 
-To build the project on CentOS Stream 9 you need to enable CodeReady Build repository:
+To build the project on CentOS Stream you need to enable CodeReady Build repository:
 
 ```bash
 sudo dnf install dnf-plugin-config-manager

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,7 +10,7 @@ to [podman installation instructions](https://podman.io/getting-started/installa
 
 ### Installing packages using RPM
 
-First, enable required repositories on CentOS Stream 9:
+First, enable required repositories on CentOS Stream:
 
 ```shell
 sudo dnf install -y dnf-plugin-config-manager


### PR DESCRIPTION
1. Mentions of "CentOS Stream 9" were replaced with plain "CentOS Stream" since we support both 9 and 10
2. Added centos-stream-10 and epel-10 targets to snapshot build configuration in Packit