### PR TITLE
Updated debian packages and changelog

### DIFF
--- a/README.maintainer.md
+++ b/README.maintainer.md
@@ -14,8 +14,10 @@ Following files need to be updated to create a new stable release commit:
 
 * In [build-scripts/version.sh](./build-scripts/version.sh) set `IS_RELEASE=true`. For the first release of that version
 `RELEASE=1` is used. This may be increased if additional package releases are needed.
-* A new `%changelog` section in [bluechi.spec.in](./bluechi.spec.in) should be added and it should contain information
-about the new package release
+* CentOS/Fedora: A new `%changelog` section in [bluechi.spec.in](./bluechi.spec.in) should be added and it should
+contain information about the new package release
+* Debian: A new changelong section in [debian/changelog](./debian/changelog) should be added. It can be as simple
+as "Upgrading to vx.x.x"
 
 Here is the example of the release commit for version
 [0.6.0](https://github.com/eclipse-bluechi/bluechi/pull/637).

--- a/debian/bluechi-is-online.install
+++ b/debian/bluechi-is-online.install
@@ -1,0 +1,1 @@
+usr/bin/bluechi-is-online

--- a/debian/bluechi-is-online.manpages
+++ b/debian/bluechi-is-online.manpages
@@ -1,0 +1,1 @@
+usr/share/man/man1/bluechi-is-online.1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+bluechi (0.9.0-1) stable; urgency=low
+
+  * Upgrading to BlueChi v0.9.0.
+
+ -- Michael Engel <mengel@redhat.com>  Di, 19 Nov 2024 14:05:29 +0200
+
+
 bluechi (0.8.0-1) stable; urgency=low
 
   * Initial packaging.

--- a/debian/control
+++ b/debian/control
@@ -53,3 +53,19 @@ Description: systemd service controller for multi-node environments
  configuration to run a container via quadlet.
  .
  This package contains bluechictl, the BlueChi command line utility.
+
+Package: bluechi-is-online
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}, systemd
+Description: systemd service controller for multi-node environments
+ Eclipse BlueChi is a systemd service controller intended for multi-node
+ environments with a predefined number of nodes and with a focus on
+ highly regulated ecosystems such as those requiring functional
+ safety (for example in cars).
+ .
+ BlueChi can also be used to control systemd services for containerized
+ applications using Podman and its ability to generate systemd service
+ configuration to run a container via quadlet.
+ .
+ This package contains bluechi-is-online, a command line utility to check
+ the connection status of BlueChi's components.


### PR DESCRIPTION
Updated the debian packages to the new v0.9.0 version and added a changelog section. In addition, another bullet point in the maintainer readme has been added to not forget about this in the future.

Note: The v0.9.0 debian release is done in https://github.com/eclipse-bluechi/bluechi-ppa/pull/3