### PR TITLE
Fix selinux policy for uds

### DIFF
--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -75,7 +75,6 @@ This package contains the controller service.
 %ghost %{_sysconfdir}/bluechi/controller.conf
 %dir %{_sysconfdir}/bluechi
 %dir %{_sysconfdir}/bluechi/controller.conf.d
-%dir %{_rundir}/bluechi
 %doc README.md
 %doc README.developer.md
 %license LICENSE
@@ -91,6 +90,11 @@ This package contains the controller service.
 %{_sysconfdir}/bluechi/controller.conf.d/README.md
 %{_unitdir}/bluechi-controller.service
 %{_unitdir}/bluechi-controller.socket
+
+# Create UDS directory on install and setup tmpfile for reboots
+%dir %{_rundir}/bluechi
+%attr(700, root, root) %{_rundir}/bluechi
+%{_tmpfilesdir}/%{name}.conf
 
 
 #####################

--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -187,11 +187,15 @@ if [ $1 -eq 1 ]; then
 fi
 %selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/bluechi.pp.bz2
 restorecon -R %{_bindir}/bluechi* &> /dev/null || :
+restorecon -R %{_rundir}/bluechi/ &> /dev/null || :
+restorecon -R %{_localstatedir}/%{_rundir}/bluechi/ &> /dev/null || :
 
 %postun selinux
 if [ $1 -eq 0 ]; then
    %selinux_modules_uninstall -s %{selinuxtype} bluechi
    restorecon -R %{_bindir}/bluechi* &> /dev/null || :
+   restorecon -R %{_rundir}/bluechi/ &> /dev/null || :
+   restorecon -R %{_localstatedir}/%{_rundir}/bluechi/ &> /dev/null || :
 fi
 
 

--- a/config/meson.build
+++ b/config/meson.build
@@ -26,3 +26,8 @@ install_data(
   'controller.conf.d/README.md',
   install_dir :  join_paths(get_option('sysconfdir') / 'bluechi' / 'controller.conf.d')
 )
+
+install_data(
+  'tmpfile/bluechi.conf',
+  install_dir : join_paths(get_option('prefix'), 'lib', 'tmpfiles.d')
+)

--- a/config/tmpfile/bluechi.conf
+++ b/config/tmpfile/bluechi.conf
@@ -1,0 +1,1 @@
+D! /run/bluechi 0700 root root

--- a/selinux/bluechi.fc
+++ b/selinux/bluechi.fc
@@ -4,3 +4,7 @@
 /usr/bin/bluechi-agent	--	gen_context(system_u:object_r:bluechi_agent_exec_t,s0)
 /usr/libexec/bluechi-agent	--	gen_context(system_u:object_r:bluechi_agent_exec_t,s0)
 
+# Since /var/run is canonical in rhel9 and /run in rhel10
+# we apply the context for both directories
+/run/bluechi(/.*)?		gen_context(system_u:object_r:bluechi_var_run_t,s0)
+/var/run/bluechi(/.*)?		gen_context(system_u:object_r:bluechi_var_run_t,s0)

--- a/selinux/bluechi.te
+++ b/selinux/bluechi.te
@@ -25,6 +25,7 @@ corenet_port(bluechi_port_t)
 type bluechi_agent_port_t;
 corenet_port(bluechi_agent_port_t)
 
+
 ########################################
 #
 # bluechi local policy
@@ -57,7 +58,7 @@ kernel_dgram_send(bluechi_t)
 logging_send_syslog_msg(bluechi_t)
 logging_read_syslog_pid(bluechi_t)
 
-allow haproxy_t bluechi_t:unix_stream_socket connectto;
+unconfined_dbus_chat(bluechi_t)
 
 ########################################
 #
@@ -98,6 +99,26 @@ dbus_system_bus_client(bluechi_agent_t)
 
 init_status(bluechi_agent_t)
 
+
+########################################
+#
+# bluechi policy for unix domain sockets
+#
+type bluechi_var_run_t;
+files_pid_file(bluechi_var_run_t)
+init_sock_file(bluechi_var_run_t)
+mls_trusted_object(bluechi_var_run_t)
+
+manage_sock_files_pattern(bluechi_t, bluechi_var_run_t, bluechi_var_run_t)
+stream_connect_pattern(bluechi_agent_t, bluechi_var_run_t, bluechi_var_run_t, bluechi_t)
+unconfined_server_stream_connectto(bluechi_agent_t)
+
+########################################
+#
+# bluechi policy with haproxy
+#
+allow haproxy_t bluechi_t:unix_stream_socket connectto;
+
 rhcs_stream_connect_haproxy(bluechi_agent_t)
 
 gen_require(`
@@ -109,5 +130,3 @@ stream_connect_pattern(bluechi_agent_t, haproxy_var_lib_t, haproxy_var_lib_t, ha
 
 manage_sock_files_pattern(init_t, haproxy_var_lib_t, haproxy_var_lib_t)
 manage_sock_files_pattern(init_t, haproxy_var_run_t, haproxy_var_run_t)
-
-unconfined_dbus_chat(bluechi_t)


### PR DESCRIPTION
### Updated SELinux policy
    
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/997
    
The SELinux policy for BlueChi did not allow using UDS. Since these where introduces in https://github.com/eclipse-bluechi/bluechi/issues/997 the policy has been updated to allow the bluechi-controller to create and manage the UDS in /run (or /var/run) and the bluechi-agent to
connect to it.

### Fixed creating /run directory
    
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/997
    
The /run directory is being cleaned up on every system boot. If the /run/bluechi directory is only created during RPM install, it is removed on the next system shutdown. Therefore, the tmpfiles.d is being used to ensure that the /run/bluechi directory will be recreated on each boot - similar to /run/podman.

Signed-off-by: Michael Engel <mengel@redhat.com>