### PR TITLE
Fixed overrunning log_level_to_string for invalid loglevel

### DIFF
--- a/src/libbluechi/log/log.c
+++ b/src/libbluechi/log/log.c
@@ -10,10 +10,13 @@
 
 #include "log.h"
 
-
-static const char * const log_level_strings[] = { "DEBUG", "INFO", "WARN", "ERROR" };
+#define NUM_LOGLEVEL 5
+static const char * const log_level_strings[NUM_LOGLEVEL] = { "DEBUG", "INFO", "WARN", "ERROR", "INVALID" };
 
 const char *log_level_to_string(LogLevel l) {
+        if (l < 0 || l > NUM_LOGLEVEL - 1) {
+                return log_level_strings[LOG_LEVEL_INVALID];
+        }
         return log_level_strings[l];
 }
 

--- a/src/libbluechi/test/log/log_level_to_string_test.c
+++ b/src/libbluechi/test/log/log_level_to_string_test.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright Contributors to the Eclipse BlueChi project
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libbluechi/common/string-util.h"
+#include "libbluechi/log/log.h"
+
+bool test_log_level_to_string(LogLevel in, const char *expected_log_level) {
+        const char *lvl = log_level_to_string(in);
+        if (lvl == NULL || !streq(expected_log_level, lvl)) {
+                fprintf(stderr,
+                        "FAILED: log_level_to_string('%d') - Expected %s, but got %s\n",
+                        in,
+                        expected_log_level,
+                        lvl);
+                return false;
+        }
+        return true;
+}
+
+int main() {
+        bool result = true;
+
+        result = result && test_log_level_to_string(LOG_LEVEL_DEBUG, "DEBUG");
+        result = result && test_log_level_to_string(LOG_LEVEL_INFO, "INFO");
+        result = result && test_log_level_to_string(LOG_LEVEL_ERROR, "ERROR");
+        result = result && test_log_level_to_string(LOG_LEVEL_WARN, "WARN");
+        result = result && test_log_level_to_string(LOG_LEVEL_INVALID, "INVALID");
+
+        result = result && test_log_level_to_string(-1, "INVALID");
+        result = result && test_log_level_to_string(99, "INVALID");
+
+        if (result) {
+                return EXIT_SUCCESS;
+        }
+        return EXIT_FAILURE;
+}

--- a/src/libbluechi/test/log/meson.build
+++ b/src/libbluechi/test/log/meson.build
@@ -7,6 +7,7 @@ common_src = [
   'bc_log_init_test',
   'bc_log_to_stderr_full_test',
   'bc_log_to_stderr_test',
+  'log_level_to_string_test',
   'log_target_to_str_test',
   'string_to_log_level_test',
 ]


### PR DESCRIPTION
There is a Buffer Overflow in the `log_level_to_string` when passing in a `LogLevel` (i.e. an index) out of range of the `log_level_strings` array. This PR fixes the `log_level_to_string` function and adds an unit test incl. these test cases to verify it.