### PR TITLE
Backport: Add support for COPR and version selection in tests_setup.sh

### DIFF
--- a/tests/containers/integration-test-snapshot
+++ b/tests/containers/integration-test-snapshot
@@ -1,6 +1,7 @@
 FROM quay.io/bluechi/integration-test-base:stream10
 
-ARG copr_repo
+ARG copr_repo="@centos-automotive-sig/bluechi-snapshot"
+ARG bluechi_version=""
 
 RUN dnf install -y dnf-plugin-config-manager
 
@@ -9,15 +10,15 @@ RUN dnf copr enable -y $copr_repo
 RUN dnf install \
         --nogpgcheck \
         --nodocs \
-        bluechi-controller \
-        bluechi-controller-debuginfo \
-        bluechi-agent \
-        bluechi-agent-debuginfo \
-        bluechi-ctl \
-        bluechi-is-online \
-        bluechi-ctl-debuginfo \
-        bluechi-selinux \
-        python3-bluechi \
+        bluechi-controller${bluechi_version:+-${bluechi_version}} \
+        bluechi-controller-debuginfo${bluechi_version:+-${bluechi_version}} \
+        bluechi-agent${bluechi_version:+-${bluechi_version}} \
+        bluechi-agent-debuginfo${bluechi_version:+-${bluechi_version}} \
+        bluechi-ctl${bluechi_version:+-${bluechi_version}} \
+        bluechi-is-online${bluechi_version:+-${bluechi_version}} \
+        bluechi-ctl-debuginfo${bluechi_version:+-${bluechi_version}} \
+        bluechi-selinux${bluechi_version:+-${bluechi_version}} \
+        python3-bluechi${bluechi_version:+-${bluechi_version}} \
         -y
 
 RUN dnf -y clean all

--- a/tests/plans/multihost.fmf
+++ b/tests/plans/multihost.fmf
@@ -21,6 +21,8 @@ environment:
     LOG_LEVEL: DEBUG
     WITH_COVERAGE: 0
     WITH_VALGRIND: 0
+    # Set specific BlueChi version if needed
+    # BLUECHI_VERSION: 1.2.0
 discover:
     how: fmf
     filter: tag:multihost


### PR DESCRIPTION
Introduce ENABLE_COPR and BLUECHI_VERSION environment variables to allow conditional COPR repository enablement and specific BlueChi version installation in both multihost and container test environments.

Usage examples:
BLUECHI_VERSION=1.2.0 ./tests/scripts/tests-setup.sh setup_multihost_test setup_worker

ENABLE_COPR=no ./tests/scripts/tests-setup.sh setup_multihost_test setup_worker