### PR TITLE
is-online system and agent shouldn't accept arguments

### DIFF
--- a/src/is-online/main.c
+++ b/src/is-online/main.c
@@ -22,9 +22,9 @@ int method_version(UNUSED Command *command, UNUSED void *userdata) {
 const Method methods[] = {
         { "help",    0, 0, OPT_NONE,                                         method_help,             usage },
         { "version", 0, 0, OPT_NONE,                                         method_version,          usage },
-        { "agent",   0, 2, OPT_MONITOR | OPT_WAIT | OPT_SWITCH_CTRL_TIMEOUT, method_is_online_agent,  usage },
-        { "node",    1, 3, OPT_MONITOR | OPT_WAIT,                           method_is_online_node,   usage },
-        { "system",  0, 2, OPT_MONITOR | OPT_WAIT,                           method_is_online_system, usage },
+        { "agent",   0, 0, OPT_MONITOR | OPT_WAIT | OPT_SWITCH_CTRL_TIMEOUT, method_is_online_agent,  usage },
+        { "node",    1, 1, OPT_MONITOR | OPT_WAIT,                           method_is_online_node,   usage },
+        { "system",  0, 0, OPT_MONITOR | OPT_WAIT,                           method_is_online_system, usage },
         { NULL,      0, 0, 0,                                                NULL,                    NULL  }
 };
 


### PR DESCRIPTION
It was found that running
```
bluechi-is-online agent --monitor 5000 --wait=10000
```
Does not return error, although `--monitor` is a flag. The reason is that `--monitor` is configured as a flag, and 5000 is treated as an argument, which the method `agent` is configured to accept (min 0, max 2), and the same goes for `system` method. Actually, these two methods do not expect any arguments at all.

This change will limit the usage of `bluechi-is-online agent` and `bluechi-is-online system` to not expect arguments, only the allowed options.