### PR TITLE
Configure Packit to handle downstream builds

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -106,3 +106,22 @@ jobs:
       - fedora-all-ppc64le
       - fedora-all-s390x
       - fedora-all-x86_64
+
+  - job: propose_downstream
+    trigger: release
+    dist_git_branches:
+      - fedora-all
+      - epel-all
+
+  - job: koji_build
+    trigger: commit
+    dist_git_branches:
+      - fedora-all
+      - epel-all
+
+  - job: bodhi_update
+    trigger: commit
+    dist_git_branches:
+      # rawhide updates are created automatically
+      - fedora-branched
+      - epel-all


### PR DESCRIPTION
Adding configuration for Packit to:
1. Propose PR on https://src.fedoraproject.org/rpms/bluechi triggered by release on GH
2. Once merged (and thus new commit created in dist-git) - Koji and Bodhi updates will be triggered.

The .packit.yml configuration file should be updated in dist-git as well as part of the PR, so no need to create Packit configuration in dist git right now