### PR TITLE
Fix finding bluechi-image container

### DIFF
--- a/tests/bluechi_test/fixtures.py
+++ b/tests/bluechi_test/fixtures.py
@@ -200,7 +200,9 @@ def bluechi_image_id(
     image = next(
         iter(
             podman_client.images.list(
-                filters="reference=*{image_name}".format(image_name=bluechi_image_name)
+                filters={
+                    "reference": "*{image_name}".format(image_name=bluechi_image_name)
+                },
             )
         ),
         None,


### PR DESCRIPTION
We have been using `filters` parameter for `images.list()` in podman-py
to search for bluechi-image container. But podman-py 5.3 changed the
behaviour of `filters` paramater as a part of
https://github.com/containers/podman-py/issues/457 , so we need to use
`name` parameter for searching.

Signed-off-by: Martin Perina <mperina@redhat.com>
