### PR TITLE
Fixed f44 NULL error in bus_id_is_valid_test

### DIFF
--- a/src/libbluechi/test/bus/utils/bus_id_is_valid_test.c
+++ b/src/libbluechi/test/bus/utils/bus_id_is_valid_test.c
@@ -15,7 +15,7 @@ bool test_bus_id_is_valid(const char *name, bool expected_is_valid) {
         if (got_is_valid != expected_is_valid) {
                 fprintf(stderr,
                         "FAILED: expected bus name '%s' to be %s, but got %s\n",
-                        name,
+                        name ? name : "(null)",
                         bool_to_str(expected_is_valid),
                         bool_to_str(got_is_valid));
                 return false;

--- a/src/libbluechi/test/common/network/is_ipv4_test.c
+++ b/src/libbluechi/test/common/network/is_ipv4_test.c
@@ -18,7 +18,7 @@ bool test_is_ipv4(const char *in, bool expected) {
         }
         fprintf(stdout,
                 "FAILED: is_ipv4('%s') - Expected %s, but got %s\n",
-                in,
+                in ? in : "(null)",
                 bool_to_str(expected),
                 bool_to_str(result));
         return false;

--- a/src/libbluechi/test/common/network/is_ipv6_test.c
+++ b/src/libbluechi/test/common/network/is_ipv6_test.c
@@ -18,7 +18,7 @@ bool test_is_ipv6(const char *in, bool expected) {
         }
         fprintf(stdout,
                 "FAILED: is_ipv6('%s') - Expected %s, but got %s\n",
-                in,
+                in ? in : "(null)",
                 bool_to_str(expected),
                 bool_to_str(result));
         return false;


### PR DESCRIPTION
This PR fixes the NULL error in the `fprintf` of the `bus_id_is_valid_test` on f44 builds. 

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2433883
