### PR TITLE
Fix integration test failure when python-podman version >=5.3.0

### DIFF
--- a/tests/bluechi_test/fixtures.py
+++ b/tests/bluechi_test/fixtures.py
@@ -187,9 +187,7 @@ def bluechi_image_id(
     image = next(
         iter(
             podman_client.images.list(
-                filters={
-                    "reference": "*{image_name}".format(image_name=bluechi_image_name)
-                },
+                name="*{image_name}".format(image_name=bluechi_image_name)
             )
         ),
         None,


### PR DESCRIPTION
All BlueChi Tests Failed on the Latest RHIVOS-1 Nightly Build The root cause has been traced to an issue in the test fixtures. 
The failure appears to be related to a change in podman-py starting from version 5.3.0, 
which differs from the behavior in version 5.2.0 when querying the image.

Fixes: #1062