### PR TITLE
Fix peer ip error log

### DIFF
--- a/src/controller/node.c
+++ b/src/controller/node.c
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
+#include <systemd/sd-bus.h>
+
 #include "libbluechi/bus/bus.h"
 #include "libbluechi/bus/utils.h"
 #include "libbluechi/common/parse-util.h"
@@ -15,7 +17,6 @@
 #include "monitor.h"
 #include "node.h"
 #include "proxy_monitor.h"
-#include <systemd/sd-bus.h>
 
 #define DEBUG_AGENT_MESSAGES 0
 
@@ -662,11 +663,12 @@ bool node_set_agent_bus(Node *node, sd_bus *bus) {
         }
 
         node->agent_bus = sd_bus_ref(bus);
+
         // If getting peer IP fails, only log and proceed as normal.
         _cleanup_free_ char *peer_ip = NULL;
         uint16_t peer_port = 0;
-        r = get_peer_address(node->agent_bus, &peer_ip, &peer_port);
-        if (r < 0) {
+        r = get_peer_ip_address(node->agent_bus, &peer_ip, &peer_port);
+        if (r < 0 && r != -EINVAL) {
                 bc_log_errorf("Failed to get peer IP: %s", strerror(-r));
         } else {
                 node->peer_ip = steal_pointer(&peer_ip);

--- a/src/libbluechi/bus/bus.c
+++ b/src/libbluechi/bus/bus.c
@@ -295,11 +295,15 @@ sd_bus *user_bus_open(sd_event *event) {
 }
 
 
-int get_peer_address(sd_bus *bus, char **ret_address, uint16_t *ret_port) {
+int get_peer_ip_address(sd_bus *bus, char **ret_address, uint16_t *ret_port) {
         int fd = sd_bus_get_fd(bus);
         if (fd < 0) {
-                bc_log_errorf("Failed to file descriptor from bus: %s", strerror(-fd));
+                bc_log_errorf("Failed to get file descriptor from bus: %s", strerror(-fd));
                 return fd;
+        }
+
+        if (!fd_is_socket_tcp(fd)) {
+                return -EINVAL;
         }
 
         struct sockaddr_storage addr = { 0 };

--- a/src/libbluechi/bus/bus.h
+++ b/src/libbluechi/bus/bus.h
@@ -18,4 +18,4 @@ sd_bus *system_bus_open(sd_event *event);
 sd_bus *systemd_bus_open(sd_event *event);
 sd_bus *user_bus_open(sd_event *event);
 
-int get_peer_address(sd_bus *bus, char **ret_address, uint16_t *ret_port);
+int get_peer_ip_address(sd_bus *bus, char **ret_address, uint16_t *ret_port);

--- a/src/libbluechi/socket.c
+++ b/src/libbluechi/socket.c
@@ -209,7 +209,7 @@ int socket_options_set_ip_recverr(SocketOptions *opts, bool recverr) {
         return 0;
 }
 
-static bool is_socket_tcp(int fd) {
+bool fd_is_socket_tcp(int fd) {
         int type = 0;
         socklen_t length = sizeof(int);
 
@@ -220,8 +220,8 @@ static bool is_socket_tcp(int fd) {
 
 int socket_set_options(int fd, SocketOptions *opts) {
         /* Just exit in case of a non-tcp socket. We could connect to a UNIX socket as well. */
-        if (!is_socket_tcp(fd)) {
-                bc_log_debug("Socket options not set. FD is a TCP socket.");
+        if (!fd_is_socket_tcp(fd)) {
+                bc_log_debug("Socket options not set. FD is a not TCP socket.");
                 return 0;
         }
 

--- a/src/libbluechi/socket.h
+++ b/src/libbluechi/socket.h
@@ -13,6 +13,7 @@ int create_uds_socket(const char *path);
 int accept_connection_request(int fd);
 
 int fd_check_peercred(int fd);
+bool fd_is_socket_tcp(int fd);
 
 
 typedef struct SocketOptions SocketOptions;

--- a/tests/tests/tier0/bluechi-controller-socket-activation/python/is_node_connected.py
+++ b/tests/tests/tier0/bluechi-controller-socket-activation/python/is_node_connected.py
@@ -15,11 +15,15 @@ NODE_NAME = "node-foo"
 
 class TestNodeIsConnected(unittest.TestCase):
     def test_node_is_connected(self):
-        n = Node(NODE_NAME)
 
         with Timeout(5, f"Timeout while waiting for agent '{NODE_NAME}' to be online"):
-            while n.status != "online":
-                time.sleep(0.5)
+            status = "offline"
+            while status != "online":
+                try:
+                    status = Node(NODE_NAME).status
+                    time.sleep(0.5)
+                except Exception:
+                    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Fix flacky node is online subtest in socket activation test

See failure in Testing Farm: https://artifacts.dev.testing-farm.io/f50e8572-659a-44ea-a901-f5bc90e48cbd/  
  
#### Check fd is TCP before determining PeerIP
    
Fixes: https://github.com/eclipse-bluechi/bluechi/issues/998
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/997
    
When using Unix Domain Sockets, we can't determine the Peer IP of the agent. Therefore, lets check the socket family and skip getting the Peer IP when the related fd is not IPv4 or IPv6.
  
Signed-off-by: Michael Engel <mengel@redhat.com>


