### PR TITLE
Create new release only for Fedora and EPEL 10

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -101,11 +101,11 @@ jobs:
     trigger: commit
     dist_git_branches:
       - fedora-all
-      - epel-all
+      - epel-10
 
   - job: bodhi_update
     trigger: commit
     dist_git_branches:
       # rawhide updates are created automatically
       - fedora-branched
-      - epel-all
+      - epel-10


### PR DESCRIPTION
Remove proposing new releases into EPEL-8 and EPEL-9, which are no
longer supported in BlueChi

Signed-off-by: Martin Perina <mperina@redhat.com>
