### PR TITLE
Support uds and tcp in parallel

### DIFF
--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -75,6 +75,7 @@ This package contains the controller service.
 %ghost %{_sysconfdir}/bluechi/controller.conf
 %dir %{_sysconfdir}/bluechi
 %dir %{_sysconfdir}/bluechi/controller.conf.d
+%dir %{_rundir}/bluechi
 %doc README.md
 %doc README.developer.md
 %license LICENSE

--- a/config/controller/controller.conf
+++ b/config/controller/controller.conf
@@ -56,3 +56,8 @@
 # Number of keepalive packets without ACK from the agent till the peer connection is dropped. Value is
 # set to socket option TCP_KEEPCNT.
 #TCPKeepAliveCount=6
+
+#
+# Enables or disables the connection handler for agents to connect remotely via TCP/IP. If disabled, the
+# all other TCP options including the ControllerPort are not used.
+#UseTCP=true

--- a/config/controller/controller.conf
+++ b/config/controller/controller.conf
@@ -58,6 +58,12 @@
 #TCPKeepAliveCount=6
 
 #
-# Enables or disables the connection handler for agents to connect remotely via TCP/IP. If disabled, the
+# Enables or disables the connection handler for agents to connect remotely via TCP/IP. If disabled,
 # all other TCP options including the ControllerPort are not used.
+# The TCP handler can run alongside the UDS handler and the systemd socket activated handler.
 #UseTCP=true
+
+#
+# Enables or disables the connection handler for agents to connect locally via Unix Domain Socket (UDS). 
+# The UDS handler can run alongside the TCP handler and the systemd socket activated handler.
+#UseUDS=true

--- a/doc/man/bluechi-controller.conf.5.md
+++ b/doc/man/bluechi-controller.conf.5.md
@@ -17,6 +17,13 @@ The bluechi-controller configuration file is using the
 
 All fields to bootstrap the bluechi controller are contained in the **bluechi-controller** section. The following keys are understood by `bluechi-controller`.
 
+#### **UseTCP** (string)
+
+If this flag is set to `true`, it enables the connection handler for agents to connect
+remotely via TCP/IP to the controller. If disabled, all other TCP options such as the
+ControllerPort or TCPKeepAliveTime are not used. 
+Default: true.
+
 #### **ControllerPort** (uint16_t)
 
 The port the bluechi-controller listens on to establish connections with the `bluechi-agent`. By default port `842` is used.
@@ -24,7 +31,7 @@ The port the bluechi-controller listens on to establish connections with the `bl
 #### **AllowedNodeNames** (string)
 
 A comma separated list of unique bluechi-agent names. It's mandatory to set the option, only nodes with names mentioned
-in the list can connect to `bluechi-controller'. These names are defined in the agent's configuration file under `NodeName`
+in the list can connect to `bluechi-controller`. These names are defined in the agent's configuration file under `NodeName`
 option (see `bluechi-agent.conf(5)`).
 
 #### **HeartbeatInterval** (long)

--- a/doc/man/bluechi-controller.conf.5.md
+++ b/doc/man/bluechi-controller.conf.5.md
@@ -21,7 +21,17 @@ All fields to bootstrap the bluechi controller are contained in the **bluechi-co
 
 If this flag is set to `true`, it enables the connection handler for agents to connect
 remotely via TCP/IP to the controller. If disabled, all other TCP options such as the
-ControllerPort or TCPKeepAliveTime are not used. 
+ControllerPort or TCPKeepAliveTime are not used.
+The TCP handler can run alongside the handler for local connections (Unix Domain Socket)
+as well as the systemd socket activated handler.
+Default: true.
+
+#### **UseUDS** (string)
+
+If this flag is set to `true`, it enables the connection handler for agents to connect
+locally via Unix Domain Socket (UDS) to the controller.
+The UDS handler can run alongside the handler for remote connections (TCP/IP) as well as
+the systemd socket activated handler.
 Default: true.
 
 #### **ControllerPort** (uint16_t)
@@ -124,10 +134,9 @@ LogIsQuiet=false
 
 ## FILES
 
-Distributions provide the __/usr/share/bluechi/config/controller.conf__ file which defines bluechi configuration defaults. Administrators can copy this file to __/etc/bluechi/controller.conf__ and specify their own configuration.
+Distributions provide the **/usr/share/bluechi/config/controller.conf** file which defines bluechi configuration defaults. Administrators can copy this file to **/etc/bluechi/controller.conf** and specify their own configuration.
 
-Administrators can also use a "drop-in" directory __/etc/bluechi/controller.conf.d__ to drop their configuration changes.
-
+Administrators can also use a "drop-in" directory **/etc/bluechi/controller.conf.d** to drop their configuration changes.
 
 ## SEE ALSO
 

--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,7 @@ conf.set('_GNU_SOURCE', true)
 
 prefixdir = get_option('prefix')
 
