### PR TITLE
Add coverage improvements and version handling

### DIFF
--- a/tests/scripts/gather-code-coverage.sh
+++ b/tests/scripts/gather-code-coverage.sh
@@ -7,10 +7,7 @@
 
 # First parameter is the name of the generated info file
 INFO_FILE=${1:-coverage.info}
-BLUECHI_VERSION=${2:-unknown}
-BLUECHI_BUILD_DIR="/github/home/rpmbuild/BUILD/bluechi-${BLUECHI_VERSION}"
-
-source $(dirname "$(readlink -f "$0")")/setup-src-dir-for-coverage.sh
+GCDA_DIR=${2:-/var/tmp/bluechi-coverage}
 
 # Move each .gcda file into the respective project directory containing the .gcno
 for file in ${GCDA_DIR}/*.gcda ; do
@@ -21,8 +18,9 @@ for file in ${GCDA_DIR}/*.gcda ; do
     mv -v $file ${GCDA_DIR}/${tmp_f}
 done
 
+BLUECHI_BUILD_DIR=".*/rpmbuild/BUILD/bluechi[^/]*"
 # Generate info file
-# Use literal paths to avoid variable expansion issues
+# Substitute build directory paths with coverage directory paths using regex pattern
 geninfo ${GCDA_DIR} \
   --substitute "s|${BLUECHI_BUILD_DIR}/|/var/tmp/bluechi-coverage/|g" \
   --ignore-errors source \


### PR DESCRIPTION

Improve code coverage handling and simplify version detection

- Remove BLUECHI_VERSION parameter dependency from gather-code-coverage.sh
- Use regex pattern for flexible BlueChi build directory detection
- Update machine.py to check for source directory existence before coverage
- Simplify coverage file generation by removing version-specific paths
- Update comment to clarify regex pattern substitution in geninfo command
- Make coverage gathering more robust and version-agnostic