### PR TITLE
Initial work on limiting what names an agent can register by the seliux context.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,7 +27,10 @@ Checks: >
     -readability-else-after-return,
     -misc-include-cleaner,
     -bugprone-multi-level-implicit-pointer-conversion,
-    -cppcoreguidelines-macro-to-enum
+    -cppcoreguidelines-macro-to-enum,
+    -cert-int09-c,
+    -readability-enum-initial-value,
+    -readability-math-missing-parentheses
 
 CheckOptions:
     - key: readability-function-cognitive-complexity.Threshold

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,7 +1,7 @@
 .PHONY: installdeps srpm
 
 installdeps:
-	dnf -y install gcc gcc-c++ git jq meson systemd-devel rpm-build
+	dnf -y install gcc gcc-c++ git jq libselinux-devel meson systemd-devel rpm-build
 
 srpm: installdeps
 	git config --global --add safe.directory "$(shell pwd)"

--- a/.packit.yml
+++ b/.packit.yml
@@ -12,6 +12,7 @@ srpm_build_deps:
   - gcc-c++
   - git
   - jq
+  - libselinux-devel
   - meson
   - systemd-devel
   - rpm-build

--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -23,6 +23,7 @@ BuildRequires:	gcc
 # Meson needs to detect C++, because part of inih library (which we don't use) provides C++ functionality
 BuildRequires:	gcc-c++
 BuildRequires:	meson
+BuildRequires:	libselinux-devel
 BuildRequires:	systemd-devel
 BuildRequires:	systemd-rpm-macros
 BuildRequires:	golang-github-cpuguy83-md2man

