### PR TITLE
Build base images for cs10

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -10,6 +10,13 @@ on:
         options:
         - build-base
         - integration-test-base
+      csversion:
+        description:
+        required: true
+        type: choice
+        options:
+        - stream9
+        - stream10
 
 jobs:
   build_container:
@@ -23,12 +30,13 @@ jobs:
 
       - name: Build manifest
         run: |
-          ./build-scripts/build-push-containers.sh ${{ inputs.image }}
+          ./build-scripts/build-push-containers.sh ${{ inputs.image }} ${{ inputs.csversion }}
 
       - name: Push manifest o quay.io
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ inputs.image }}
+          tags: ${{ inputs.csversion }}
           registry: quay.io/bluechi
           username: bluechi+bluechi_bot
           password: ${{ secrets.QUAY_BOT_API_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
   rpmbuild:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/bluechi/build-base:latest
+      image: quay.io/bluechi/build-base:stream10
     env:
       ARTIFACTS_DIR: exported-artifacts
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
     name: Common
     runs-on: ubuntu-latest
     container:
-      image: quay.io/bluechi/build-base:latest
+      image: quay.io/bluechi/build-base:stream10
 
     steps:
       - name: Checkout sources
@@ -68,7 +68,7 @@ jobs:
     name: C
     runs-on: ubuntu-latest
     container:
-      image: quay.io/bluechi/build-base:latest
+      image: quay.io/bluechi/build-base:stream10
 
     steps:
       - name: Checkout sources
@@ -113,7 +113,7 @@ jobs:
     name: Python
     runs-on: ubuntu-latest
     container:
-      image: quay.io/bluechi/build-base:latest
+      image: quay.io/bluechi/build-base:stream10
 
     steps:
       - name: Checkout sources
@@ -147,7 +147,7 @@ jobs:
     name:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/bluechi/build-base:latest
+      image: quay.io/bluechi/build-base:stream10
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/multihost-tests.yml
+++ b/.github/workflows/multihost-tests.yml
@@ -35,7 +35,7 @@ jobs:
     name: Run Integration Tests on testing farm in multihost mode
     runs-on: ubuntu-latest
     container:
-      image: quay.io/bluechi/build-base:latest
+      image: quay.io/bluechi/build-base:stream10
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     name: Create GitHub release for BlueChi
     runs-on: ubuntu-latest
     container:
-      image: quay.io/bluechi/build-base:latest
+      image: quay.io/bluechi/build-base:stream10
 
     steps:
       - name: Checkout sources
@@ -60,7 +60,7 @@ jobs:
     name: Publish bluechi on PyPi
     runs-on: ubuntu-latest
     container:
-      image: quay.io/bluechi/build-base:latest
+      image: quay.io/bluechi/build-base:stream10
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -7,7 +7,7 @@ jobs:
   sbom:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/bluechi/build-base:latest
+      image: quay.io/bluechi/build-base:stream10
     env:
       ARTIFACTS_DIR: /tmp/bluechi-artifacts
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/bluechi/build-base:latest
+      image: quay.io/bluechi/build-base:stream10
 
     steps:
       - name: Checkout sources

--- a/.packit.yml
+++ b/.packit.yml
@@ -36,6 +36,7 @@ jobs:
     trigger: pull_request
     targets:
       - epel-9-x86_64
+      - epel-10-x86_64
       - fedora-rawhide-aarch64
       - fedora-rawhide-i386
       - fedora-rawhide-ppc64le

--- a/README.developer.md
+++ b/README.developer.md
@@ -231,7 +231,7 @@ and run tests for BlueChi also in the [build-base](./containers/build-base):
 cd bluechi
 
 # run build-base container and mount bluechi directory
-podman run -it -v ./:/var/bluechi quay.io/bluechi/build-base:latest
+podman run -it -v ./:/var/bluechi quay.io/bluechi/build-base:stream10
 
 # configure meson to enable code analysis and build the project
 meson setup builddir

--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -34,7 +34,7 @@ BuildRequires: sed
 %endif
 
 %description
-BlueChi is a systemd service controller for multi-nodes environements with a
+BlueChi is a systemd service controller for multi-nodes environments with a
 predefined number of nodes and with a focus on highly regulated environment
 such as those requiring functional safety (for example in cars).
 
@@ -58,7 +58,7 @@ Obsoletes:	bluechi < 0.7.0
 Provides:	bluechi = %{version}-%{release}
 
 %description controller
-BlueChi is a systemd service controller for multi-nodes environements with a
+BlueChi is a systemd service controller for multi-nodes environments with a
 predefined number of nodes and with a focus on highly regulated environment
 such as those requiring functional safety (for example in cars).
 This package contains the controller service.
@@ -115,7 +115,7 @@ Obsoletes:	hirte-agent < 0.6.0
 Provides:	hirte-agent = %{version}-%{release}
 
 %description agent
-BlueChi is a systemd service controller for multi-nodes environements with a
+BlueChi is a systemd service controller for multi-nodes environments with a
 predefined number of nodes and with a focus on highly regulated environment
 such as those requiring functional safety (for example in cars).
 This package contains the node agent.
@@ -220,7 +220,7 @@ Obsoletes:	hirte-ctl < 0.6.0
 Provides:	hirte-ctl = %{version}-%{release}
 
 %description ctl
-BlueChi is a systemd service controller for multi-nodes environements with a
+BlueChi is a systemd service controller for multi-nodes environments with a
 predefined number of nodes and with a focus on highly regulated environment
 such as those requiring functional safety (for example in cars).
 This package contains the service controller command line tool.
@@ -246,7 +246,7 @@ Requires:	bluechi-coverage = %{version}-%{release}
 %endif
 
 %description is-online
-BlueChi is a systemd service controller for multi-nodes environements with a
+BlueChi is a systemd service controller for multi-nodes environments with a
 predefined number of nodes and with a focus on highly regulated environment
 such as those requiring functional safety (for example in cars).
 This package contains a command line tool for checking and monitoring the

--- a/build-scripts/build-push-containers.sh
+++ b/build-scripts/build-push-containers.sh
@@ -7,28 +7,35 @@
 # The 1st parameter is the image name
 IMAGE="$1"
 
-# The 2nd parameter is optional and it specifies the container architecture. If omitted, all archs will be built.
-ARCHITECTURES="${2:-amd64 arm64}"
+# The 2nd parameter is the centos stream version
+CENTOS_STREAM_VERSION="$2"
+
+# The 3rd parameter is optional and it specifies the container architecture. If omitted, all archs will be built.
+ARCHITECTURES="${3:-amd64 arm64}"
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 ROOT_DIR=$SCRIPT_DIR"/../"
 CONTAINER_FILE_DIR=$SCRIPT_DIR"/../containers"
 
+IMAGE_NAME="${IMAGE}:${CENTOS_STREAM_VERSION}"
+QUAY_NAME="quay.io/bluechi/${IMAGE_NAME}"
+
 function push(){
-    buildah manifest push --all $IMAGE "docker://quay.io/bluechi/$IMAGE"
+    buildah manifest push --all "${IMAGE_NAME}" "docker://${QUAY_NAME}"
 }
 
 function build(){
     # remove old image, ignore result
-    buildah manifest rm $IMAGE &> /dev/null || true
+    buildah manifest rm "${IMAGE_NAME}" &> /dev/null || true
 
-    buildah manifest create $IMAGE
+    buildah manifest create "${IMAGE_NAME}"
 
     for arch in $ARCHITECTURES; do
-        buildah bud --tag "quay.io/bluechi/$IMAGE" \
-            --manifest $IMAGE \
-            --arch ${arch} \
-            -f ${CONTAINER_FILE_DIR}/${IMAGE} \
-            ${ROOT_DIR}
+        buildah bud --tag "${QUAY_NAME}" \
+            --manifest "${IMAGE_NAME}" \
+            --arch "${arch}" \
+            --build-arg "centos_stream_version=${CENTOS_STREAM_VERSION}" \
+            -f "${CONTAINER_FILE_DIR}/${IMAGE}" \
+            "${ROOT_DIR}"
     done
 }
 

--- a/containers/build-base
+++ b/containers/build-base
@@ -1,8 +1,11 @@
-FROM quay.io/centos/centos:stream9
+ARG centos_stream_version
 
-# CRB is required for meson
+FROM quay.io/centos/centos:$centos_stream_version
+
+# CRB is required for meson and lcovs perl dependencies
 # EPEL is required for lcov, python3-flake8, python3-html2text and codespell
-RUN dnf install -y dnf-plugin-config-manager && \
+RUN dnf upgrade --refresh --nodocs -y && \
+    dnf install -y dnf-plugin-config-manager && \
     dnf config-manager -y --set-enabled crb && \
     dnf install -y epel-release && \
     dnf update --refresh --nodocs -y && \
@@ -23,17 +26,18 @@ RUN dnf install -y dnf-plugin-config-manager && \
         libselinux-devel \
         make \
         meson \
+        pyproject-rpm-macros \
+        python3-devel \
+        python3-dasbus \
         python3-html2text \
         python3-pip \
-        python3-devel \
+        python3-tomli \
         rpm-build \
         sed \
         selinux-policy-devel \
         systemd-devel \
         tar \
         valgrind \
-        pyproject-rpm-macros \
-        python3-tomli \
     -y && \
     dnf -y clean all
 

--- a/containers/integration-test-base
+++ b/containers/integration-test-base
@@ -1,6 +1,12 @@
-FROM quay.io/centos/centos:stream9
+ARG centos_stream_version
 
+FROM quay.io/centos/centos:$centos_stream_version
+
+# CRB is required for lcovs perl dependencies
+# EPEL is required for lcov python3-dasbus, etc.
 RUN dnf upgrade --refresh --nodocs -y && \
+    dnf install -y dnf-plugin-config-manager && \
+    dnf config-manager -y --set-enabled crb && \
     dnf install --nodocs epel-release -y && \
     dnf install --nodocs \
             lcov \

--- a/doc/docs/security/securing_multi_node.md
+++ b/doc/docs/security/securing_multi_node.md
@@ -130,7 +130,7 @@ All traffic is forwarded to bluechi-controller via its Unix socket.
 
 ```haproxy
 #---------------------------------------------------------------------
-# main frontend which proxys to the backends
+# main frontend which proxies to the backends
 #---------------------------------------------------------------------
 frontend bluechi-controller
     mode tcp
@@ -161,7 +161,7 @@ All traffic is forwarded to the remote machine while enforcing mTLS.
 
 ```haproxy
 #----------------------------------------------------------------
-# main frontend which proxys to the backends
+# main frontend which proxies to the backends
 #----------------------------------------------------------------
 frontend bluechi-agent
     mode tcp

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ target-version = ["py39", "py310", "py311"]
 
 [flake8]
 max-line-length = 120
-extend-ignore = E203,E701
+extend-ignore = E203,E701,E231,E222,E272
 
 [isort]
 profile = black

--- a/src/client/method-list-unit-files.c
+++ b/src/client/method-list-unit-files.c
@@ -72,6 +72,10 @@ static int parse_unit_file_list(sd_bus_message *message, const char *node_name, 
 static int method_list_unit_files_on_all(sd_bus *api_bus, print_unit_file_list_fn print, const char *glob_filter) {
         int r = 0;
         _cleanup_unit_file_list_ UnitFileList *unit_file_list = new_unit_file_list();
+        if (unit_file_list == NULL) {
+                fprintf(stderr, "Failed to create unit file list, OOM");
+                return -ENOMEM;
+        }
 
         _cleanup_sd_bus_error_ sd_bus_error error = SD_BUS_ERROR_NULL;
         _cleanup_sd_bus_message_ sd_bus_message *message = NULL;

--- a/src/client/method-list-units.c
+++ b/src/client/method-list-units.c
@@ -68,6 +68,10 @@ static int parse_unit_list(sd_bus_message *message, const char *node_name, UnitL
 static int method_list_units_on_all(sd_bus *api_bus, print_unit_list_fn print, const char *glob_filter) {
         int r = 0;
         _cleanup_unit_list_ UnitList *unit_list = new_unit_list();
+        if (unit_list == NULL) {
+                fprintf(stderr, "Failed to create unit list, OOM");
+                return -ENOMEM;
+        }
 
         _cleanup_sd_bus_error_ sd_bus_error error = SD_BUS_ERROR_NULL;
         _cleanup_sd_bus_message_ sd_bus_message *message = NULL;

--- a/src/client/method-status.c
+++ b/src/client/method-status.c
@@ -461,10 +461,22 @@ static Node *
                 node = NULL;
                 return NULL;
         }
-        node->connection->name = strdup(node_name);
-        node->connection->node_path = strdup(node_path);
-        node->connection->state = strdup(node_state);
-        node->connection->ip = strdup(ip);
+
+        _cleanup_free_ char *name_dup = strdup(node_name);
+        _cleanup_free_ char *node_path_dup = strdup(node_path);
+        _cleanup_free_ char *state_dup = strdup(node_state);
+        _cleanup_free_ char *ip_dup = strdup(ip);
+        if (name_dup == NULL || node_path_dup == NULL || state_dup == NULL || ip_dup == NULL) {
+                free(node->connection);
+                node->connection = NULL;
+                free(node);
+                node = NULL;
+                return NULL;
+        }
+        node->connection->name = steal_pointer(&name_dup);
+        node->connection->node_path = steal_pointer(&node_path_dup);
+        node->connection->state = steal_pointer(&state_dup);
+        node->connection->ip = steal_pointer(&ip_dup);
         node->connection->last_seen = last_seen_timestamp;
         node->api_bus = api_bus;
         node->nodes = head;

--- a/src/libbluechi/common/string-util.c
+++ b/src/libbluechi/common/string-util.c
@@ -72,7 +72,7 @@ bool string_builder_append(StringBuilder *builder, const char *str) {
 bool string_builder_printf(StringBuilder *builder, const char *format, ...) {
         va_list ap;
 
-        /* Compute reqiured size */
+        /* Compute required size */
         va_start(ap, format);
         int n = vsnprintf(builder->str, 0, format, ap);
         va_end(ap);

--- a/tests/containers/integration-test-local
+++ b/tests/containers/integration-test-local
@@ -1,4 +1,4 @@
-FROM quay.io/bluechi/integration-test-base:latest
+FROM quay.io/bluechi/integration-test-base:stream10
 
 RUN mkdir -p /tmp/bluechi-rpms
 

--- a/tests/containers/integration-test-snapshot
+++ b/tests/containers/integration-test-snapshot
@@ -1,4 +1,4 @@
-FROM quay.io/bluechi/integration-test-base:latest
+FROM quay.io/bluechi/integration-test-base:stream10
 
 ARG copr_repo
 

--- a/tests/scripts/create_coverage_report.py
+++ b/tests/scripts/create_coverage_report.py
@@ -33,6 +33,8 @@ def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
     root = pathlib.Path(path_to_info_files)
     lcov_list = list()
     lcov_list.append("lcov")
+    lcov_list.append("--ignore-errors")
+    lcov_list.append("gcov,empty")
     for file_path in root.glob("**/*.info"):
         LOGGER.debug(f"Found info file '{str(file_path)}'")
         content = read_file(file_path)

--- a/tests/scripts/gather-code-coverage.sh
+++ b/tests/scripts/gather-code-coverage.sh
@@ -20,4 +20,4 @@ for file in ${GCDA_DIR}/*.gcda ; do
 done
 
 # Generate info file
-geninfo ${GCDA_DIR} -b ${GCDA_DIR}/src -o ${INFO_FILE}
+geninfo --ignore-errors gcov,empty ${GCDA_DIR} -b ${GCDA_DIR}/src -o ${INFO_FILE}

--- a/tests/tests/tier0/bluechi-agent-cmd-options/test_bluechi_agent_cmd_options.py
+++ b/tests/tests/tier0/bluechi-agent-cmd-options/test_bluechi_agent_cmd_options.py
@@ -65,12 +65,12 @@ def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
 
     # Check if node connected successfully
     time.sleep(1)
-    LOGGER.debug("Veryfying node connection")
+    LOGGER.debug("Verifying node connection")
     result, _ = ctrl.run_python(os.path.join("python", "is_node_connected.py"))
     assert result == 0
 
     # Verify the heartbeat is shorter than configured in agent.conf
-    LOGGER.debug("Veryfying expected heartbeat interval")
+    LOGGER.debug("Verifying expected heartbeat interval")
     result, _ = ctrl.run_python(os.path.join("python", "verify_heartbeat.py"))
     assert result == 0
 
@@ -100,7 +100,7 @@ def exec(ctrl: BluechiControllerMachine, nodes: Dict[str, BluechiAgentMachine]):
 
     # Check if node connected successfully
     time.sleep(1)
-    LOGGER.debug("Veryfying node connection")
+    LOGGER.debug("Verifying node connection")
     result, _ = ctrl.run_python(os.path.join("python", "is_node_connected.py"))
     assert result == 0
 

--- a/tests/tests/tier0/monitor-multiple-nodes-and-units/main.fmf
+++ b/tests/tests/tier0/monitor-multiple-nodes-and-units/main.fmf
@@ -1,2 +1,2 @@
-summary: Test if a montor with a subscription to a list of units on a single node receives the relevant signals, but none from a different node with the same unit
+summary: Test if a monitor with a subscription to a list of units on a single node receives the relevant signals, but none from a different node with the same unit
 id: 0d86b4bb-8e92-488a-8a17-bef9cfe1d2ce


### PR DESCRIPTION
Relates to: https://github.com/eclipse-bluechi/bluechi/issues/1086
    
In order to be able to build and test on CentOS Stream 10 while simultaneously supporting CentOS Stream 9 builds and tests for backport, the CentOS Stream version is being parameterized and the GH Action for building and pushing the images have been updated.

**Edit:** 
Container images build and pushed for the tags `stream9` and `stream10`:
https://quay.io/repository/bluechi/build-base?tab=tags
https://quay.io/repository/bluechi/integration-test-base?tab=tags