### PR TITLE
Change restart behavior in systemd units

### DIFF
--- a/src/libbluechi/common/parse-util.c
+++ b/src/libbluechi/common/parse-util.c
@@ -66,7 +66,7 @@ char *parse_selinux_type(const char *context) {
         /* Format is user:role:type:level */
 
         /* Skip user */
-        char *s = strchr(context, ':');
+        const char *s = strchr(context, ':');
         if (s == NULL) {
                 return NULL;
         }
@@ -85,7 +85,7 @@ char *parse_selinux_type(const char *context) {
                 return NULL;
         }
 
-        char *end = strchr(s, ':');
+        const char *end = strchr(s, ':');
         if (end == NULL) {
                 return NULL;
         }

--- a/src/proxy/main.c
+++ b/src/proxy/main.c
@@ -52,7 +52,7 @@ int parse_node_unit_opt(const char *opt_node_unit, char **ret_node_name, char **
                 return -EINVAL;
         }
 
-        char *split = strchr(opt_node_unit, '_');
+        const char *split = strchr(opt_node_unit, '_');
         if (split == NULL || split == opt_node_unit) {
                 fprintf(stderr, "No underscore in unit name '%s'\n", opt_node_unit);
                 return -EINVAL;

--- a/systemd-units/bluechi-agent.service
+++ b/systemd-units/bluechi-agent.service
@@ -10,7 +10,12 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/usr/libexec/bluechi-agent
-Restart=on-failure
+
+# Only restart bluechi-agent on events such as unexpected signals. The signals 
+# SIGTERM and SIGINT are already handled internally by bluechi-agent.
+# For an overview of exit causes triggering a restart see here:
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Restart=
+Restart=on-abnormal
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd-units/bluechi-controller.service
+++ b/systemd-units/bluechi-controller.service
@@ -10,7 +10,12 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/usr/libexec/bluechi-controller
-Restart=on-failure
+
+# Only restart bluechi-controller on events such as unexpected signals. The signals 
+# SIGTERM and SIGINT are already handled internally by bluechi-controller.
+# For an overview of exit causes triggering a restart see here:
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Restart=
+Restart=on-abnormal
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The Restart=on-failure policy restarted the BlueChi components on any failure 5 times, thus triggering the max. restart limit (with a 100ms delay in between each restart by default) which caused the service to fail in the end. Since both, bluechi-agent and bluechi-controller, only exit with an error code on an unrecoverable one, e.g. a configuration file has invalid syntax, these restarts are unnecessary and can potentially cause issues. Therefore, the Restart= option has been changed to on-abnormal so that BlueChi gets restarted on unclean signals, timeouts, watchdog and OOM. See here for more details: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Restart=