--- a/doc/man/bluechi-controller.conf.5.md
+++ b/doc/man/bluechi-controller.conf.5.md
@@ -13,11 +13,14 @@ The basic file definition used to bootstrap bluechi-controller.
 The bluechi-controller configuration file is using the
 [systemd configuration file format](https://www.freedesktop.org/software/systemd/man/systemd.syntax.html). Contrary to this, there is no need for the `\` symbol at the end of a line to continue a value on the next line. A value continued on multiple lines will just be concatenated by bluechi. The maximum line length supported is 500 characters. If the value exceeds this limitation, use multiple, indented lines.
 
-### **bluechi-controller** section
+Global options for the bluechi controller are contained in the
+**[bluechi-controller]** section. In addition, sections named **[node
+NODENAME]** allow setting options that are specific to the a
+particular node.
 
-All fields to bootstrap the bluechi controller are contained in the **bluechi-controller** section. The following keys are understood by `bluechi-controller`.
+## Global options
 
-#### **UseTCP** (string)
+### **UseTCP** (string)
 
 If this flag is set to `true`, it enables the connection handler for agents to connect
 remotely via TCP/IP to the controller. If disabled, all other TCP options such as the
@@ -26,7 +29,7 @@ The TCP handler can run alongside the handler for local connections (Unix Domain
 as well as the systemd socket activated handler.
 Default: true.
 
-#### **UseUDS** (string)
+### **UseUDS** (string)
 
 If this flag is set to `true`, it enables the connection handler for agents to connect
 locally via Unix Domain Socket (UDS) to the controller.
@@ -34,25 +37,27 @@ The UDS handler can run alongside the handler for remote connections (TCP/IP) as
 the systemd socket activated handler.
 Default: true.
 
-#### **ControllerPort** (uint16_t)
+### **ControllerPort** (uint16_t)
 
 The port the bluechi-controller listens on to establish connections with the `bluechi-agent`. By default port `842` is used.
 
-#### **AllowedNodeNames** (string)
+### **AllowedNodeNames** (string)
 
-A comma separated list of unique bluechi-agent names. It's mandatory to set the option, only nodes with names mentioned
-in the list can connect to `bluechi-controller`. These names are defined in the agent's configuration file under `NodeName`
-option (see `bluechi-agent.conf(5)`).
+A comma separated list of unique bluechi-agent names. Only nodes with
+names mentioned in the list, or nodes with **Allowed=true** in a
+separate node section can connect to `bluechi-controller`.
 
-#### **HeartbeatInterval** (long)
+These names are defined in the agent's configuration file under `NodeName` option (see `bluechi-agent.conf(5)`).
+
+### **HeartbeatInterval** (long)
 
 The interval to periodically check node's connectivity based on heartbeat signals sent to bluechi, in milliseconds. A value of 0 disables it.
 
-#### **NodeHeartbeatThreshold** (long)
+### **NodeHeartbeatThreshold** (long)
 
 The threshold in milliseconds to determine whether a node is disconnected. If the node's last heartbeat signal was received before this threshold, bluechi assumes that the node is down or the connection was cut off and performs a disconnect.
 
-#### **LogLevel** (string)
+### **LogLevel** (string)
 
 The level used for logging. Supported values are:
 
@@ -63,7 +68,7 @@ The level used for logging. Supported values are:
 
 By default `INFO` level is used for logging.
 
-#### **LogTarget** (string)
+### **LogTarget** (string)
 
 The target where logs are written to. Supported values are:
 
@@ -73,11 +78,11 @@ The target where logs are written to. Supported values are:
 
 By default `journald` is used as the target.
 
-#### **LogIsQuiet** (string)
+### **LogIsQuiet** (string)
 
 If this flag is set to `true`, no logs are written by bluechi. By default the flag is set to `false`.
 
-#### **IPReceiveErrors** (string)
+### **IPReceiveErrors** (string)
 
 If this flag is set to `true`, it enables extended, reliable error message passing for
 the peer connection with all agents. This results in BlueChi receiving errors such as
@@ -86,24 +91,39 @@ useful to detect disconnects faster, but should be used with care as this might 
 unnecessary disconnects in less robut networks.
 Default: true.
 
-#### **TCPKeepAliveTime** (long)
+### **TCPKeepAliveTime** (long)
 
 The number of seconds the individual TCP connection with an agent needs to be idle
 before keepalive packets are sent. When `TCPKeepAliveTime` is set to 0, the system
 default will be used.
 Default: 1s.
 
-#### **TCPKeepAliveInterval** (long)
+### **TCPKeepAliveInterval** (long)
 
 The number of seconds between each keepalive packet. When `TCPKeepAliveInterval` is set to 0,
 the system default will be used.
 Default: 1s.
 
-#### **TCPKeepAliveCount** (long)
+### **TCPKeepAliveCount** (long)
 
 The number of keepalive packets without ACK from an agent till the individual connection is dropped.
 When `TCPKeepAliveCount` is set to 0, the system default will be used.
 Default: 6.
+
+## Per-node options
+
+### **Allowed** (boolean)
+
+If true, the node with the section name is allowed to connect. See **AllowedNodeNames** above.
+
+### **RequiredSelinuxContext** (string)
+
+If set, the connecting node process must have the specified SELinux
+type label. Typically for local connections these would be
+bluechi_agent_t or haproxy_t.
+
+Note: this option only works when the agent connects using unix domain
+sockets.
 
 ## Example
 
@@ -116,9 +136,13 @@ AllowedNodeNames=agent-007,agent-123
 LogLevel=DEBUG
 LogTarget=journald
 LogIsQuiet=false
+
+[node agent-009]
+Allowed=true
+RequiredSelinuxContext=haproxy_t
 ```
 
-Using a value that is continued on multiple lines:
+Example using a value that is continued on multiple lines:
 
 ```
 [bluechi-controller]
@@ -137,6 +161,8 @@ LogIsQuiet=false
 Distributions provide the **/usr/share/bluechi/config/controller.conf** file which defines bluechi configuration defaults. Administrators can copy this file to **/etc/bluechi/controller.conf** and specify their own configuration.
 
 Administrators can also use a "drop-in" directory **/etc/bluechi/controller.conf.d** to drop their configuration changes.
+Such drop-ins are especially useful for per-node configuration as they can extend the list of available nodes without
+modifying the base configuration file.
 
 ## SEE ALSO
 

--- a/meson.build
+++ b/meson.build
@@ -59,6 +59,12 @@ conf = configuration_data()
 # Enable GNU extensions.
 conf.set('_GNU_SOURCE', true)
 
+with_selinux = get_option('with_selinux')
+if with_selinux
+  selinux_dep = dependency('libselinux', required: true)
+  conf.set('CONFIG_H_USE_SELINUX', true)
+endif
+
 prefixdir = get_option('prefix')
 
 conf.set_quoted('CONFIG_H_UDS_SOCKET_PATH', get_option('unix_domain_socket_path'))
@@ -99,7 +105,7 @@ subdir('src/libbluechi')
 subdir('config')
 
 # selinux
-if get_option('with_selinux')
+if with_selinux
   subdir('selinux')
 endif
 

--- a/src/controller/main.c
+++ b/src/controller/main.c
@@ -31,7 +31,7 @@ static void usage(char *argv[]) {
                "Available options are:\n"
                "\t-%c %s\t\t Print this help message.\n"
                "\t-%c %s\t\t The port of bluechi to connect to.\n"
-               "\t-%c %s\t A path to a config file used to bootstrap bluechi-agent.\n"
+               "\t-%c %s\t A path to a config file used to bootstrap bluechi-controller.\n"
                "\t-%c %s\t Print current bluechi version.\n",
                argv[0],
                ARG_HELP_SHORT,

--- a/src/controller/meson.build
+++ b/src/controller/meson.build
@@ -21,14 +21,20 @@ ctrl_src = [
     'main.c',
 ]
 
-executable(
-  'bluechi-controller',
-  ctrl_src,
-  dependencies: [
+controller_deps = [
     systemd_dep,
     inih_dep,
     hashmapc_dep,
-  ],
+  ]
+
+if with_selinux
+   controller_deps += [ selinux_dep, ]
+endif
+
+executable(
+  'bluechi-controller',
+  ctrl_src,
+  dependencies: controller_deps,
   link_with: [
     bluechi_lib,
   ],

--- a/src/controller/node.h
+++ b/src/controller/node.h
@@ -54,6 +54,7 @@ struct Node {
         char *name; /* NULL for not yet registered nodes */
         char *object_path;
         char *peer_ip;
+        char *peer_selinux_context;
 
         LIST_HEAD(AgentRequest, outstanding_requests);
         LIST_HEAD(ProxyMonitor, proxy_monitors);

--- a/src/controller/node.h
+++ b/src/controller/node.h
@@ -52,6 +52,7 @@ struct Node {
         LIST_FIELDS(Node, nodes);
 
         char *name; /* NULL for not yet registered nodes */
+        char *required_selinux_context;
         char *object_path;
         char *peer_ip;
         char *peer_selinux_context;
@@ -80,6 +81,7 @@ bool node_has_agent(Node *node);
 bool node_is_online(Node *node);
 bool node_set_agent_bus(Node *node, sd_bus *bus);
 void node_unset_agent_bus(Node *node);
+bool node_set_required_selinux_context(Node *node, const char *selinux_context);
 
 AgentRequest *node_request_list_units(
                 Node *node, agent_request_response_t cb, void *userdata, free_func_t free_userdata);

--- a/src/controller/test/controller/meson.build
+++ b/src/controller/test/controller/meson.build
@@ -20,11 +20,7 @@ endforeach
 foreach src : controller_src
   exec_test = executable(src,
     controller_test_src + [src + '.c'],
-    dependencies: [
-        systemd_dep,
-        inih_dep,
-        hashmapc_dep,
-    ],
+    dependencies: controller_deps,
     link_with: [
         bluechi_lib,
     ],

--- a/src/libbluechi/common/cfg.c
+++ b/src/libbluechi/common/cfg.c
@@ -358,7 +358,7 @@ int cfg_s_set_value(
         }
         struct config_option *replaced = (struct config_option *) hashmap_set(
                         config->cfg_store,
-                        &(struct config_option){
+                        &(struct config_option) {
                                         .section = section_copy, .name = name_copy, .value = value_copy });
         if (hashmap_oom(config->cfg_store)) {
                 free(section_copy);
@@ -382,8 +382,8 @@ const char *cfg_get_value(struct config *config, const char *option_name) {
 const char *cfg_s_get_value(struct config *config, const char *section_name, const char *option_name) {
         struct config_option *found = (struct config_option *) hashmap_get(
                         config->cfg_store,
-                        &(struct config_option){ .section = (char *) section_name,
-                                                 .name = (char *) option_name });
+                        &(struct config_option) { .section = (char *) section_name,
+                                                  .name = (char *) option_name });
         if (found != NULL) {
                 return found->value;
         }

--- a/src/libbluechi/common/cfg.h
+++ b/src/libbluechi/common/cfg.h
@@ -206,6 +206,8 @@ bool cfg_s_get_bool_value(struct config *config, const char *section, const char
  */
 const char *cfg_dump(struct config *config);
 
+char **cfg_list_sections(struct config *config);
+
 /*
  * Populate the default agent configuration from the source code
  */

--- a/src/libbluechi/common/cfg.h
+++ b/src/libbluechi/common/cfg.h
@@ -19,6 +19,8 @@
 #define CFG_CONTROLLER_HOST "ControllerHost"
 #define CFG_CONTROLLER_PORT "ControllerPort"
 #define CFG_CONTROLLER_ADDRESS "ControllerAddress"
+#define CFG_ALLOWED "Allowed"
+#define CFG_REQUIRED_SELINUX_CONTEXT "RequiredSelinuxContext"
 #define CFG_NODE_NAME "NodeName"
 #define CFG_ALLOWED_NODE_NAMES "AllowedNodeNames"
 #define CFG_HEARTBEAT_INTERVAL "HeartbeatInterval"
@@ -39,6 +41,11 @@
  * Configuration section for bluechi controller.
  */
 #define CFG_SECT_BLUECHI "bluechi-controller"
+
+/*
+ * Prefix of per-node configuration section for bluechi controller.
+ */
+#define CFG_SECT_NODE_PREFIX "node "
 
 /*
  * Configuration section for bluechi agent.

--- a/src/libbluechi/common/common.h
+++ b/src/libbluechi/common/common.h
@@ -86,6 +86,7 @@ static inline void *malloc0_array(size_t base_size, size_t element_size, size_t 
 #define _cleanup_free_ _cleanup_(freep)
 #define _cleanup_freev_ _cleanup_(freepv)
 #define _cleanup_fd_ _cleanup_(closep)
+#define _cleanup_string_builder_ _cleanup_(string_builder_destroy)
 
 // NOLINTBEGIN(bugprone-macro-parentheses)
 #define DEFINE_CLEANUP_FUNC(_type, _freefunc)         \

--- a/src/libbluechi/common/common.h
+++ b/src/libbluechi/common/common.h
@@ -41,6 +41,21 @@ static inline void freep(void *p) {
         free(*(void **) p);
 }
 
+/* Free null terminated array of pointers (each with free) */
+static inline void freev(void **p) {
+        if (p) {
+                for (size_t i = 0; p[i] != NULL; i++) {
+                        free(p[i]);
+                }
+                free(p);
+        }
+}
+
+static inline void freepv(void *p) {
+        freev(*(void ***) p);
+}
+
+
 // NOLINTBEGIN(bugprone-macro-parentheses)
 #define free_and_null(ptr) \
         free(ptr);         \
@@ -69,6 +84,7 @@ static inline void *malloc0_array(size_t base_size, size_t element_size, size_t 
 
 #define _cleanup_(x) __attribute__((__cleanup__(x)))
 #define _cleanup_free_ _cleanup_(freep)
+#define _cleanup_freev_ _cleanup_(freepv)
 #define _cleanup_fd_ _cleanup_(closep)
 
 // NOLINTBEGIN(bugprone-macro-parentheses)

--- a/src/libbluechi/common/parse-util.c
+++ b/src/libbluechi/common/parse-util.c
@@ -61,3 +61,34 @@ bool parse_linux_signal(const char *in, uint32_t *ret) {
         *ret = (uint32_t) l;
         return true;
 }
+
+char *parse_selinux_type(const char *context) {
+        /* Format is user:role:type:level */
+
+        /* Skip user */
+        char *s = strchr(context, ':');
+        if (s == NULL) {
+                return NULL;
+        }
+        s++;
+        if (*s == 0) {
+                return NULL;
+        }
+
+        /* Skip role */
+        s = strchr(s, ':');
+        if (s == NULL) {
+                return NULL;
+        }
+        s++;
+        if (*s == 0) {
+                return NULL;
+        }
+
+        char *end = strchr(s, ':');
+        if (end == NULL) {
+                return NULL;
+        }
+
+        return strndup(s, end - s);
+}

--- a/src/libbluechi/common/parse-util.h
+++ b/src/libbluechi/common/parse-util.h
@@ -15,3 +15,4 @@ bool parse_port(const char *in, uint16_t *ret);
 #define MAX_SIGNAL_VALUE 31
 
 bool parse_linux_signal(const char *in, uint32_t *ret);
+char *parse_selinux_type(const char *context);

--- a/src/libbluechi/common/string-util.c
+++ b/src/libbluechi/common/string-util.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright Contributors to the Eclipse BlueChi project
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+#include <stdio.h>
+
+#include "string-util.h"
+
+bool string_builder_init(StringBuilder *builder, size_t initial_capacity) {
+        if (initial_capacity == 0) {
+                initial_capacity = STRING_BUILDER_DEFAULT_CAPACITY;
+        }
+
+        char *str = malloc(initial_capacity);
+        if (str == NULL) {
+                return false;
+        }
+
+        str[0] = 0; /* zero terminate */
+        builder->str = str;
+        builder->len = 0;
+        builder->capacity = initial_capacity;
+
+        return true;
+}
+
+void string_builder_destroy(StringBuilder *builder) {
+        free(builder->str);
+}
+
+static bool string_builder_realloc(StringBuilder *builder, size_t new_size) {
+        char *new_str = realloc(builder->str, new_size);
+        if (new_str == NULL) {
+                return false;
+        }
+
+        builder->str = new_str;
+        builder->capacity = new_size;
+
+        return true;
+}
+
+static bool string_builder_grow(StringBuilder *builder, size_t extra_size) {
+        size_t required_size = builder->len + extra_size + 1;
+        if (builder->capacity < required_size) {
+                size_t new_size = builder->capacity * 2;
+                if (new_size < required_size) {
+                        new_size = required_size;
+                }
+
+                if (!string_builder_realloc(builder, new_size)) {
+                        return false;
+                }
+        }
+
+        builder->len += extra_size;
+        return true;
+}
+
+bool string_builder_append(StringBuilder *builder, const char *str) {
+        size_t old_len = builder->len;
+        if (!string_builder_grow(builder, strlen(str))) {
+                return false;
+        }
+
+        strncpy(builder->str + old_len, str, builder->capacity - old_len);
+
+        return true;
+}
+
+bool string_builder_printf(StringBuilder *builder, const char *format, ...) {
+        va_list ap;
+
+        /* Compute reqiured size */
+        va_start(ap, format);
+        int n = vsnprintf(builder->str, 0, format, ap);
+        va_end(ap);
+        if (n < 0) {
+                return false;
+        }
+
+        size_t old_len = builder->len;
+        if (!string_builder_grow(builder, n)) {
+                return false;
+        }
+
+        va_start(ap, format);
+        vsnprintf(builder->str + old_len, n + 1, format, ap);
+        va_end(ap);
+
+        return true;
+}

--- a/src/libbluechi/common/string-util.h
+++ b/src/libbluechi/common/string-util.h
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -100,3 +101,18 @@ static inline bool ends_with(const char *str, const char *suffix) {
         }
         return strncmp(str + str_length - suffix_length, suffix, suffix_length) == 0;
 }
+
+typedef struct StringBuilder StringBuilder;
+struct StringBuilder {
+        char *str;
+        size_t len; /* Not including terminating zero */
+        size_t capacity;
+};
+
+#define STRING_BUILDER_INIT { NULL, 0, 0 }
+#define STRING_BUILDER_DEFAULT_CAPACITY 1024
+
+bool string_builder_init(StringBuilder *builder, size_t initial_capacity);
+void string_builder_destroy(StringBuilder *builder);
+bool string_builder_append(StringBuilder *builder, const char *str);
+bool string_builder_printf(StringBuilder *builder, const char *format, ...);

--- a/src/libbluechi/common/string-util.h
+++ b/src/libbluechi/common/string-util.h
@@ -62,6 +62,10 @@ static inline bool is_glob(const char *s) {
         return s != NULL && (strchr(s, SYMBOL_GLOB_ALL) != NULL || strchr(s, SYMBOL_GLOB_ONE) != NULL);
 }
 
+static inline bool str_has_prefix(const char *s, const char *prefix) {
+        return strncmp(s, prefix, strlen(prefix)) == 0;
+}
+
 // NOLINTBEGIN(misc-no-recursion)
 static inline bool match_glob(const char *str, const char *glob) {
         if (str == NULL || glob == NULL) {

--- a/src/libbluechi/meson.build
+++ b/src/libbluechi/meson.build
@@ -24,6 +24,7 @@ libbluechi_src = [
     'common/parse-util.c',
     'common/parse-util.h',
     'common/protocol.c',
+    'common/string-util.c',
     'common/time-util.c',
     'common/time-util.h',
     'log/log.c',

--- a/src/libbluechi/test/common/parse-util_test.c
+++ b/src/libbluechi/test/common/parse-util_test.c
@@ -85,6 +85,22 @@ bool test_parse_linux_signal(const char *input, bool expected_return, uint32_t e
         return true;
 }
 
+bool test_parse_selinux_type(const char *input, const char *expected_return) {
+        _cleanup_free_ char *msg = NULL;
+        _cleanup_free_ char *res = parse_selinux_type(input);
+        if ((expected_return == NULL && res != NULL) ||
+            (expected_return != NULL && (res == NULL || !streq(expected_return, res)))) {
+                fprintf(stderr,
+                        "FAILED: %s\n\tInput: '%s'\n\tExpected: %s\n\tGot: %s\n",
+                        __FUNCTION_NAME__,
+                        input,
+                        expected_return,
+                        res);
+                return false;
+        }
+
+        return true;
+}
 
 int main() {
         bool result = true;
@@ -118,6 +134,12 @@ int main() {
         result = result && test_parse_linux_signal("32", false, 0);
         result = result && test_parse_linux_signal("-2", false, 0);
         result = result && test_parse_linux_signal("65.536", false, 0);
+
+        result = result &&
+                        test_parse_selinux_type(
+                                        "unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023",
+                                        "unconfined_t");
+        result = result && test_parse_selinux_type("unconfined_u:unconfined_r", NULL);
 
         if (!result) {
                 return EXIT_FAILURE;

--- a/src/libbluechi/test/common/string-util/meson.build
+++ b/src/libbluechi/test/common/string-util/meson.build
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 string_util_src = [
+  'string_builder_test',
   'match_glob_test',
   'ends_with_test',
 ]

--- a/src/libbluechi/test/common/string-util/string_builder_test.c
+++ b/src/libbluechi/test/common/string-util/string_builder_test.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright Contributors to the Eclipse BlueChi project
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libbluechi/common/common.h"
+#include "libbluechi/common/string-util.h"
+
+static bool check_builder_len(const char *test, StringBuilder *builder, size_t expected_len) {
+        if (builder->len != expected_len) {
+                fprintf(stdout,
+                        "FAILED: %s - Expected Length: '%zd', but got '%zd'\n",
+                        test,
+                        expected_len,
+                        builder->len);
+                return false;
+        }
+        return true;
+}
+
+
+static bool check_builder(const char *test, StringBuilder *builder, const char *expected_str) {
+        if (!streq(builder->str, expected_str)) {
+                fprintf(stdout, "FAILED: %s - Expected: '%s', but got '%s'\n", test, expected_str, builder->str);
+                return false;
+        }
+        return check_builder_len(test, builder, strlen(expected_str));
+}
+
+bool test_append(void) {
+        _cleanup_string_builder_ StringBuilder builder = STRING_BUILDER_INIT;
+
+        /* Start with low capacity to verify growing */
+        if (!string_builder_init(&builder, 1)) {
+                fprintf(stdout, "FAILED: string_builder_init() - Unexpected failure\n");
+                return false;
+        }
+
+        if (!string_builder_append(&builder, "string1")) {
+                fprintf(stdout, "FAILED: string_builder_append() - Unexpected failure\n");
+                return false;
+        }
+
+        if (!check_builder("test_append 1", &builder, "string1")) {
+                return false;
+        }
+
+        if (!string_builder_append(&builder, "string2")) {
+                fprintf(stdout, "FAILED: string_builder_append() - Unexpected failure\n");
+                return false;
+        }
+
+        if (!check_builder("test_append 2", &builder, "string1string2")) {
+                return false;
+        }
+
+        for (int i = 0; i < 1000; i++) {
+                if (!string_builder_append(&builder, "XXXXXXXXXX")) {
+                        fprintf(stdout, "FAILED: string_builder_append() - Unexpected failure\n");
+                        return false;
+                }
+        }
+
+        if (!check_builder_len(
+                            "test_append 3", &builder, strlen("string1string2") + 1000 * strlen("XXXXXXXXXX"))) {
+                return false;
+        }
+
+        return true;
+}
+
+bool test_printf(void) {
+        _cleanup_string_builder_ StringBuilder builder = STRING_BUILDER_INIT;
+
+        /* Start with low capacity to verify growing */
+        if (!string_builder_init(&builder, 1)) {
+                fprintf(stdout, "FAILED: string_builder_init() - Unexpected failure\n");
+                return false;
+        }
+
+        if (!string_builder_printf(&builder, "string%d", 1)) {
+                fprintf(stdout, "FAILED: string_builder_printf() - Unexpected failure\n");
+                return false;
+        }
+
+        if (!check_builder("test_printf 1", &builder, "string1")) {
+                return false;
+        }
+
+        if (!string_builder_printf(&builder, "string%s", "2")) {
+                fprintf(stdout, "FAILED: string_builder_printf() - Unexpected failure\n");
+                return false;
+        }
+
+        if (!check_builder("test_printf 2", &builder, "string1string2")) {
+                return false;
+        }
+
+        for (int i = 0; i < 1000; i++) {
+                if (!string_builder_printf(&builder, "%10s", "X")) {
+                        fprintf(stdout, "FAILED: string_builder_print() - Unexpected failure\n");
+                        return false;
+                }
+        }
+
+        if (!check_builder_len(
+                            "test_printf 3", &builder, strlen("string1string2") + 1000 * strlen("XXXXXXXXXX"))) {
+                return false;
+        }
+
+        return true;
+}
+
+
+int main() {
+        bool result = true;
+
+        result = result && test_append();
+        result = result && test_printf();
+
+        if (result) {
+                return EXIT_SUCCESS;
+        }
+        return EXIT_FAILURE;
+}


### PR DESCRIPTION
This extends how we configure allowed node names, and allows us to  configure per-node-name requirements.
    
A node name can now either be in the allowed names list, or the controller config (or via a .d dropin) can have a section named "[node FOO]", with a key Allowed=true.
    
If a named node is allowed, we look for the "RequiredSelinuxContext" key in the above section, and if it is set, we require the connecting agent to have the given selinux context type.
    
Note: We already disallow most processes (except bluechi_agent_t and haproxy_t) to connect to the controller, but with this we can limit what names they can claim. For example, we could enforce a special name for an agent running in qm.
