### PR TITLE
Add paramiko to tests pip requirments

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -32,7 +32,7 @@ dnf install \
     python3-pytest \
     python3-pyyaml \
     tmt \
-    tmt-report-junit \
+    tmt+report-junit \
     -y
 ```
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,4 @@ pytest >= 7.3.1
 podman >= 4.5.0
 strato-skipper >= 2.0.2
 tmt >= 1.35
+paramiko >= 3.5.0


### PR DESCRIPTION
Have run integration tests for the first time after F41 upgrade, and found that paramiko is never installed when installing all requirements according to the documentation, and is required by the tests.