### PR TITLE
Fix lcov coverage collection for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -103,11 +103,13 @@ jobs:
         id: run-tests
         run: |
           cd tests
+          BLUECHI_VERSION=$(../build-scripts/version.sh)
           tmt --feeling-safe \
             run -v \
             -eCONTAINER_USED=integration-test-local \
             -eWITH_COVERAGE=1 \
             -eLOG_LEVEL=DEBUG \
+            -eBLUECHI_VERSION=${BLUECHI_VERSION} \
             plan --name container
 
       - name: Show tmt log output in case of failure

--- a/containers/build-base
+++ b/containers/build-base
@@ -32,6 +32,7 @@ RUN dnf upgrade --refresh --nodocs -y && \
         python3-html2text \
         python3-pip \
         python3-tomli \
+        python3-wheel \
         rpm-build \
         sed \
         selinux-policy-devel \

--- a/tests/bluechi_test/machine.py
+++ b/tests/bluechi_test/machine.py
@@ -16,7 +16,7 @@ from bluechi_test.client import Client
 from bluechi_test.config import BluechiAgentConfig, BluechiControllerConfig
 from bluechi_test.service import Service
 from bluechi_test.systemctl import SystemCtl
-from bluechi_test.util import get_random_name, read_file
+from bluechi_test.util import get_env_value, get_random_name, read_file
 
 LOGGER = logging.getLogger(__name__)
 
@@ -276,8 +276,10 @@ class BluechiMachine:
         coverage_file = f"{BluechiMachine.gcda_file_location}/coverage-{self.name}.info"
 
         LOGGER.info(f"Generating info file '{coverage_file}' started")
+        bluechi_version = get_env_value("BLUECHI_VERSION", "unknown")
+
         result, output = self.client.exec_run(
-            f"/usr/share/bluechi-coverage/bin/gather-code-coverage.sh {coverage_file}"
+            f"/usr/share/bluechi-coverage/bin/gather-code-coverage.sh {coverage_file} {bluechi_version}"
         )
         if result != 0:
             LOGGER.error(f"Failed to gather code coverage: {output}")

--- a/tests/scripts/gather-code-coverage.sh
+++ b/tests/scripts/gather-code-coverage.sh
@@ -7,6 +7,8 @@
 
 # First parameter is the name of the generated info file
 INFO_FILE=${1:-coverage.info}
+BLUECHI_VERSION=${2:-unknown}
+BLUECHI_BUILD_DIR="/github/home/rpmbuild/BUILD/bluechi-${BLUECHI_VERSION}"
 
 source $(dirname "$(readlink -f "$0")")/setup-src-dir-for-coverage.sh
 
@@ -20,4 +22,8 @@ for file in ${GCDA_DIR}/*.gcda ; do
 done
 
 # Generate info file
-geninfo --ignore-errors gcov,empty ${GCDA_DIR} -b ${GCDA_DIR}/src -o ${INFO_FILE}
+# Use literal paths to avoid variable expansion issues
+geninfo ${GCDA_DIR} \
+  --substitute "s|${BLUECHI_BUILD_DIR}/|/var/tmp/bluechi-coverage/|g" \
+  --ignore-errors source \
+  --output-file ${INFO_FILE}


### PR DESCRIPTION
Fix geninfo path mapping issues that prevented proper coverage collection during integration tests. The issue was caused by hardcoded build paths in .gcno files that didn't match the runtime container paths.

Changes made:
- Add python3-wheel dependency to build-base container
- Fix geninfo path substitution in gather-code-coverage.sh using --substitute
- Replace build-time paths with runtime container paths dynamically

This resolves the coverage drop issues and enables successful coverage collection during integration tests with proper path mapping.

Closes https://github.com/eclipse-bluechi/bluechi/issues/1088