### PR TITLE
Added whitelist for nodes of proxy services

### DIFF
--- a/doc/man/bluechi-controller.conf.5.md
+++ b/doc/man/bluechi-controller.conf.5.md
@@ -125,6 +125,14 @@ bluechi_agent_t or haproxy_t.
 Note: this option only works when the agent connects using unix domain
 sockets.
 
+### **AllowDependenciesOn** (string)
+
+A comma separated list of bluechi-agent names on which the configured
+node can request services to be started with the `bluechi-proxy@.service`. 
+By default, this list is empty and thus all proxies are denied.
+
+The names are defined in the agent's configuration file under `NodeName` option (see `bluechi-agent.conf(5)`).
+
 ## Example
 
 A basic example of a configuration file for `bluechi`:
@@ -136,10 +144,17 @@ AllowedNodeNames=agent-007,agent-123
 LogLevel=DEBUG
 LogTarget=journald
 LogIsQuiet=false
+```
+
+Example with specific configuration for node `agent-009`:
+```
+[bluechi-controller]
+AllowedNodeNames=agent-007,agent-123
 
 [node agent-009]
 Allowed=true
 RequiredSelinuxContext=haproxy_t
+AllowDependenciesOn=agent-007
 ```
 
 Example using a value that is continued on multiple lines:

--- a/src/controller/node.h
+++ b/src/controller/node.h
@@ -60,6 +60,7 @@ struct Node {
         LIST_HEAD(AgentRequest, outstanding_requests);
         LIST_HEAD(ProxyMonitor, proxy_monitors);
         LIST_HEAD(ProxyDependency, proxy_dependencies);
+        LIST_HEAD(ProxyTarget, allowed_proxy_targets);
 
         struct hashmap *unit_subscriptions;
         uint64_t last_seen;
@@ -82,6 +83,7 @@ bool node_is_online(Node *node);
 bool node_set_agent_bus(Node *node, sd_bus *bus);
 void node_unset_agent_bus(Node *node);
 bool node_set_required_selinux_context(Node *node, const char *selinux_context);
+int node_add_allowed_proxy_target(Node *node, const char *target_name);
 
 AgentRequest *node_request_list_units(
                 Node *node, agent_request_response_t cb, void *userdata, free_func_t free_userdata);

--- a/src/controller/types.h
+++ b/src/controller/types.h
@@ -15,3 +15,4 @@ typedef struct Subscription Subscription;
 typedef struct SubscribedUnit SubscribedUnit;
 typedef struct MonitorPeer MonitorPeer;
 typedef struct ProxyDependency ProxyDependency;
+typedef struct ProxyTarget ProxyTarget;

--- a/src/libbluechi/common/cfg.h
+++ b/src/libbluechi/common/cfg.h
@@ -21,6 +21,7 @@
 #define CFG_CONTROLLER_ADDRESS "ControllerAddress"
 #define CFG_ALLOWED "Allowed"
 #define CFG_REQUIRED_SELINUX_CONTEXT "RequiredSelinuxContext"
+#define CFG_ALLOW_DEPENDENCIES_ON "AllowDependenciesOn"
 #define CFG_NODE_NAME "NodeName"
 #define CFG_ALLOWED_NODE_NAMES "AllowedNodeNames"
 #define CFG_HEARTBEAT_INTERVAL "HeartbeatInterval"

--- a/tests/tests/tier0/proxy-service-denied-by-default/main.fmf
+++ b/tests/tests/tier0/proxy-service-denied-by-default/main.fmf
@@ -1,0 +1,2 @@
+summary: Test if proxy services from one node to another are denied by default
+id: a52188d1-02dd-4430-801d-e29eaec217cd

--- a/tests/tests/tier0/proxy-service-fails-on-execstart/test_proxy_service_fails_on_execstart.py
+++ b/tests/tests/tier0/proxy-service-fails-on-execstart/test_proxy_service_fails_on_execstart.py
@@ -5,7 +5,11 @@
 
 from typing import Dict
 
-from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.config import (
+    BluechiAgentConfig,
+    BluechiControllerConfig,
+    BluechiControllerPerNodeConfig,
+)
 from bluechi_test.constants import NODE_CTRL_NAME
 from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
 from bluechi_test.service import Option, Section, SimpleRemainingService
@@ -61,6 +65,9 @@ def test_proxy_service_fails_on_execstart(
     node_bar_cfg.node_name = node_bar_name
 
     bluechi_ctrl_default_config.allowed_node_names = [node_bar_name]
+    bluechi_ctrl_default_config.per_node_config.append(
+        BluechiControllerPerNodeConfig(node_foo_name, proxy_to=[node_bar_name]),
+    )
 
     bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
     bluechi_test.add_bluechi_agent_config(node_bar_cfg)

--- a/tests/tests/tier0/proxy-service-multiple-services-multiple-nodes/test_proxy_service_multiple_services_multiple_nodes.py
+++ b/tests/tests/tier0/proxy-service-multiple-services-multiple-nodes/test_proxy_service_multiple_services_multiple_nodes.py
@@ -5,7 +5,11 @@
 
 from typing import Dict
 
-from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.config import (
+    BluechiAgentConfig,
+    BluechiControllerConfig,
+    BluechiControllerPerNodeConfig,
+)
 from bluechi_test.constants import NODE_CTRL_NAME
 from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
 from bluechi_test.service import Option, Section, SimpleRemainingService
@@ -89,6 +93,12 @@ def test_proxy_service_multiple_services_multiple_nodes(
         node_foo1_name,
         node_bar_name,
     ]
+    bluechi_ctrl_default_config.per_node_config.append(
+        BluechiControllerPerNodeConfig(node_foo1_name, proxy_to=[node_bar_name])
+    )
+    bluechi_ctrl_default_config.per_node_config.append(
+        BluechiControllerPerNodeConfig(node_foo2_name, proxy_to=[node_bar_name])
+    )
 
     bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
     bluechi_test.add_bluechi_agent_config(node_foo1_cfg)

--- a/tests/tests/tier0/proxy-service-multiple-services-one-node/test_proxy_service_multiple_services_one_node.py
+++ b/tests/tests/tier0/proxy-service-multiple-services-one-node/test_proxy_service_multiple_services_one_node.py
@@ -5,7 +5,11 @@
 
 from typing import Dict
 
-from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.config import (
+    BluechiAgentConfig,
+    BluechiControllerConfig,
+    BluechiControllerPerNodeConfig,
+)
 from bluechi_test.constants import NODE_CTRL_NAME
 from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
 from bluechi_test.service import Option, Section, SimpleRemainingService
@@ -97,6 +101,9 @@ def test_proxy_service_multiple_services_one_node(
     node_bar_cfg.node_name = node_bar_name
 
     bluechi_ctrl_default_config.allowed_node_names = [node_bar_name]
+    bluechi_ctrl_default_config.per_node_config.append(
+        BluechiControllerPerNodeConfig(node_foo_name, proxy_to=[node_bar_name]),
+    )
 
     bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
     bluechi_test.add_bluechi_agent_config(node_bar_cfg)

--- a/tests/tests/tier0/proxy-service-propagate-target-service-failure/test_proxy_service_propagate_target_service_failure.py
+++ b/tests/tests/tier0/proxy-service-propagate-target-service-failure/test_proxy_service_propagate_target_service_failure.py
@@ -6,7 +6,12 @@
 import logging
 from typing import Dict
 
-from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.config import (
+    BluechiAgentConfig,
+    BluechiControllerConfig,
+    BluechiControllerPerNodeConfig,
+)
+from bluechi_test.constants import NODE_CTRL_NAME
 from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
 from bluechi_test.service import Option, Section, SimpleRemainingService
 from bluechi_test.test import BluechiTest
@@ -59,6 +64,10 @@ def test_proxy_service_propagate_target_service_failure(
     bluechi_test.add_bluechi_agent_config(node_bar_cfg)
 
     bluechi_ctrl_default_config.allowed_node_names = [NODE_BAR]
+    bluechi_ctrl_default_config.per_node_config.append(
+        BluechiControllerPerNodeConfig(NODE_CTRL_NAME, proxy_to=[NODE_BAR]),
+    )
+
     bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
 
     bluechi_test.run(exec)

--- a/tests/tests/tier0/proxy-service-start/test_proxy_service_start.py
+++ b/tests/tests/tier0/proxy-service-start/test_proxy_service_start.py
@@ -5,7 +5,11 @@
 
 from typing import Dict
 
-from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.config import (
+    BluechiAgentConfig,
+    BluechiControllerConfig,
+    BluechiControllerPerNodeConfig,
+)
 from bluechi_test.constants import NODE_CTRL_NAME
 from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
 from bluechi_test.service import Option, Section, SimpleRemainingService
@@ -62,6 +66,9 @@ def test_proxy_service_start(
     node_bar_cfg.node_name = node_bar_name
 
     bluechi_ctrl_default_config.allowed_node_names = [node_bar_name]
+    bluechi_ctrl_default_config.per_node_config.append(
+        BluechiControllerPerNodeConfig(node_foo_name, proxy_to=[node_bar_name]),
+    )
 
     bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
     bluechi_test.add_bluechi_agent_config(node_bar_cfg)

--- a/tests/tests/tier0/proxy-service-stop-bluechi-dep/test_proxy_service_stop_bluechi_dep.py
+++ b/tests/tests/tier0/proxy-service-stop-bluechi-dep/test_proxy_service_stop_bluechi_dep.py
@@ -5,7 +5,11 @@
 
 from typing import Dict
 
-from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.config import (
+    BluechiAgentConfig,
+    BluechiControllerConfig,
+    BluechiControllerPerNodeConfig,
+)
 from bluechi_test.constants import NODE_CTRL_NAME
 from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
 from bluechi_test.service import Option, Section, SimpleRemainingService
@@ -72,6 +76,10 @@ def test_proxy_service_stop_bluechi_dep(
     bluechi_ctrl_default_config.allowed_node_names = [node_bar_name]
 
     bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_ctrl_default_config.per_node_config.append(
+        BluechiControllerPerNodeConfig(node_foo_name, proxy_to=[node_bar_name]),
+    )
+
     bluechi_test.add_bluechi_agent_config(node_bar_cfg)
 
     bluechi_test.run(exec)

--- a/tests/tests/tier0/proxy-service-stop-requesting-with-unneeded/test_proxy_service_stop_requesting_with_unneeded.py
+++ b/tests/tests/tier0/proxy-service-stop-requesting-with-unneeded/test_proxy_service_stop_requesting_with_unneeded.py
@@ -5,7 +5,11 @@
 
 from typing import Dict
 
-from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.config import (
+    BluechiAgentConfig,
+    BluechiControllerConfig,
+    BluechiControllerPerNodeConfig,
+)
 from bluechi_test.constants import NODE_CTRL_NAME
 from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
 from bluechi_test.service import Option, Section, SimpleRemainingService
@@ -73,6 +77,10 @@ def test_proxy_service_stop_requesting(
     bluechi_ctrl_default_config.allowed_node_names = [node_bar_name]
 
     bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_ctrl_default_config.per_node_config.append(
+        BluechiControllerPerNodeConfig(node_foo_name, proxy_to=[node_bar_name]),
+    )
+
     bluechi_test.add_bluechi_agent_config(node_bar_cfg)
 
     bluechi_test.run(exec)

--- a/tests/tests/tier0/proxy-service-stop-target/test_proxy_service_stop_target.py
+++ b/tests/tests/tier0/proxy-service-stop-target/test_proxy_service_stop_target.py
@@ -5,7 +5,11 @@
 
 from typing import Dict
 
-from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
+from bluechi_test.config import (
+    BluechiAgentConfig,
+    BluechiControllerConfig,
+    BluechiControllerPerNodeConfig,
+)
 from bluechi_test.constants import NODE_CTRL_NAME
 from bluechi_test.machine import BluechiAgentMachine, BluechiControllerMachine
 from bluechi_test.service import Option, Section, SimpleRemainingService
@@ -73,6 +77,9 @@ def test_proxy_service_stop_target(
     bluechi_ctrl_default_config.allowed_node_names = [node_bar_name]
 
     bluechi_test.set_bluechi_controller_config(bluechi_ctrl_default_config)
+    bluechi_ctrl_default_config.per_node_config.append(
+        BluechiControllerPerNodeConfig(node_foo_name, proxy_to=[node_bar_name]),
+    )
 
     bluechi_test.add_bluechi_agent_config(node_bar_cfg)
 


### PR DESCRIPTION
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/1069

Added a configuration option to enable specifying proxy services on a per-node basis in the bluechi-controller configuration. This option restricts agents from specifying dependencies on any other managed node and allows to selectively enable the proxy service feature.