### PR TITLE
Backport: Fixed unterminated string initialization

### DIFF
--- a/build-scripts/version.sh
+++ b/build-scripts/version.sh
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 # Current version of BlueChi
-VERSION=0.9.0
+VERSION=0.9.1
 # Specify if build is a official release or a snapshot build
-IS_RELEASE="1"
+IS_RELEASE="0"
 # Used for official releases. Increment if necessary
 RELEASE="1"
 # Used to cache generated snapshot release for further usage

--- a/src/bindings/python/setup.py
+++ b/src/bindings/python/setup.py
@@ -12,7 +12,7 @@ def readme():
 
 setup(
     name="bluechi",
-    version="0.9.0",
+    version="0.9.1",
     description="Python bindings for BlueChi's D-Bus API",
     long_description=readme(),
     long_description_content_type="text/markdown",

--- a/src/libbluechi/bus/utils.c
+++ b/src/libbluechi/bus/utils.c
@@ -315,10 +315,20 @@ int assemble_object_path_string(const char *prefix, const char *name, char **res
         return asprintf(res, "%s/%s", prefix, escaped);
 }
 
+// Disabling -Wunterminated-string-initialization temporarily.
+// hexchar uses the table array only for mapping an integer to
+// a hexadecimal char, no need for it to be NULL terminated.
+#if __GNUC__ >= 15
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wunterminated-string-initialization"
+#endif
 static char hexchar(int x) {
         static const char table[16] = "0123456789abcdef";
         return table[(unsigned int) x % sizeof(table)];
 }
+#if __GNUC__ >= 15
+#        pragma GCC diagnostic pop
+#endif
 
 char *bus_path_escape(const char *s) {
 

--- a/tests/bluechi_test/fixtures.py
+++ b/tests/bluechi_test/fixtures.py
@@ -200,11 +200,14 @@ def bluechi_image_id(
     image = next(
         iter(
             podman_client.images.list(
-                filters="reference=*{image_name}".format(image_name=bluechi_image_name)
+                filters={
+                    "reference=*{image_name}".format(image_name=bluechi_image_name)
+                },
             )
         ),
         None,
     )
+
     assert image, f"Image '{bluechi_image_name}' was not found"
     return image.id
 


### PR DESCRIPTION
Backport of: https://github.com/eclipse-bluechi/bluechi/pull/1030
Relates to: https://bugzilla.redhat.com/show_bug.cgi?id=2339937

gcc v15+ will add the static check for unterminated string initialization as default, thus causing the build to fail due to the hexchar function. Since this function uses the char array only for mapping an integer to a hexadecimal char, this error can be ignored.