+conf.set_quoted('CONFIG_H_UDS_SOCKET_PATH', get_option('unix_domain_socket_path'))
 conf.set_quoted('CONFIG_H_SYSCONFDIR', join_paths(prefixdir, get_option('sysconfdir')))
 conf.set_quoted('CONFIG_H_DATADIR', join_paths(prefixdir, get_option('datadir')))
 conf.set_quoted('CONFIG_H_BC_VERSION', run_command(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,3 +16,6 @@ option('with_man_pages', type : 'boolean', value : true,
 option('with_selinux', type : 'boolean', value : true,
     description : 'Include the build and install of bluechi-selinux')
 
+option('unix_domain_socket_path', type : 'string', 
+    description: 'The path of the Unix Domain Socket for BlueChi', 
+    value: '/run/bluechi/bluechi.sock')

--- a/src/controller/controller.h
+++ b/src/controller/controller.h
@@ -17,6 +17,7 @@
 struct Controller {
         int ref_count;
 
+        bool use_uds;
         bool use_tcp;
         uint16_t port;
         char *api_bus_service_name;
@@ -25,6 +26,7 @@ struct Controller {
 
         sd_event *event;
         sd_event_source *node_connection_tcp_socket_source;
+        sd_event_source *node_connection_uds_socket_source;
         sd_event_source *node_connection_systemd_socket_source;
 
         sd_bus *api_bus;

--- a/src/controller/controller.h
+++ b/src/controller/controller.h
@@ -17,13 +17,15 @@
 struct Controller {
         int ref_count;
 
+        bool use_tcp;
         uint16_t port;
         char *api_bus_service_name;
         long heartbeat_interval_msec;
         long heartbeat_threshold_msec;
 
         sd_event *event;
-        sd_event_source *node_connection_source;
+        sd_event_source *node_connection_tcp_socket_source;
+        sd_event_source *node_connection_systemd_socket_source;
 
         sd_bus *api_bus;
         sd_bus_slot *controller_slot;

--- a/src/controller/test/controller/controller_apply_config_test.c
+++ b/src/controller/test/controller/controller_apply_config_test.c
@@ -66,6 +66,7 @@ bool check_controller(
                 const char *func_name,
                 Controller *controller,
                 bool expected_use_tcp,
+                bool expected_use_uds,
                 uint16_t expected_port,
                 const char **expected_node_names,
                 uint16_t expected_node_number) {
@@ -78,6 +79,15 @@ bool check_controller(
                                 "use_tcp",
                                 bool_to_str(expected_use_tcp),
                                 bool_to_str(controller->use_tcp));
+                result = false;
+        }
+
+        if (expected_use_uds != controller->use_uds) {
+                print_controller_field_error(
+                                func_name,
+                                "use_uds",
+                                bool_to_str(expected_use_uds),
+                                bool_to_str(controller->use_uds));
                 result = false;
         }
 
@@ -142,7 +152,7 @@ bool test_controller_apply_config_none() {
                 return false;
         }
 
-        return check_controller(__func__, controller, false, 0, NULL, 0);
+        return check_controller(__func__, controller, false, false, 0, NULL, 0);
 }
 
 
@@ -155,6 +165,7 @@ bool test_controller_apply_config_valid_all() {
         }
 
         cfg_set_value(controller->config, CFG_CONTROLLER_USE_TCP, "true");
+        cfg_set_value(controller->config, CFG_CONTROLLER_USE_UDS, "true");
         cfg_set_value(controller->config, CFG_CONTROLLER_PORT, "1337");
         cfg_set_value(controller->config, CFG_ALLOWED_NODE_NAMES, "foo,bar,another");
         cfg_set_value(controller->config, CFG_TCP_KEEPALIVE_TIME, "10000");
@@ -169,7 +180,7 @@ bool test_controller_apply_config_valid_all() {
         }
 
         const char *expected_nodes[3] = { "foo", "bar", "another" };
-        return check_controller(__func__, controller, true, 1337, expected_nodes, 3);
+        return check_controller(__func__, controller, true, true, 1337, expected_nodes, 3);
 }
 
 bool test_controller_apply_config_invalid_port() {

--- a/src/controller/test/controller/controller_apply_config_test.c
+++ b/src/controller/test/controller/controller_apply_config_test.c
@@ -65,10 +65,21 @@ bool check_str(const char *func_name, const char *field_name, const char *expect
 bool check_controller(
                 const char *func_name,
                 Controller *controller,
+                bool expected_use_tcp,
                 uint16_t expected_port,
                 const char **expected_node_names,
                 uint16_t expected_node_number) {
+
         bool result = true;
+
+        if (expected_use_tcp != controller->use_tcp) {
+                print_controller_field_error(
+                                func_name,
+                                "use_tcp",
+                                bool_to_str(expected_use_tcp),
+                                bool_to_str(controller->use_tcp));
+                result = false;
+        }
 
         if (expected_port != controller->port) {
                 _cleanup_free_ char *actual = NULL;
@@ -131,7 +142,7 @@ bool test_controller_apply_config_none() {
                 return false;
         }
 
-        return check_controller(__func__, controller, 0, NULL, 0);
+        return check_controller(__func__, controller, false, 0, NULL, 0);
 }
 
 
@@ -143,6 +154,7 @@ bool test_controller_apply_config_valid_all() {
                 return false;
         }
 
+        cfg_set_value(controller->config, CFG_CONTROLLER_USE_TCP, "true");
         cfg_set_value(controller->config, CFG_CONTROLLER_PORT, "1337");
         cfg_set_value(controller->config, CFG_ALLOWED_NODE_NAMES, "foo,bar,another");
         cfg_set_value(controller->config, CFG_TCP_KEEPALIVE_TIME, "10000");
@@ -157,7 +169,7 @@ bool test_controller_apply_config_valid_all() {
         }
 
         const char *expected_nodes[3] = { "foo", "bar", "another" };
-        return check_controller(__func__, controller, 1337, expected_nodes, 3);
+        return check_controller(__func__, controller, true, 1337, expected_nodes, 3);
 }
 
 bool test_controller_apply_config_invalid_port() {

--- a/src/libbluechi/common/cfg.c
+++ b/src/libbluechi/common/cfg.c
@@ -506,6 +506,10 @@ int cfg_controller_def_conf(struct config *config) {
                 return result;
         }
 
+        if ((result = cfg_set_value(config, CFG_CONTROLLER_USE_TCP, CONTROLLER_DEFAULT_USE_TCP)) != 0) {
+                return result;
+        }
+
         if ((result = cfg_set_value(config, CFG_CONTROLLER_PORT, BC_DEFAULT_PORT)) != 0) {
                 return result;
         }

--- a/src/libbluechi/common/cfg.c
+++ b/src/libbluechi/common/cfg.c
@@ -510,6 +510,10 @@ int cfg_controller_def_conf(struct config *config) {
                 return result;
         }
 
+        if ((result = cfg_set_value(config, CFG_CONTROLLER_USE_UDS, CONTROLLER_DEFAULT_USE_UDS)) != 0) {
+                return result;
+        }
+
         if ((result = cfg_set_value(config, CFG_CONTROLLER_PORT, BC_DEFAULT_PORT)) != 0) {
                 return result;
         }

--- a/src/libbluechi/common/cfg.h
+++ b/src/libbluechi/common/cfg.h
@@ -14,6 +14,7 @@
 #define CFG_LOG_LEVEL "LogLevel"
 #define CFG_LOG_TARGET "LogTarget"
 #define CFG_LOG_IS_QUIET "LogIsQuiet"
+#define CFG_CONTROLLER_USE_TCP "UseTCP"
 #define CFG_CONTROLLER_HOST "ControllerHost"
 #define CFG_CONTROLLER_PORT "ControllerPort"
 #define CFG_CONTROLLER_ADDRESS "ControllerAddress"

--- a/src/libbluechi/common/cfg.h
+++ b/src/libbluechi/common/cfg.h
@@ -15,6 +15,7 @@
 #define CFG_LOG_TARGET "LogTarget"
 #define CFG_LOG_IS_QUIET "LogIsQuiet"
 #define CFG_CONTROLLER_USE_TCP "UseTCP"
+#define CFG_CONTROLLER_USE_UDS "UseUDS"
 #define CFG_CONTROLLER_HOST "ControllerHost"
 #define CFG_CONTROLLER_PORT "ControllerPort"
 #define CFG_CONTROLLER_ADDRESS "ControllerAddress"

--- a/src/libbluechi/common/protocol.h
+++ b/src/libbluechi/common/protocol.h
@@ -10,6 +10,10 @@
 #include "time-util.h"
 
 /* Configuration defaults */
+
+/* Enable using remote control for BlueChi via TCP */
+#define CONTROLLER_DEFAULT_USE_TCP "true"
+/* Default TCP connection information */
 #define BC_DEFAULT_PORT "842"
 #define BC_DEFAULT_HOST "127.0.0.1"
 /* Number of seconds idle before sending keepalive packets. Value is set to socket option TCP_KEEPIDLE. */

--- a/src/libbluechi/common/protocol.h
+++ b/src/libbluechi/common/protocol.h
@@ -13,6 +13,8 @@
 
 /* Enable using remote control for BlueChi via TCP */
 #define CONTROLLER_DEFAULT_USE_TCP "true"
+/* Disable using local control for BlueChi via Unix Domain Socket */
+#define CONTROLLER_DEFAULT_USE_UDS "true"
 /* Default TCP connection information */
 #define BC_DEFAULT_PORT "842"
 #define BC_DEFAULT_HOST "127.0.0.1"

--- a/src/libbluechi/socket.c
+++ b/src/libbluechi/socket.c
@@ -49,7 +49,7 @@ int create_tcp_socket(uint16_t port) {
         return steal_fd(&fd);
 }
 
-int accept_tcp_connection_request(int fd) {
+int accept_connection_request(int fd) {
         int nfd = accept4(fd, NULL, NULL, SOCK_NONBLOCK | SOCK_CLOEXEC);
         if (nfd < 0) {
                 if (errno == EAGAIN || errno == EINTR || errno == EWOULDBLOCK) {

--- a/src/libbluechi/socket.h
+++ b/src/libbluechi/socket.h
@@ -9,7 +9,7 @@
 #include <stdbool.h>
 
 int create_tcp_socket(uint16_t port);
-int accept_tcp_connection_request(int fd);
+int accept_connection_request(int fd);
 
 int fd_check_peercred(int fd);
 

--- a/src/libbluechi/socket.h
+++ b/src/libbluechi/socket.h
@@ -9,6 +9,7 @@
 #include <stdbool.h>
 
 int create_tcp_socket(uint16_t port);
+int create_uds_socket(const char *path);
 int accept_connection_request(int fd);
 
 int fd_check_peercred(int fd);

--- a/src/libbluechi/test/common/cfg/cfg_def_conf_test.c
+++ b/src/libbluechi/test/common/cfg/cfg_def_conf_test.c
@@ -212,6 +212,15 @@ bool test_cfg_controller_def_conf() {
         }
 
         /* Controller specific options */
+        value = cfg_get_value(config, CFG_CONTROLLER_USE_TCP);
+        if (!streq(value, CONTROLLER_DEFAULT_USE_TCP)) {
+                fprintf(stderr,
+                        "Expected config option %s to have default value '%s', but got '%s'\n",
+                        CFG_CONTROLLER_USE_TCP,
+                        CONTROLLER_DEFAULT_USE_TCP,
+                        value);
+                result = false;
+        }
         value = cfg_get_value(config, CFG_CONTROLLER_PORT);
         if (!streq(value, BC_DEFAULT_PORT)) {
                 fprintf(stderr,

--- a/src/libbluechi/test/common/cfg/cfg_def_conf_test.c
+++ b/src/libbluechi/test/common/cfg/cfg_def_conf_test.c
@@ -221,6 +221,15 @@ bool test_cfg_controller_def_conf() {
                         value);
                 result = false;
         }
+        value = cfg_get_value(config, CFG_CONTROLLER_USE_UDS);
+        if (!streq(value, CONTROLLER_DEFAULT_USE_UDS)) {
+                fprintf(stderr,
+                        "Expected config option %s to have default value '%s', but got '%s'\n",
+                        CFG_CONTROLLER_USE_UDS,
+                        CONTROLLER_DEFAULT_USE_UDS,
+                        value);
+                result = false;
+        }
         value = cfg_get_value(config, CFG_CONTROLLER_PORT);
         if (!streq(value, BC_DEFAULT_PORT)) {
                 fprintf(stderr,

--- a/systemd-units/bluechi-controller.socket
+++ b/systemd-units/bluechi-controller.socket
@@ -1,5 +1,10 @@
+[Unit]
+Description=BlueChi Controller Socket
+Documentation=man:bluechi-controller(1)
+
 [Socket]
-ListenStream=842
+ListenStream=%t/bluechi/bluechi.sock
+SocketMode=0666
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sockets.target

--- a/systemd-units/bluechi-controller.socket.in
+++ b/systemd-units/bluechi-controller.socket.in
@@ -3,7 +3,7 @@ Description=BlueChi Controller Socket
 Documentation=man:bluechi-controller(1)
 
 [Socket]
-ListenStream=%t/bluechi/bluechi.sock
+ListenStream=@unix_domain_socket_path@
 SocketMode=0666
 
 [Install]

--- a/systemd-units/meson.build
+++ b/systemd-units/meson.build
@@ -10,11 +10,27 @@ install_data(
   [
     'bluechi-controller.service',
     'bluechi-agent.service',
-    'bluechi-controller.socket',
     'bluechi-proxy@.service',
     'bluechi-dep@.service'
     ],
   install_dir : systemd_unit_dir
+)
+
+conf = configuration_data()
+conf.set('unix_domain_socket_path', get_option('unix_domain_socket_path'))
+
+configure_file(
+    output: 'bluechi-controller.socket',
+    input: 'bluechi-controller.socket.in',
+    configuration: conf,
+    install_dir: systemd_unit_dir,
+)
+
+# Meson does not have a variable for the /run directory.
+#   see: https://mesonbuild.com/Builtin-options.html#directories
+install_subdir(
+    'bluechi',
+    install_dir: '/run/',
 )
 
 install_data(

--- a/tests/bluechi_test/config.py
+++ b/tests/bluechi_test/config.py
@@ -38,6 +38,7 @@ class BluechiControllerConfig(BluechiConfig):
         log_target: str = "journald",
         log_is_quiet: bool = False,
         use_tcp: bool = True,
+        use_uds: bool = True,
     ) -> None:
         super().__init__(file_name)
 
@@ -50,6 +51,7 @@ class BluechiControllerConfig(BluechiConfig):
         self.log_target = log_target
         self.log_is_quiet = log_is_quiet
         self.use_tcp = use_tcp
+        self.use_uds = use_uds
 
     def serialize(self) -> str:
         # use one line for each node name so the max line length
@@ -65,6 +67,7 @@ LogLevel={self.log_level}
 LogTarget={self.log_target}
 LogIsQuiet={self.log_is_quiet}
 UseTCP={self.use_tcp}
+UseUDS={self.use_uds}
 """
 
     def get_confd_dir(self) -> str:
@@ -81,6 +84,7 @@ UseTCP={self.use_tcp}
         cfg.log_target = self.log_target
         cfg.log_is_quiet = self.log_is_quiet
         cfg.use_tcp = self.use_tcp
+        cfg.use_uds = self.use_uds
         return cfg
 
 

--- a/tests/bluechi_test/config.py
+++ b/tests/bluechi_test/config.py
@@ -37,6 +37,7 @@ class BluechiControllerConfig(BluechiConfig):
         log_level: str = "DEBUG",
         log_target: str = "journald",
         log_is_quiet: bool = False,
+        use_tcp: bool = True,
     ) -> None:
         super().__init__(file_name)
 
@@ -48,6 +49,7 @@ class BluechiControllerConfig(BluechiConfig):
         self.log_level = log_level
         self.log_target = log_target
         self.log_is_quiet = log_is_quiet
+        self.use_tcp = use_tcp
 
     def serialize(self) -> str:
         # use one line for each node name so the max line length
@@ -62,6 +64,7 @@ NodeHeartbeatThreshold={self.node_heartbeat_threshold}
 LogLevel={self.log_level}
 LogTarget={self.log_target}
 LogIsQuiet={self.log_is_quiet}
+UseTCP={self.use_tcp}
 """
 
     def get_confd_dir(self) -> str:
@@ -77,6 +80,7 @@ LogIsQuiet={self.log_is_quiet}
         cfg.log_level = self.log_level
         cfg.log_target = self.log_target
         cfg.log_is_quiet = self.log_is_quiet
+        cfg.use_tcp = self.use_tcp
         return cfg
 
 

--- a/tests/tests/tier0/bluechi-controller-disable-tcp-enable-uds/main.fmf
+++ b/tests/tests/tier0/bluechi-controller-disable-tcp-enable-uds/main.fmf
@@ -1,0 +1,3 @@
+summary: Test that bluechi-controller will add only connection handler for Unix Domain
+    Socket and disables TCP handler
+id: 4ebe60af-8eb7-4bb8-b95f-c6810369efb7

--- a/tests/tests/tier0/bluechi-controller-disable-tcp-enable-uds/test_bluechi_controller_disable_tcp_enable_uds.py
+++ b/tests/tests/tier0/bluechi-controller-disable-tcp-enable-uds/test_bluechi_controller_disable_tcp_enable_uds.py
@@ -1,0 +1,58 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import logging
+from typing import Dict
+
+from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
+from bluechi_test.test import BluechiTest
+from bluechi_test.util import Timeout
+
+LOGGER = logging.getLogger(__name__)
+NODE_LOCAL = "node-local"
+
+
+def exec(ctrl: BluechiControllerMachine, _: Dict[str, BluechiAgentMachine]):
+    assert ctrl.wait_for_unit_state_to_be("bluechi-controller.service", "active")
+
+    # Copy the port check script and run it
+    ctrl.copy_container_script("cmd-on-port.sh")
+    res, output = ctrl.exec_run(f"bash /var/cmd-on-port.sh {ctrl.config.port}")
+    assert (
+        res == 2
+    ), f"Expected bluechi-controller to not listen on port {ctrl.config.port}"
+
+    # Create configuration for local bluechi-agent
+    agent_config = BluechiAgentConfig(
+        file_name="agent.conf",
+        controller_address="unix:path=/run/bluechi/bluechi.sock",
+        node_name=NODE_LOCAL,
+    )
+    ctrl.create_file(
+        agent_config.get_confd_dir(),
+        agent_config.file_name,
+        agent_config.serialize(),
+    )
+    ctrl.systemctl.start_unit("bluechi-agent.service")
+    ctrl.wait_for_unit_state_to_be("bluechi-agent.service", "active")
+
+    with Timeout(3, f"Node {NODE_LOCAL} didn't get online in time"):
+        is_online = False
+        while not is_online:
+            _, output = ctrl.bluechictl.get_node_status(NODE_LOCAL, check_result=False)
+            is_online = "online" in output
+
+
+def test_bluechi_controller_disable_tcp_enable_uds(
+    bluechi_test: BluechiTest,
+    bluechi_ctrl_default_config: BluechiControllerConfig,
+):
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_LOCAL]
+    bluechi_ctrl_default_config.use_tcp = False
+    bluechi_ctrl_default_config.use_uds = True
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(exec)

--- a/tests/tests/tier0/bluechi-controller-disable-tcp/main.fmf
+++ b/tests/tests/tier0/bluechi-controller-disable-tcp/main.fmf
@@ -1,0 +1,2 @@
+summary: Test disabling TCP for bluechi-controller so no connection requests are accepted
+id: 234b0af5-9e78-4119-8023-5598eb91100b

--- a/tests/tests/tier0/bluechi-controller-disable-tcp/python/is_node_connected.py
+++ b/tests/tests/tier0/bluechi-controller-disable-tcp/python/is_node_connected.py
@@ -1,0 +1,26 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import time
+import unittest
+
+from bluechi_machine_lib.util import Timeout
+
+from bluechi.api import Node
+
+NODE_NAME = "node-foo"
+
+
+class TestNodeIsConnected(unittest.TestCase):
+    def test_node_is_connected(self):
+        n = Node(NODE_NAME)
+
+        with Timeout(5, f"Timeout while waiting for agent '{NODE_NAME}' to be online"):
+            while n.status != "online":
+                time.sleep(0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechi-controller-disable-tcp/test_bluechi_controller_disable_tcp.py
+++ b/tests/tests/tier0/bluechi-controller-disable-tcp/test_bluechi_controller_disable_tcp.py
@@ -1,0 +1,66 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import logging
+import os
+from typing import Dict
+
+from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
+from bluechi_test.test import BluechiTest
+
+LOGGER = logging.getLogger(__name__)
+NODE_FOO = "node-foo"
+
+
+def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
+    # Verify that the bluechi-agent is connected to bluechi-controller
+    result, output = ctrl.run_python(os.path.join("python", "is_node_connected.py"))
+    if result != 0:
+        raise Exception(output)
+
+    # Stop both components
+    ctrl.systemctl.stop_unit("bluechi-controller")
+    nodes[NODE_FOO].systemctl.stop_unit("bluechi-agent")
+
+    # Set UseTCP=False and overwrite controller config
+    ctrl_config = ctrl.config.deep_copy()
+    ctrl_config.use_tcp = False
+    ctrl.create_file(
+        ctrl_config.get_confd_dir(),
+        ctrl_config.file_name,
+        ctrl_config.serialize(),
+    )
+
+    # Start both components
+    ctrl.systemctl.start_unit("bluechi-controller")
+    ctrl.wait_for_unit_state_to_be("bluechi-controller", "active")
+    nodes[NODE_FOO].systemctl.start_unit("bluechi-agent")
+    nodes[NODE_FOO].wait_for_unit_state_to_be("bluechi-agent", "active")
+
+    # Copy the port check script and run it
+    ctrl.copy_container_script("cmd-on-port.sh")
+    res, output = ctrl.exec_run(f"bash /var/cmd-on-port.sh {ctrl_config.port}")
+    assert (
+        res == 2
+    ), f"Expected bluechi-controller to not listen on port {ctrl_config.port}"
+
+    _, output = ctrl.bluechictl.get_node_status(NODE_FOO, check_result=False)
+    assert "offline" in output, f"Expected {NODE_FOO} to be offline"
+
+
+def test_bluechi_controller_disable_tcp(
+    bluechi_test: BluechiTest,
+    bluechi_node_default_config: BluechiAgentConfig,
+    bluechi_ctrl_default_config: BluechiControllerConfig,
+):
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = NODE_FOO
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO]
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(exec)

--- a/tests/tests/tier0/bluechi-controller-runs-tcp-and-socket-activation-parallel/main.fmf
+++ b/tests/tests/tier0/bluechi-controller-runs-tcp-and-socket-activation-parallel/main.fmf
@@ -1,0 +1,3 @@
+summary: Test that the systemd socket unit for bluechi-controller will start the service
+    and it listens on the Unix Domain Socket passed to it as well as on TCP
+id: 62705aa9-a422-4280-9d93-bfa03ea749a4

--- a/tests/tests/tier0/bluechi-controller-runs-tcp-and-socket-activation-parallel/test_bluechi_controller_runs_tcp_and_socket_activation_parallel.py
+++ b/tests/tests/tier0/bluechi-controller-runs-tcp-and-socket-activation-parallel/test_bluechi_controller_runs_tcp_and_socket_activation_parallel.py
@@ -1,0 +1,67 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import logging
+from typing import Dict
+
+from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
+from bluechi_test.test import BluechiTest
+from bluechi_test.util import Timeout
+
+LOGGER = logging.getLogger(__name__)
+NODE_LOCAL = "node-local"
+NODE_REMOTE = "node-remote"
+
+
+def exec(ctrl: BluechiControllerMachine, _: Dict[str, BluechiAgentMachine]):
+    ctrl.systemctl.stop_unit("bluechi-controller.service", check_result=False)
+    assert ctrl.wait_for_unit_state_to_be("bluechi-controller.service", "inactive")
+
+    ctrl.systemctl.start_unit("bluechi-controller.socket")
+    assert ctrl.wait_for_unit_state_to_be("bluechi-controller.socket", "active")
+
+    agent_config = BluechiAgentConfig(
+        file_name="agent.conf",
+        controller_address="unix:path=/run/bluechi/bluechi.sock",
+        node_name=NODE_LOCAL,
+    )
+    ctrl.create_file(
+        agent_config.get_confd_dir(),
+        agent_config.file_name,
+        agent_config.serialize(),
+    )
+
+    ctrl.systemctl.start_unit("bluechi-agent.service")
+    ctrl.wait_for_unit_state_to_be("bluechi-agent.service", "active")
+    ctrl.wait_for_unit_state_to_be("bluechi-controller.service", "active")
+
+    with Timeout(3, f"Node {NODE_LOCAL} didn't get online in time"):
+        is_online = False
+        while not is_online:
+            _, output = ctrl.bluechictl.get_node_status(NODE_LOCAL, check_result=False)
+            is_online = "online" in output
+
+    with Timeout(3, f"Node {NODE_REMOTE} didn't get online in time"):
+        is_online = False
+        while not is_online:
+            _, output = ctrl.bluechictl.get_node_status(NODE_REMOTE, check_result=False)
+            is_online = "online" in output
+
+
+def test_bluechi_controller_runs_tcp_and_socket_activation_parallel(
+    bluechi_test: BluechiTest,
+    bluechi_node_default_config: BluechiAgentConfig,
+    bluechi_ctrl_default_config: BluechiControllerConfig,
+):
+    node_foo_cfg = bluechi_node_default_config.deep_copy()
+    node_foo_cfg.node_name = NODE_REMOTE
+    node_foo_cfg.heartbeat_interval = 500
+    bluechi_test.add_bluechi_agent_config(node_foo_cfg)
+
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_LOCAL, NODE_REMOTE]
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(exec)

--- a/tests/tests/tier0/bluechi-controller-runs-uds-and-socket-activation-parallel/main.fmf
+++ b/tests/tests/tier0/bluechi-controller-runs-uds-and-socket-activation-parallel/main.fmf
@@ -1,0 +1,3 @@
+summary: Test that the systemd socket unit for bluechi-controller will start the service,
+    listens on the Unix Domain Socket passed to it and handles the collision
+id: 9c27c73d-9bd7-4253-aedd-58401d907d46

--- a/tests/tests/tier0/bluechi-controller-runs-uds-and-socket-activation-parallel/test_bluechi_controller_runs_uds_and_socket_activation_parallel.py
+++ b/tests/tests/tier0/bluechi-controller-runs-uds-and-socket-activation-parallel/test_bluechi_controller_runs_uds_and_socket_activation_parallel.py
@@ -1,0 +1,55 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import logging
+from typing import Dict
+
+from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
+from bluechi_test.test import BluechiTest
+from bluechi_test.util import Timeout
+
+LOGGER = logging.getLogger(__name__)
+NODE_LOCAL = "node-local"
+
+
+def exec(ctrl: BluechiControllerMachine, _: Dict[str, BluechiAgentMachine]):
+    ctrl.systemctl.stop_unit("bluechi-controller.service", check_result=False)
+    assert ctrl.wait_for_unit_state_to_be("bluechi-controller.service", "inactive")
+
+    ctrl.systemctl.start_unit("bluechi-controller.socket")
+    assert ctrl.wait_for_unit_state_to_be("bluechi-controller.socket", "active")
+
+    agent_config = BluechiAgentConfig(
+        file_name="agent.conf",
+        controller_address="unix:path=/run/bluechi/bluechi.sock",
+        node_name=NODE_LOCAL,
+    )
+    ctrl.create_file(
+        agent_config.get_confd_dir(),
+        agent_config.file_name,
+        agent_config.serialize(),
+    )
+
+    ctrl.systemctl.start_unit("bluechi-agent.service")
+    ctrl.wait_for_unit_state_to_be("bluechi-agent.service", "active")
+    ctrl.wait_for_unit_state_to_be("bluechi-controller.service", "active")
+
+    with Timeout(3, f"Node {NODE_LOCAL} didn't get online in time"):
+        is_online = False
+        while not is_online:
+            _, output = ctrl.bluechictl.get_node_status(NODE_LOCAL, check_result=False)
+            is_online = "online" in output
+
+
+def test_bluechi_controller_runs_uds_and_socket_activation_parallel(
+    bluechi_test: BluechiTest,
+    bluechi_ctrl_default_config: BluechiControllerConfig,
+):
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_LOCAL]
+    bluechi_ctrl_default_config.use_uds = True
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(exec)

--- a/tests/tests/tier0/bluechi-controller-socket-activation/main.fmf
+++ b/tests/tests/tier0/bluechi-controller-socket-activation/main.fmf
@@ -1,0 +1,3 @@
+summary: Test that the systemd socket unit for bluechi-controller will start the service
+    and it listens on the Unix Domain Socket passed to it
+id: 5166606e-41e5-416f-b61d-3f2252706db7

--- a/tests/tests/tier0/bluechi-controller-socket-activation/python/is_node_connected.py
+++ b/tests/tests/tier0/bluechi-controller-socket-activation/python/is_node_connected.py
@@ -1,0 +1,26 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import time
+import unittest
+
+from bluechi_machine_lib.util import Timeout
+
+from bluechi.api import Node
+
+NODE_NAME = "node-foo"
+
+
+class TestNodeIsConnected(unittest.TestCase):
+    def test_node_is_connected(self):
+        n = Node(NODE_NAME)
+
+        with Timeout(5, f"Timeout while waiting for agent '{NODE_NAME}' to be online"):
+            while n.status != "online":
+                time.sleep(0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests/tier0/bluechi-controller-socket-activation/test_bluechi_controller_socket_activation.py
+++ b/tests/tests/tier0/bluechi-controller-socket-activation/test_bluechi_controller_socket_activation.py
@@ -1,0 +1,52 @@
+#
+# Copyright Contributors to the Eclipse BlueChi project
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import logging
+import os
+from typing import Dict
+
+from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
+from bluechi_test.test import BluechiTest
+
+LOGGER = logging.getLogger(__name__)
+NODE_FOO = "node-foo"
+
+
+def exec(ctrl: BluechiControllerMachine, _: Dict[str, BluechiAgentMachine]):
+    ctrl.systemctl.stop_unit("bluechi-controller.service", check_result=False)
+    assert ctrl.wait_for_unit_state_to_be("bluechi-controller.service", "inactive")
+
+    ctrl.systemctl.start_unit("bluechi-controller.socket")
+    assert ctrl.wait_for_unit_state_to_be("bluechi-controller.socket", "active")
+
+    agent_config = BluechiAgentConfig(
+        file_name="agent.conf",
+        controller_address="unix:path=/run/bluechi/bluechi.sock",
+        node_name=NODE_FOO,
+    )
+    ctrl.create_file(
+        agent_config.get_confd_dir(),
+        agent_config.file_name,
+        agent_config.serialize(),
+    )
+
+    ctrl.systemctl.start_unit("bluechi-agent.service")
+    ctrl.wait_for_unit_state_to_be("bluechi-agent.service", "active")
+    ctrl.wait_for_unit_state_to_be("bluechi-controller.service", "active")
+
+    result, output = ctrl.run_python(os.path.join("python", "is_node_connected.py"))
+    if result != 0:
+        raise Exception(output)
+
+
+def test_bluechi_controller_socket_activation(
+    bluechi_test: BluechiTest,
+    bluechi_ctrl_default_config: BluechiControllerConfig,
+):
+    bluechi_ctrl_default_config.allowed_node_names = [NODE_FOO]
+    bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+
+    bluechi_test.run(exec)


### PR DESCRIPTION
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/997

### Added UDS support without sock activation
    
Due to the systemd socket unit for the bluechi-controller multiple connection mechanisms such as TCP or UDS are supported. However, it is not possible to start BlueChi directly (or the systemd service) and use UDS since the FD for it gets passed from the socket unit. In order to support this, another connection handler has been added as well as the corresponding configuration option UseUDS, which is set to false by default. A collision of the systemd socket unit and the built-in UDS is being detected, logged and proceeded since the desired event source is available. Additionally, a meson option has been added to simplify using the same UDS path everywhere.

### Add support to run TCP/IP and UDS (via socket activation) in parallel

In order to support to run TCP/IP and UDS (via systemds socket activation), an event source is being added to the loop for both methods. The systemd socket unit might be changed so that the used TCP/IP address collides with the configured ControllerPort. This is being detected and causes the controller to skip setting up the duplicated TCP/IP handler - socket activation has precedence. Additionally, to only accept connection requests via UDS, another configuration option UseTCP has been added. If set to true, setting up the handler for TCP/IP will be skipped. By default, TCP will be used. Additionally, integration tests were added to verify the socket activation as well as the new UseTCP configuration option.

Signed-off-by: Michael Engel <mengel@redhat.com>


### Missing

~- [ ] SELinux policy needs to be refined for UDS~
~- [ ] Documentation has been updated~