### PR TITLE
Add bluechi_is_online node module and integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # IDE
 .vscode/
+.idea/
+inspectionProfiles/
 
 # Build
 tags

--- a/tests/bluechi_test/bluechi_is_online.py
+++ b/tests/bluechi_test/bluechi_is_online.py
@@ -34,3 +34,12 @@ class BluechiIsOnline:
             0,
         )
         return result == 0
+
+    def node_is_online(self, node_name: str) -> bool:
+        result, output = self.run(
+            "Checking controller status.",
+            f"node {node_name}",
+            False,
+            0,
+        )
+        return result == 0

--- a/tests/tests/tier0/bluechi-is-online-node/main.fmf
+++ b/tests/tests/tier0/bluechi-is-online-node/main.fmf
@@ -1,0 +1,2 @@
+summary: on the controller machine test the connection of the given node to the controller
+id: fa5a2ff8-fbea-4a0c-8106-a8cb2c295581

--- a/tests/tests/tier0/bluechi-is-online-node/test_bluechi_is_online_node.py
+++ b/tests/tests/tier0/bluechi-is-online-node/test_bluechi_is_online_node.py
@@ -1,0 +1,46 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+from typing import Dict
+
+from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
+from bluechi_test.test import BluechiTest
+
+NODE_FOO = "node-foo"
+
+
+def check_execs(ctrl: BluechiControllerMachine, node: BluechiAgentMachine):
+    # Check that the BlueChi controller is online at the startup
+    result = ctrl.bluechi_is_online.node_is_online(node_name=NODE_FOO)
+    assert result, f"bluechi-agent for node {node.name} should be online"
+
+    # Stop the BlueChi controller
+    node.systemctl.stop_unit("bluechi-agent")
+    assert node.wait_for_unit_state_to_be("bluechi-agent", "inactive")
+
+    # Check that the BlueChi controller is offline
+    result = ctrl.bluechi_is_online.node_is_online(node_name=NODE_FOO)
+    assert not result, f"bluechi-agent for node {node.name} should be offline"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    node_foo = nodes.get(NODE_FOO)
+    check_execs(ctrl=ctrl, node=node_foo)
+
+
+def test_bluechi_is_online_controller(
+    bluechi_test: BluechiTest,
+    bluechi_node_default_config: BluechiAgentConfig,
+    bluechi_ctrl_default_config: BluechiControllerConfig,
+):
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = NODE_FOO
+
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO]
+
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Adding test for bluechi-is-online node.
'bluechi-is-online node' command is verifying on the controller machine (check and/or monitor) the connection of the given node to the controller
When the node is online, it exits with a status code 0 and does not produce any CLI output.

Fixes: https://github.com/eclipse-bluechi/bluechi/issues/982
Signed-off-by: Nisim Simsolo [nsimsolo@redhat.com](mailto:nsimsolo@redhat.com)