### PR TITLE
Add integration test for bluechi-is-online agent

### DIFF
--- a/tests/bluechi_test/bluechi_is_online.py
+++ b/tests/bluechi_test/bluechi_is_online.py
@@ -1,0 +1,36 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+
+from bluechi_test.client import Client
+
+
+class BluechiIsOnline:
+
+    binary_name = "bluechi-is-online"
+
+    def __init__(self, client: Client) -> None:
+        self.client = client
+        self.tracked_services: Dict[str, List[str]] = dict()
+
+    def run(
+        self, log_txt: str, cmd: str, check_result: bool, expected_result: int
+    ) -> Tuple[Optional[int], Union[Iterator[bytes], Any, Tuple[bytes, bytes]]]:
+        result, output = self.client.exec_run(f"{BluechiIsOnline.binary_name} {cmd}")
+        if check_result and result != expected_result:
+            raise Exception(
+                f"{log_txt} failed with {result} (expected {expected_result}): {output}"
+            )
+        return result, output
+
+    def agent_is_online(self) -> bool:
+        result, output = self.run(
+            "Checking if agent is active.",
+            "agent",
+            False,
+            0,
+        )
+        return result == 0

--- a/tests/bluechi_test/machine.py
+++ b/tests/bluechi_test/machine.py
@@ -10,6 +10,7 @@ import traceback
 from typing import Any, Iterator, List, Optional, Tuple, Union
 
 import bluechi_machine_lib as bml
+from bluechi_test.bluechi_is_online import BluechiIsOnline
 from bluechi_test.bluechictl import BluechiCtl
 from bluechi_test.client import Client
 from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
@@ -35,6 +36,7 @@ class BluechiMachine:
         self.client = client
 
         self.systemctl = SystemCtl(client)
+        self.bluechi_is_online = BluechiIsOnline(client)
 
         self.created_files: List[str] = []
         self.changed_files: List[str] = []

--- a/tests/tests/tier0/bluechi-is-online-agent/main.fmf
+++ b/tests/tests/tier0/bluechi-is-online-agent/main.fmf
@@ -1,0 +1,2 @@
+summary: On the agent machine test the connection of the agent to the controller
+id: 4af7b1da-39e7-46d5-bf00-586a8df17f1b

--- a/tests/tests/tier0/bluechi-is-online-agent/test_bluechi_is_online_agent.py
+++ b/tests/tests/tier0/bluechi-is-online-agent/test_bluechi_is_online_agent.py
@@ -1,0 +1,46 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+from typing import Dict
+
+from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
+from bluechi_test.test import BluechiTest
+
+NODE_FOO = "node-foo"
+
+
+def check_execs(node: BluechiAgentMachine):
+    # check that bluechi-agent is online at the test startup
+    result = node.bluechi_is_online.agent_is_online()
+    assert result, f"bluechi-agent on node {node.name} should be online"
+
+    # stop bluechi-agent
+    node.systemctl.stop_unit("bluechi-agent")
+    assert node.wait_for_unit_state_to_be("bluechi-agent", "inactive")
+
+    # check that bluechi-agent is offline
+    result = node.bluechi_is_online.agent_is_online()
+    assert not result, f"bluechi-agent on node {node.name} should be offline"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    node_foo = nodes[NODE_FOO]
+    check_execs(node=node_foo)
+
+
+def test_bluechi_is_online(
+    bluechi_test: BluechiTest,
+    bluechi_node_default_config: BluechiAgentConfig,
+    bluechi_ctrl_default_config: BluechiControllerConfig,
+):
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = NODE_FOO
+
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION

Adding test for bluechi-is-online agent.
'bluechi-is-online agent' command is verifying  on the agent machine check and/or monitor the connection of the agent to the controller.
When the agent is online, it exits with a status code 0 and does not produce any CLI output.


Fixes: https://github.com/eclipse-bluechi/bluechi/issues/981
Signed-off-by: Dana Orr <dorr@redhat.com>
