### PR TITLE
Remove "Vendor:" and "Packager:" from spec

### DIFF
--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -15,8 +15,6 @@ Release:	@RELEASE@%{?dist}
 Summary:	A systemd service controller for multi-nodes environments
 License:	LGPL-2.1-or-later AND CC0-1.0
 URL:		https://github.com/eclipse-bluechi/bluechi
-Vendor:		Eclipse BlueChi
-Packager:	Red Hat
 Source0:	%{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
 # Required to apply the patch


### PR DESCRIPTION
As instructed in https://docs.fedoraproject.org/en-US/packaging-guidelines/#_tags_and_sections the "Vendor:" and "Packager:" tags must not be used. Thus, removing them from the spec file.