### PR TITLE
Adding bluechi-is-online installation

### DIFF
--- a/tests/containers/integration-test-local
+++ b/tests/containers/integration-test-local
@@ -13,6 +13,7 @@ RUN dnf install --repo bluechi-rpms \
         bluechi-agent \
         bluechi-agent-debuginfo \
         bluechi-ctl \
+        bluechi-is-online \
         bluechi-ctl-debuginfo \
         bluechi-selinux \
         python3-bluechi \

--- a/tests/containers/integration-test-snapshot
+++ b/tests/containers/integration-test-snapshot
@@ -14,6 +14,7 @@ RUN dnf install \
         bluechi-agent \
         bluechi-agent-debuginfo \
         bluechi-ctl \
+        bluechi-is-online \
         bluechi-ctl-debuginfo \
         bluechi-selinux \
         python3-bluechi \

--- a/tests/scripts/tests-setup.sh
+++ b/tests/scripts/tests-setup.sh
@@ -64,6 +64,7 @@ function setup_worker(){
         bluechi-agent \
         bluechi-agent-debuginfo \
         bluechi-ctl \
+        bluechi-is-online \
         bluechi-ctl-debuginfo \
         bluechi-selinux \
         python3-bluechi \


### PR DESCRIPTION
In order to test bluechi-is-online cmd, we need to add it for the containers installed packages.