### PR TITLE
Add upstream_tag_template config to packit

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -4,6 +4,7 @@ issue_repository: https://github.com/eclipse-bluechi/bluechi
 specfile_path: bluechi.spec
 upstream_package_name: bluechi
 downstream_package_name: bluechi
+upstream_tag_template: v{version}
 
 update_release: false
 


### PR DESCRIPTION
Since we use v0.x.y form for release tags, Packit requires a config named upstream_tag_template to be able to extract version number from the tag.